### PR TITLE
Add productionization baseline

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,14 @@
+common --enable_bzlmod
+
+build --announce_rc
+build --spawn_strategy=sandboxed
+
+test --test_output=errors
+test --test_summary=detailed
+
+# Shared-cache CI configuration. Pass --remote_cache from a wrapper because
+# Bazel does not expand environment variables in .bazelrc values.
+build:ci-cached --remote_upload_local_results=true
+build:ci-cached --remote_timeout=60
+test:ci-cached --remote_upload_local_results=true
+test:ci-cached --remote_timeout=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build
+        run: go build ./...
+        env:
+          GOFLAGS: -mod=vendor
+      - name: Test
+        run: go test ./...
+        env:
+          GOFLAGS: -mod=vendor
+      - name: Vet
+        run: go vet ./...
+        env:
+          GOFLAGS: -mod=vendor
+
+  bazel:
+    name: Bazel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+      - name: Test
+        run: nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...

--- a/.github/workflows/gloriousflywheel-proof.yml
+++ b/.github/workflows/gloriousflywheel-proof.yml
@@ -1,0 +1,30 @@
+name: GloriousFlywheel Proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      bazel_remote_cache:
+        description: Bazel remote cache URL
+        required: true
+        default: grpc://bazel-cache.nix-cache.svc.cluster.local:9092
+
+jobs:
+  shared-cache-proof:
+    name: Shared cache proof
+    runs-on: tinyland-nix
+    env:
+      BAZEL_REMOTE_CACHE: ${{ inputs.bazel_remote_cache }}
+      GF_BAZEL_SUBSTRATE_MODE: shared-cache-backed
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Go validation
+        run: |
+          go test ./...
+          go vet ./...
+          go build ./...
+        env:
+          GOFLAGS: -mod=vendor
+      - name: Nix package
+        run: nix build .#default --no-link --print-build-logs
+      - name: Bazel shared-cache test
+        run: nix shell nixpkgs#bazelisk --command bash scripts/bazel-cache-backed.sh test //...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  artifacts:
+    name: Build release artifacts
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build
+        run: |
+          mkdir -p dist
+          artifact="tinyland-cleanup-${GITHUB_REF_NAME}-${GOOS}-${GOARCH}"
+          CGO_ENABLED=0 go build -trimpath \
+            -ldflags "-s -w -X main.version=${GITHUB_REF_NAME} -X main.commit=${GITHUB_SHA} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o "dist/${artifact}/tinyland-cleanup" \
+            .
+          cp README.md LICENSE "dist/${artifact}/"
+          tar -C dist -czf "dist/${artifact}.tar.gz" "${artifact}"
+        env:
+          GOFLAGS: -mod=vendor
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tinyland-cleanup-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: artifacts
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Checksums
+        run: sha256sum dist/*.tar.gz > dist/SHA256SUMS
+      - name: Publish
+        uses: softprops/action-gh-release@v3
+        with:
+          draft: true
+          files: |
+            dist/*.tar.gz
+            dist/SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 result
 result-*
 .direnv/
+
+.DS_Store
+bazel-*
+coverage.out
+dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Guidance
+
+## Role
+
+`tinyland-cleanup` is a disk-pressure cleanup daemon for Tinyland developer
+machines and CI hosts. It must be conservative by default because it runs on
+workstations that host multiple hermetic build systems and local developer
+state.
+
+The canonical upstream is `github.com/Jesssullivan/tinyland-cleanup`. Treat the
+old Tinyland organization fork as historical context only unless a current
+operator runbook says otherwise.
+
+## Build Authority
+
+- Native Go commands are the fastest local validation path.
+- Nix is the package authority for Darwin and Linux ingestion.
+- Bazel is the hermetic build/test graph and the surface used by
+  GloriousFlywheel shared-cache runners.
+- GloriousFlywheel cache attachment is an acceleration contract. Do not claim
+  remote execution/offload unless a runner contract proves it for this repo.
+
+## Safety Defaults
+
+- Prefer dry-run and plan output before destructive cleanup.
+- Preserve host free-space accounting before and after every cleanup decision.
+- Keep privileged operations, offline compaction, and disruptive service work
+  explicitly opt-in.
+- Keep Darwin and Linux/Rocky behavior separate where platform semantics differ.
+
+## Validation
+
+Use repo-managed caches outside the user profile when possible:
+
+```sh
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
+nix build .#default --no-link --print-build-logs
+nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+```

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,23 +1,16 @@
-# =============================================================================
-# BUILD.bazel - tinyland-cleanup Go application
-# =============================================================================
-# Cross-platform disk cleanup daemon with graduated thresholds.
-#
-# Usage:
-#   bazel build //cmd/tinyland-cleanup:tinyland-cleanup
-#   bazel run //cmd/tinyland-cleanup:tinyland-cleanup -- --help
-#   bazel test //cmd/tinyland-cleanup/...
-#
-# Platform-specific builds:
-#   bazel build --config=linux //cmd/tinyland-cleanup:tinyland-cleanup
-#   bazel build --config=macos //cmd/tinyland-cleanup:tinyland-cleanup
-# =============================================================================
-
+load("@gazelle//:def.bzl", "gazelle")
 load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
-# =============================================================================
-# Main Binary
-# =============================================================================
+# Root Bazel targets for tinyland-cleanup.
+#
+# Preferred commands:
+#   bazel build //...
+#   bazel test //...
+#   bazel run //:tinyland-cleanup -- --dry-run --config ./config/default.yaml
+#
+# gazelle:prefix github.com/Jesssullivan/tinyland-cleanup
+
+gazelle(name = "gazelle")
 
 go_binary(
     name = "tinyland-cleanup",
@@ -27,9 +20,9 @@ go_binary(
     }),
     visibility = ["//visibility:public"],
     x_defs = {
-        "main.version": "{STABLE_VERSION}",
         "main.commit": "{STABLE_GIT_COMMIT}",
         "main.date": "{BUILD_TIMESTAMP}",
+        "main.version": "0.2.0",
     },
     deps = [
         ":config",
@@ -38,84 +31,30 @@ go_binary(
     ],
 )
 
-# =============================================================================
-# Libraries
-# =============================================================================
-
 go_library(
     name = "config",
     srcs = ["config/config.go"],
-    importpath = "gitlab.com/tinyland/lab/tinyland-cleanup/config",
+    importpath = "github.com/Jesssullivan/tinyland-cleanup/config",
     visibility = ["//visibility:public"],
-    deps = [
-        "@in_gopkg_yaml_v3//:yaml_v3",
-    ],
+    deps = ["@in_gopkg_yaml_v3//:yaml_v3"],
 )
 
-go_library(
-    name = "plugins",
+go_test(
+    name = "config_test",
     srcs = [
-        "plugins/cache.go",
-        "plugins/docker.go",
-        "plugins/etcd.go",
-        "plugins/gitlab_runner.go",
-        "plugins/nix.go",
-        "plugins/plugin.go",
-        "plugins/podman.go",
-        "plugins/rke2.go",
-    ] + select({
-        "@platforms//os:macos": [
-            "plugins/darwin.go",
-            "plugins/lima.go",
-        ],
-        "//conditions:default": [],
-    }),
-    importpath = "gitlab.com/tinyland/lab/tinyland-cleanup/plugins",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":config",
+        "config/config_pbt_test.go",
+        "config/config_test.go",
     ],
+    embed = [":config"],
+    deps = ["@net_pgregory_rapid//:rapid"],
 )
 
 go_library(
     name = "monitor",
     srcs = ["monitor/disk.go"],
-    importpath = "gitlab.com/tinyland/lab/tinyland-cleanup/monitor",
+    importpath = "github.com/Jesssullivan/tinyland-cleanup/monitor",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_shirou_gopsutil_v3//disk",
-    ],
-)
-
-# =============================================================================
-# Tests
-# =============================================================================
-
-go_test(
-    name = "config_test",
-    srcs = [
-        "config/config_test.go",
-        "config/config_pbt_test.go",
-    ],
-    embed = [":config"],
-    deps = [
-        "@net_pgregory_rapid//:rapid",
-    ],
-    timeout = "short",
-)
-
-go_test(
-    name = "plugins_test",
-    srcs = [
-        "plugins/plugin_test.go",
-        "plugins/plugin_pbt_test.go",
-    ],
-    embed = [":plugins"],
-    deps = [
-        ":config",
-        "@net_pgregory_rapid//:rapid",
-    ],
-    timeout = "short",
+    deps = ["@com_github_shirou_gopsutil_v3//disk"],
 )
 
 go_test(
@@ -125,49 +64,61 @@ go_test(
         "monitor/monitor_pbt_test.go",
     ],
     embed = [":monitor"],
+    deps = ["@net_pgregory_rapid//:rapid"],
+)
+
+go_library(
+    name = "plugins",
+    srcs = [
+        "plugins/cache.go",
+        "plugins/devartifacts.go",
+        "plugins/docker.go",
+        "plugins/etcd.go",
+        "plugins/fs.go",
+        "plugins/gitlab_runner.go",
+        "plugins/nix.go",
+        "plugins/plugin.go",
+        "plugins/podman.go",
+        "plugins/rke2.go",
+        "plugins/sudo.go",
+    ] + select({
+        "@platforms//os:macos": [
+            "plugins/apfs_darwin.go",
+            "plugins/darwin.go",
+            "plugins/lima.go",
+        ],
+        "//conditions:default": [
+            "plugins/github_runner.go",
+            "plugins/yum.go",
+        ],
+    }),
+    importpath = "github.com/Jesssullivan/tinyland-cleanup/plugins",
+    visibility = ["//visibility:public"],
     deps = [
+        ":config",
+    ],
+)
+
+go_test(
+    name = "plugins_test",
+    srcs = [
+        "plugins/devartifacts_test.go",
+        "plugins/plugin_pbt_test.go",
+        "plugins/plugin_test.go",
+        "plugins/sudo_test.go",
+    ] + select({
+        "@platforms//os:macos": ["plugins/apfs_darwin_test.go"],
+        "//conditions:default": [],
+    }),
+    embed = [":plugins"],
+    deps = [
+        ":config",
         "@net_pgregory_rapid//:rapid",
     ],
-    timeout = "short",
 )
 
-# =============================================================================
-# Test Suites
-# =============================================================================
-
-# All platform-agnostic tests (safe to run on any CI runner)
 test_suite(
     name = "all_tests",
-    tests = [
-        ":config_test",
-        ":monitor_test",
-        ":plugins_test",
-    ],
-)
-
-# Linux-specific test suite
-test_suite(
-    name = "linux_tests",
-    tests = [
-        ":config_test",
-        ":monitor_test",
-        ":plugins_test",
-    ],
-)
-
-# Darwin test suite (includes Darwin-specific tests when available)
-test_suite(
-    name = "darwin_tests",
-    tests = [
-        ":config_test",
-        ":monitor_test",
-        ":plugins_test",
-    ],
-)
-
-# Property-based test suite (uses rapid library)
-test_suite(
-    name = "pbt_tests",
     tests = [
         ":config_test",
         ":monitor_test",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Repository authority, contribution, security, and productionization docs.
+- Bazel/Bzlmod surface for the Go build and test graph.
+- GitHub CI and release workflow scaffolding.
+- Shared-cache Bazel wrapper for GloriousFlywheel runner attachment.
+
+### Changed
+
+- Go module path moved to `github.com/Jesssullivan/tinyland-cleanup`.
+
+## [0.2.0]
+
+### Added
+
+- Darwin Podman fstrim accounting fix.
+- Nix flake package for `tinyland-cleanup`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Use small, reviewable changes and keep safety-sensitive behavior explicit.
+
+Before opening a pull request, run the relevant validation:
+
+```sh
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
+nix build .#default --no-link --print-build-logs
+```
+
+For changes touching the Bazel graph, also run:
+
+```sh
+nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+```
+
+Do not include secrets, host-local config, or `.env` files in commits.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jess Sullivan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,14 +1,7 @@
-# =============================================================================
-# MODULE.bazel - Bazel Module for tinyland-cleanup
-# =============================================================================
-# Standalone Bazel module for cross-platform disk cleanup daemon.
-# Uses rules_nixpkgs for hermetic Go toolchain from Nix.
+# Bzlmod root for tinyland-cleanup.
 #
-# Usage:
-#   bazel build //...
-#   bazel test //...
-#   bazel run //:gazelle    # Regenerate BUILD files
-# =============================================================================
+# Nix remains the packaging authority; Bazel is the hermetic build/test graph
+# and the surface that can attach to GloriousFlywheel shared cache runners.
 
 module(
     name = "tinyland_cleanup",
@@ -16,56 +9,20 @@ module(
     compatibility_level = 1,
 )
 
-# Core dependencies
-bazel_dep(name = "rules_nixpkgs_core", version = "0.12.0")
-bazel_dep(name = "rules_nixpkgs_go", version = "0.12.0")
-bazel_dep(name = "rules_nixpkgs_cc", version = "0.12.0")
-bazel_dep(name = "rules_go", version = "0.46.0")
-bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "gazelle", version = "0.37.0")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.10")
+bazel_dep(name = "rules_go", version = "0.46.0")
 
-# =============================================================================
-# Nix Toolchains
-# =============================================================================
-
-nixpkgs = use_extension("@rules_nixpkgs_core//extensions:nixpkgs.bzl", "nixpkgs")
-nixpkgs.default(name = "nixpkgs", nix_file_content = """
-    import (builtins.fetchTarball {
-        name = "nixpkgs-24.11";
-        url = "https://github.com/NixOS/nixpkgs/archive/nixos-24.11.tar.gz";
-    }) {}
-""")
-use_repo(nixpkgs, "nixpkgs")
-
-# Go toolchain from Nix (Go 1.23)
-nixpkgs_go = use_extension("@rules_nixpkgs_go//extensions:go.bzl", "nixpkgs_go")
-nixpkgs_go.configure(
-    name = "nixpkgs_go_toolchain",
-    repository = "@nixpkgs",
-    attribute_path = "go_1_23",
-)
-use_repo(nixpkgs_go, "nixpkgs_go_toolchain")
-register_toolchains("@nixpkgs_go_toolchain//:toolchain")
-
-# C/C++ toolchain from Nix (required for cgo)
-nixpkgs_cc = use_extension("@rules_nixpkgs_cc//extensions:cc.bzl", "nixpkgs_cc")
-nixpkgs_cc.configure(
-    name = "nixpkgs_cc_toolchain",
-    repository = "@nixpkgs",
-)
-use_repo(nixpkgs_cc, "nixpkgs_cc_toolchain")
-register_toolchains("@nixpkgs_cc_toolchain//:toolchain")
-
-# =============================================================================
-# Go Dependencies
-# =============================================================================
-
-# Go SDK version from go.mod
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.from_file(go_mod = "//:go.mod")
+go_sdk.download(version = "1.23.0")
 
-# Go deps managed by Gazelle
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_shirou_gopsutil_v3",
+    "in_gopkg_yaml_v3",
+    "net_pgregory_rapid",
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# tinyland-cleanup
+
+`tinyland-cleanup` is a conservative disk-pressure cleanup daemon for developer
+machines and CI hosts. It focuses on build-system and developer-tool caches
+where unmanaged disk pressure can break local work, remote runners, or
+hermetic build flows.
+
+The current production target is Darwin developer machines plus Linux/Rocky
+builder and runner machines.
+
+## Safety Model
+
+- Dry-run behavior must stay useful enough for operator review.
+- Cleanup policy should explain what it plans to remove and why.
+- Host free-space accounting should be measured before and after cleanup.
+- Privileged actions, offline compaction, and service disruption must remain
+  explicit policy choices.
+
+## Build And Test
+
+Fast local validation:
+
+```sh
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
+```
+
+Nix package build:
+
+```sh
+nix build .#default --no-link --print-build-logs
+```
+
+Bazel build/test graph:
+
+```sh
+nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+```
+
+Shared-cache Bazel runners can use:
+
+```sh
+BAZEL_REMOTE_CACHE=grpc://bazel-cache.nix-cache.svc.cluster.local:9092 \
+  scripts/bazel-cache-backed.sh test //...
+```
+
+## Distribution Status
+
+Current package authority is the Nix flake package `.#tinyland-cleanup`.
+Release archives are produced from GitHub tags. RPM and broader Linux package
+publication are planned but should be added only after service/user contracts
+and upgrade semantics are explicit.
+
+## Roadmap
+
+Open productionization work is tracked in GitHub issues:
+
+- `#2`: durable disk-pressure policy overhaul
+- `#3`: Bazel cache tiering, budgets, and active-use detection
+- `#4`: Nix cleanup policy for generations, roots, and daemon contention
+- `#5`: Darwin IDE and developer-tool cache budgets
+- `#6`: Podman offline compaction for Darwin `applehv`
+- `#7`: dry-run, telemetry, and host free-space accounting
+
+See [docs/productionization-plan-2026-04-25.md](docs/productionization-plan-2026-04-25.md)
+for the current productionization plan.
+
+Current validation notes are tracked in
+[docs/validation-status-2026-04-25.md](docs/validation-status-2026-04-25.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security
+
+Report security-sensitive issues privately to the repository maintainer.
+
+This daemon can remove local state, interact with build caches, and invoke
+platform cleanup operations. Treat policy changes, privilege escalation paths,
+service stop/start behavior, and offline compaction as security-sensitive.
+
+Security-related pull requests should include:
+
+- the affected platform or plugin;
+- the safety invariant being preserved;
+- dry-run output or equivalent evidence;
+- validation commands that were run.

--- a/docs/productionization-plan-2026-04-25.md
+++ b/docs/productionization-plan-2026-04-25.md
@@ -1,0 +1,106 @@
+# Productionization Plan: tinyland-cleanup
+
+Date: 2026-04-25
+
+## Current Authority
+
+- Source authority: `github.com/Jesssullivan/tinyland-cleanup`
+- Historical fork: `tinyland-inc/tinyland-cleanup`, public and archived
+- Packaging authority today: Nix flake package `.#tinyland-cleanup`
+- Runtime consumers in flight: Darwin developer machines and Linux/Rocky
+  builder or runner machines
+
+## Related Work
+
+- GitHub `#2`: durable disk-pressure policy overhaul
+- GitHub `#3`: Bazel cache tiering, budgets, and active-use detection
+- GitHub `#4`: Nix cleanup policy for generations, roots, and daemon contention
+- GitHub `#5`: Darwin IDE and developer-tool cache budgets
+- GitHub `#6`: Podman offline compaction for Darwin `applehv`
+- GitHub `#7`: dry-run, telemetry, and host free-space accounting
+- Linear `TIN-117`: canonical repo decision for `tinyland-cleanup`
+- Linear `TIN-139`: Nix/Bazel audit and cleanup
+- Linear `TIN-127`: Linux builder and publication contracts
+
+## Style Alignment
+
+Follow the scheduling package pattern where artifact authority is explicit:
+
+- Nix owns host ingestion and package materialization.
+- Bazel owns the hermetic graph and CI conformance checks.
+- GitHub releases own public binary archives.
+- GloriousFlywheel runners provide shared cache acceleration and runner
+  capability classes, not repo-shaped special runners.
+
+## Phase 1: Baseline Lock
+
+- Add repo authority docs, FOSS metadata, and contribution/security guidance.
+- Repair Go module import path to the canonical GitHub repo.
+- Repair Bazel/Bzlmod so `bazel test //...` is meaningful.
+- Add hosted GitHub CI for Go and Bazel validation.
+- Add manual GloriousFlywheel proof workflow for shared-cache validation.
+
+Validation note: Go, Nix, and hosted Bazel CI are green as of 2026-04-25.
+Bazel now gets past the previous missing-module failure, but local Darwin
+validation still has a rules_go cold-start blocker before tests execute. See
+[validation-status-2026-04-25.md](validation-status-2026-04-25.md).
+
+Exit criteria:
+
+- `go test ./...`, `go vet ./...`, and `go build ./...` pass.
+- `nix build .#default` passes.
+- `bazel test //...` passes or has a documented external blocker.
+- README identifies package authority and roadmap issues.
+
+## Phase 2: Runtime Contracts
+
+- Define policy budgets per cleanup domain.
+- Add active-use detection for Bazel, Nix, Podman, and IDE caches.
+- Make dry-run output a stable operator contract.
+- Record free-space deltas before and after each plugin decision.
+- Separate disruptive operations from normal cleanup with explicit opt-ins.
+
+Exit criteria:
+
+- GitHub `#2` and `#7` acceptance criteria are testable.
+- Operator output can explain every removal candidate.
+- Mission-critical machines can run in audit mode without mutation.
+
+## Phase 3: Darwin Production Path
+
+- Finalize LaunchAgent behavior and config defaults.
+- Keep APFS/Podman `applehv` compaction guarded and auditable.
+- Add IDE and developer-tool cache budgets for Xcode, iOS simulator,
+  Homebrew, language servers, and editor caches.
+- Confirm ingestion in the `lab` Home Manager module.
+
+Exit criteria:
+
+- Darwin dry-run and cleanup behavior is validated on real developer hosts.
+- `lab` consumes the upstream flake package without in-tree source drift.
+
+## Phase 4: Linux/Rocky Production Path
+
+- Define systemd user/service packaging.
+- Add RPM packaging once install, upgrade, config, and service semantics are
+  explicit.
+- Validate runner-safe behavior for Bazel, Nix, container, and CI caches.
+
+Exit criteria:
+
+- Rocky package installs, upgrades, and removes cleanly.
+- Runner cleanup avoids active jobs and preserves remote-cache correctness.
+
+## Phase 5: Public FOSS Readiness
+
+- Publish tagged GitHub release artifacts and checksums.
+- Add release notes and upgrade guidance.
+- Decide whether RPM publication belongs in this repo or an external package
+  index.
+- Keep external dependencies and packaging metadata auditable.
+
+Exit criteria:
+
+- Fresh users can build, test, install, configure, and run dry-run mode from
+  documented instructions.
+- Public CI proves the same package surfaces used by internal ingestion.

--- a/docs/validation-status-2026-04-25.md
+++ b/docs/validation-status-2026-04-25.md
@@ -1,0 +1,58 @@
+# Validation Status: 2026-04-25
+
+Branch: `codex/productionization-baseline`
+
+## Passed
+
+```sh
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
+nix build .#default --no-link --print-build-logs
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /tmp/tinyland-cleanup-linux-amd64 .
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /tmp/tinyland-cleanup-darwin-arm64 .
+```
+
+The Nix build produced:
+
+```text
+/nix/store/75pd38gkwddpcaz7l7jcwrnmgbp6qpsf-tinyland-cleanup-0.2.0
+```
+
+Hosted PR CI also passed:
+
+```text
+GitHub Actions run 24942288608
+Go: passed in 20s
+Bazel: passed in 1m29s
+```
+
+## Local Darwin Blocker
+
+```sh
+nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+```
+
+This no longer fails at Bzlmod module resolution. It loads the module graph and
+analyzes the repo targets, then stalls locally on Darwin while building the
+`rules_go` builder action:
+
+```text
+GoToolchainBinaryBuild external/rules_go~0.46.0~go_sdk~tinyland_cleanup__download_0/builder
+```
+
+A second diagnostic run with local spawn strategy also failed to reach test
+execution in a reasonable time:
+
+```sh
+nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel-local test --spawn_strategy=local --strategy=GoToolchainBinaryBuild=local //...
+```
+
+Next investigation should decide whether to:
+
+- move this repo to the newer rules_go version already used by other Tinyland
+  Bazel surfaces;
+- run the Bazel proof on a GloriousFlywheel `tinyland-nix` runner instead of
+  local Darwin;
+- avoid downloading a Go SDK through rules_go and use a proven Nix-provided
+  toolchain bridge if a current Bzlmod-compatible one exists.

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
 
           meta = with pkgs.lib; {
             description = "Cross-platform disk cleanup daemon with graduated thresholds";
-            homepage = "https://gitlab.com/tinyland/projects/tinyland-cleanup";
+            homepage = "https://github.com/Jesssullivan/tinyland-cleanup";
             license = licenses.mit;
             platforms = platforms.unix;
             mainProgram = "tinyland-cleanup";
@@ -35,7 +35,15 @@
 
         devShells.default = pkgs.mkShell {
           inputsFrom = [ self'.packages.default ];
-          packages = with pkgs; [ go_1_23 gopls golangci-lint ];
+          packages = with pkgs; [
+            bazelisk
+            buildifier
+            go_1_23
+            gopls
+            golangci-lint
+            just
+            ripgrep
+          ];
         };
       };
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitlab.com/tinyland/lab/tinyland-cleanup
+module github.com/Jesssullivan/tinyland-cleanup
 
 // Minimum Go version for tinyland-cleanup
 go 1.23

--- a/main.go
+++ b/main.go
@@ -31,9 +31,9 @@ import (
 	"syscall"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
-	"gitlab.com/tinyland/lab/tinyland-cleanup/monitor"
-	"gitlab.com/tinyland/lab/tinyland-cleanup/plugins"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/monitor"
+	"github.com/Jesssullivan/tinyland-cleanup/plugins"
 )
 
 var (

--- a/plugins/apfs_darwin.go
+++ b/plugins/apfs_darwin.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // APFSPlugin handles APFS snapshot thinning and Time Machine cleanup.

--- a/plugins/apfs_darwin_test.go
+++ b/plugins/apfs_darwin_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 func TestAPFSPluginInterface(t *testing.T) {

--- a/plugins/cache.go
+++ b/plugins/cache.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // CachePlugin handles cache cleanup operations.

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // HomebrewPlugin handles Homebrew cleanup operations.

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // DevArtifactsPlugin handles stale development artifact cleanup.
@@ -61,9 +61,9 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 		p.reportArtifacts(ctx, daCfg, home, logger)
 		return result
 	case LevelModerate:
-		nodeAge = 30 * 24 * time.Hour  // 30 days
-		venvAge = 60 * 24 * time.Hour  // 60 days
-		rustAge = 30 * 24 * time.Hour  // 30 days
+		nodeAge = 30 * 24 * time.Hour // 30 days
+		venvAge = 60 * 24 * time.Hour // 60 days
+		rustAge = 30 * 24 * time.Hour // 30 days
 	case LevelAggressive:
 		nodeAge = 7 * 24 * time.Hour  // 7 days
 		venvAge = 14 * 24 * time.Hour // 14 days
@@ -547,4 +547,3 @@ func expandHome(path string, home string) string {
 	}
 	return path
 }
-

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 func TestDevArtifactsPluginInterface(t *testing.T) {

--- a/plugins/docker.go
+++ b/plugins/docker.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // DockerPlugin handles Docker cleanup operations.

--- a/plugins/etcd.go
+++ b/plugins/etcd.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // EtcdPlugin handles etcd snapshot and WAL cleanup for Kubernetes clusters.
@@ -95,10 +95,10 @@ func (p *EtcdPlugin) isEtcdPresent(cfg *config.Config) bool {
 
 // Default etcd configuration when cfg.Etcd is not yet implemented
 const (
-	defaultEtcdDataDir          = "/var/lib/rancher/rke2/server/db/etcd"
-	defaultEtcdWALRetentionDays = 7
+	defaultEtcdDataDir           = "/var/lib/rancher/rke2/server/db/etcd"
+	defaultEtcdWALRetentionDays  = 7
 	defaultEtcdSnapshotRetention = 5
-	defaultEtcdDefragThreshold  = 80
+	defaultEtcdDefragThreshold   = 80
 )
 
 func (p *EtcdPlugin) cleanOldWAL(ctx context.Context, cfg *config.Config, logger *slog.Logger) CleanupResult {

--- a/plugins/github_runner.go
+++ b/plugins/github_runner.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // GitHubRunnerPlugin handles GitHub Actions runner cleanup operations.

--- a/plugins/gitlab_runner.go
+++ b/plugins/gitlab_runner.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // GitLabRunnerPlugin cleans up GitLab runner caches and build artifacts.

--- a/plugins/lima.go
+++ b/plugins/lima.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // LimaPlugin handles Lima VM cleanup and disk resize operations.

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // NixPlugin handles Nix garbage collection operations.

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"runtime"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // CleanupLevel represents the cleanup severity level.

--- a/plugins/plugin_test.go
+++ b/plugins/plugin_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 func TestCleanupLevelString(t *testing.T) {

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // PodmanPlugin handles Podman cleanup operations.

--- a/plugins/rke2.go
+++ b/plugins/rke2.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // RKE2Plugin handles RKE2/k3s containerd image and cache cleanup.

--- a/plugins/yum.go
+++ b/plugins/yum.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"os/exec"
 
-	"gitlab.com/tinyland/lab/tinyland-cleanup/config"
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 // YumPlugin handles YUM/DNF cache cleanup operations.

--- a/plugins_darwin.go
+++ b/plugins_darwin.go
@@ -2,7 +2,7 @@
 
 package main
 
-import "gitlab.com/tinyland/lab/tinyland-cleanup/plugins"
+import "github.com/Jesssullivan/tinyland-cleanup/plugins"
 
 func registerLinuxPlugins(registry *plugins.Registry) {
 	// Linux-specific plugins are not available on Darwin

--- a/plugins_other.go
+++ b/plugins_other.go
@@ -2,7 +2,7 @@
 
 package main
 
-import "gitlab.com/tinyland/lab/tinyland-cleanup/plugins"
+import "github.com/Jesssullivan/tinyland-cleanup/plugins"
 
 func registerDarwinPlugins(registry *plugins.Registry) {
 	// Darwin-specific plugins are not available on other platforms


### PR DESCRIPTION
## Summary
- Add repo authority, FOSS baseline, contribution, security, changelog, and roadmap docs.
- Move Go module/import authority to github.com/Jesssullivan/tinyland-cleanup.
- Repair the Bazel/Bzlmod surface and add a shared-cache wrapper for GloriousFlywheel runner attachment.
- Add hosted CI, manual GloriousFlywheel proof workflow, and draft-release artifact workflow.

## Validation
- PASS: go test ./...
- PASS: go vet ./...
- PASS: go build ./...
- PASS: nix build .#default --no-link --print-build-logs
- PASS: release-matrix smoke builds for linux/amd64 and darwin/arm64
- PASS: hosted GitHub CI run 24942347361, including Go and Bazel jobs
- NOTE: local Darwin Bazel validation now gets past missing Bzlmod modules, but stalls in rules_go builder cold-start before test execution. Hosted Bazel CI passed; details are documented in docs/validation-status-2026-04-25.md.

## Notes
This is intentionally a draft PR. The GloriousFlywheel proof workflow is included, but GitHub cannot dispatch a newly added manual workflow until that workflow file exists on main.