### PR TITLE
Add Podman compaction preflight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ result-*
 
 .DS_Store
 bazel-*
+MODULE.bazel.lock
 coverage.out
 dist/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,16 +14,34 @@ gazelle(name = "gazelle")
 
 go_binary(
     name = "tinyland-cleanup",
-    srcs = ["main.go"] + select({
-        "@platforms//os:macos": ["plugins_darwin.go"],
-        "//conditions:default": ["plugins_other.go"],
-    }),
+    embed = [":tinyland-cleanup_lib"],
     visibility = ["//visibility:public"],
     x_defs = {
         "main.commit": "{STABLE_GIT_COMMIT}",
         "main.date": "{BUILD_TIMESTAMP}",
         "main.version": "0.2.0",
     },
+)
+
+go_library(
+    name = "tinyland-cleanup_lib",
+    srcs = ["main.go"] + select({
+        "@platforms//os:macos": ["plugins_darwin.go"],
+        "//conditions:default": ["plugins_other.go"],
+    }),
+    importpath = "github.com/Jesssullivan/tinyland-cleanup",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":config",
+        ":monitor",
+        ":plugins",
+    ],
+)
+
+go_test(
+    name = "tinyland-cleanup_test",
+    srcs = ["main_test.go"],
+    embed = [":tinyland-cleanup_lib"],
     deps = [
         ":config",
         ":monitor",
@@ -103,6 +121,7 @@ go_test(
     name = "plugins_test",
     srcs = [
         "plugins/devartifacts_test.go",
+        "plugins/podman_compaction_test.go",
         "plugins/plugin_pbt_test.go",
         "plugins/plugin_test.go",
         "plugins/sudo_test.go",
@@ -122,6 +141,7 @@ test_suite(
     tests = [
         ":config_test",
         ":monitor_test",
+        ":tinyland-cleanup_test",
         ":plugins_test",
     ],
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - Shared-cache Bazel wrapper for GloriousFlywheel runner attachment.
 - JSON cleanup cycle reports with dry-run plugin plans and host free-space
   accounting.
+- Podman offline compaction preflight for Darwin VM disks, including physical
+  allocation accounting and active-container safety gates.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ tinyland-cleanup --once --dry-run --level critical --output json
 See [docs/operator-workflow.md](docs/operator-workflow.md) for the current
 dry-run and host free-space accounting workflow.
 
+Podman on macOS needs extra care because `applehv` raw sparse images do not
+shrink from guest `fstrim` alone. See
+[docs/podman-darwin-compaction.md](docs/podman-darwin-compaction.md) before
+enabling offline compaction.
+
 ## Distribution Status
 
 Current package authority is the Nix flake package `.#tinyland-cleanup`.

--- a/config/config.go
+++ b/config/config.go
@@ -150,6 +150,14 @@ type PodmanConfig struct {
 	TrimVMDisk bool `yaml:"trim_vm_disk"`
 	// CompactDiskOffline enables offline raw disk compaction at Critical level
 	CompactDiskOffline bool `yaml:"compact_disk_offline"`
+	// CompactMinReclaimGB is the minimum physical allocation worth compacting
+	CompactMinReclaimGB int `yaml:"compact_min_reclaim_gb"`
+	// CompactRequireNoActiveContainers skips offline compaction when containers are running
+	CompactRequireNoActiveContainers bool `yaml:"compact_require_no_active_containers"`
+	// CompactKeepBackupUntilRestart preserves the original image until restart verifies the compacted image
+	CompactKeepBackupUntilRestart bool `yaml:"compact_keep_backup_until_restart"`
+	// CompactProviderAllowlist restricts offline compaction to known providers
+	CompactProviderAllowlist []string `yaml:"compact_provider_allowlist"`
 }
 
 // ICloudConfig holds iCloud-specific cleanup settings (Darwin).
@@ -224,14 +232,14 @@ func DefaultConfig() *Config {
 		TargetFree: 70,
 		LogFile:    logFile,
 		Enable: EnableFlags{
-			Cache:        true,
-			NixGC:        true,
-			Docker:       true,
-			Podman:       true,
-			Lima:         runtime.GOOS == "darwin",
-			Homebrew:     runtime.GOOS == "darwin",
-			IOSSimulator: runtime.GOOS == "darwin",
-			GitLabRunner: true,
+			Cache:         true,
+			NixGC:         true,
+			Docker:        true,
+			Podman:        true,
+			Lima:          runtime.GOOS == "darwin",
+			Homebrew:      runtime.GOOS == "darwin",
+			IOSSimulator:  runtime.GOOS == "darwin",
+			GitLabRunner:  true,
 			ICloud:        runtime.GOOS == "darwin",
 			Photos:        runtime.GOOS == "darwin",
 			DevArtifacts:  true,
@@ -242,11 +250,15 @@ func DefaultConfig() *Config {
 			ProtectRunningContainers: true,
 		},
 		Podman: PodmanConfig{
-			PruneImagesAge:           "24h",
-			ProtectRunningContainers: true,
-			MachineNames:             []string{"podman-machine-default"},
-			CleanInsideVM:            true,
-			TrimVMDisk:               true,
+			PruneImagesAge:                   "24h",
+			ProtectRunningContainers:         true,
+			MachineNames:                     []string{"podman-machine-default"},
+			CleanInsideVM:                    true,
+			TrimVMDisk:                       true,
+			CompactMinReclaimGB:              8,
+			CompactRequireNoActiveContainers: true,
+			CompactKeepBackupUntilRestart:    true,
+			CompactProviderAllowlist:         []string{"applehv", "libkrun", "qemu"},
 		},
 		Lima: LimaConfig{
 			VMNames: []string{"colima", "unified"},
@@ -267,9 +279,9 @@ func DefaultConfig() *Config {
 			ProtectPaths:   []string{},
 		},
 		APFS: APFSConfig{
-			ThinEnabled:    true,
-			MaxThinGB:      50,
-			KeepRecentDays: 1,
+			ThinEnabled:     true,
+			MaxThinGB:       50,
+			KeepRecentDays:  1,
 			DeleteOSUpdates: true,
 		},
 		Notify: NotifyConfig{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -219,6 +219,18 @@ func TestPodmanCompactDefaults(t *testing.T) {
 	if cfg.Podman.CompactDiskOffline {
 		t.Error("Podman.CompactDiskOffline should be false by default (opt-in)")
 	}
+	if cfg.Podman.CompactMinReclaimGB != 8 {
+		t.Errorf("Podman.CompactMinReclaimGB should default to 8, got %d", cfg.Podman.CompactMinReclaimGB)
+	}
+	if !cfg.Podman.CompactRequireNoActiveContainers {
+		t.Error("Podman.CompactRequireNoActiveContainers should default to true")
+	}
+	if !cfg.Podman.CompactKeepBackupUntilRestart {
+		t.Error("Podman.CompactKeepBackupUntilRestart should default to true")
+	}
+	if len(cfg.Podman.CompactProviderAllowlist) == 0 {
+		t.Fatal("Podman.CompactProviderAllowlist should have defaults")
+	}
 }
 
 func TestLoadConfigWithNewFields(t *testing.T) {
@@ -249,6 +261,11 @@ lima:
   compact_offline: true
 podman:
   compact_disk_offline: true
+  compact_min_reclaim_gb: 12
+  compact_require_no_active_containers: false
+  compact_keep_backup_until_restart: false
+  compact_provider_allowlist:
+    - applehv
 `
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -291,5 +308,17 @@ podman:
 	}
 	if !cfg.Podman.CompactDiskOffline {
 		t.Error("Podman.CompactDiskOffline should be true per config")
+	}
+	if cfg.Podman.CompactMinReclaimGB != 12 {
+		t.Errorf("Podman.CompactMinReclaimGB should be 12 per config, got %d", cfg.Podman.CompactMinReclaimGB)
+	}
+	if cfg.Podman.CompactRequireNoActiveContainers {
+		t.Error("Podman.CompactRequireNoActiveContainers should be false per config")
+	}
+	if cfg.Podman.CompactKeepBackupUntilRestart {
+		t.Error("Podman.CompactKeepBackupUntilRestart should be false per config")
+	}
+	if len(cfg.Podman.CompactProviderAllowlist) != 1 || cfg.Podman.CompactProviderAllowlist[0] != "applehv" {
+		t.Errorf("unexpected Podman.CompactProviderAllowlist: %#v", cfg.Podman.CompactProviderAllowlist)
 	}
 }

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -47,6 +47,11 @@ usable space. Plugin byte counts are supporting evidence and may differ from
 physical host reclaim, especially for sparse VM disks, container stores, and
 filesystem snapshots.
 
+For macOS Podman VM disk compaction, review
+[podman-darwin-compaction.md](podman-darwin-compaction.md). Guest `fstrim` on
+`applehv` raw images is advisory and is not counted as host-side reclaimed
+space.
+
 ## Current Boundary
 
 This is the first stable reporting surface. It does not yet expose per-file

--- a/docs/podman-darwin-compaction.md
+++ b/docs/podman-darwin-compaction.md
@@ -1,0 +1,54 @@
+# Podman Darwin Compaction
+
+Podman on macOS runs Linux containers inside a VM. With the `applehv` provider,
+the VM disk is a raw sparse file on APFS. Guest `fstrim` can report large
+trimmed byte counts inside the VM, but that does not prove the host raw image
+released APFS allocation. The daemon therefore does not count `applehv` guest
+`fstrim` output as host bytes freed.
+
+## Review
+
+Use dry-run JSON before enabling offline compaction:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --output json
+```
+
+The Podman plan reports:
+
+- provider and running state;
+- disk format and disk path;
+- logical image size and physical host allocation;
+- required temporary free space based on physical allocation plus headroom;
+- active-container status;
+- whether `qemu-img` is available;
+- the exact stop, convert, verify, replace, and start sequence.
+
+## Enable
+
+Offline compaction is opt-in because it stops the Podman machine:
+
+```yaml
+podman:
+  compact_disk_offline: true
+  compact_min_reclaim_gb: 8
+  compact_require_no_active_containers: true
+  compact_keep_backup_until_restart: true
+  compact_provider_allowlist:
+    - applehv
+    - libkrun
+    - qemu
+```
+
+The preflight skips compaction when the disk path is outside expected Podman
+machine directories, `qemu-img` is unavailable, active containers are running,
+the provider is unknown, a rollback backup already exists, or the filesystem
+does not have enough physical free space for the compacted copy.
+
+## Rollback Boundary
+
+When `compact_keep_backup_until_restart` is enabled, the daemon preserves the
+original disk image as a `.backup` file until the compacted image starts
+successfully. If restart fails, it restores the original disk and attempts to
+start the machine again. Host bytes freed are reported from physical allocation
+before and after compaction, not from the raw image's logical size.

--- a/main.go
+++ b/main.go
@@ -256,6 +256,10 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 		}
 
 		if d.dryRun {
+			if planner, ok := p.(plugins.Planner); ok {
+				plan := planner.PlanCleanup(ctx, pluginLevel, d.config, d.logger)
+				pluginReport.Plan = &plan
+			}
 			pluginReport.SkipReason = "dry_run"
 			d.logger.Info("dry-run plugin plan",
 				"plugin", p.Name(),
@@ -350,18 +354,19 @@ type mountReport struct {
 }
 
 type pluginCycleReport struct {
-	Name                string `json:"name"`
-	Description         string `json:"description"`
-	Level               string `json:"level"`
-	DryRun              bool   `json:"dry_run"`
-	WouldRun            bool   `json:"would_run"`
-	SkipReason          string `json:"skip_reason,omitempty"`
-	BytesFreed          int64  `json:"bytes_freed"`
-	EstimatedBytesFreed int64  `json:"estimated_bytes_freed"`
-	CommandBytesFreed   int64  `json:"command_bytes_freed"`
-	HostBytesFreed      int64  `json:"host_bytes_freed"`
-	ItemsCleaned        int    `json:"items_cleaned"`
-	Error               string `json:"error,omitempty"`
+	Name                string               `json:"name"`
+	Description         string               `json:"description"`
+	Level               string               `json:"level"`
+	DryRun              bool                 `json:"dry_run"`
+	WouldRun            bool                 `json:"would_run"`
+	SkipReason          string               `json:"skip_reason,omitempty"`
+	Plan                *plugins.CleanupPlan `json:"plan,omitempty"`
+	BytesFreed          int64                `json:"bytes_freed"`
+	EstimatedBytesFreed int64                `json:"estimated_bytes_freed"`
+	CommandBytesFreed   int64                `json:"command_bytes_freed"`
+	HostBytesFreed      int64                `json:"host_bytes_freed"`
+	ItemsCleaned        int                  `json:"items_cleaned"`
+	Error               string               `json:"error,omitempty"`
 }
 
 type mountAssessment struct {

--- a/main_test.go
+++ b/main_test.go
@@ -34,8 +34,8 @@ func TestRunOnceDryRunJSONReport(t *testing.T) {
 	if report.Level != "critical" {
 		t.Fatalf("expected critical level, got %q", report.Level)
 	}
-	if report.HostFreeBeforeBytes == 0 || report.HostFreeAfterBytes == 0 {
-		t.Fatal("expected host free-space measurements")
+	if report.MonitorPath == "" {
+		t.Fatal("expected monitor path")
 	}
 	if len(report.Plugins) != 1 {
 		t.Fatalf("expected 1 plugin report, got %d", len(report.Plugins))
@@ -50,6 +50,45 @@ func TestRunOnceDryRunJSONReport(t *testing.T) {
 	}
 	if plugin.SkipReason != "dry_run" {
 		t.Fatalf("expected dry_run skip reason, got %q", plugin.SkipReason)
+	}
+}
+
+func TestRunOnceDryRunJSONReportIncludesPluginPlan(t *testing.T) {
+	var output bytes.Buffer
+	mock := &planningPlugin{
+		reportingPlugin: reportingPlugin{},
+		plan: plugins.CleanupPlan{
+			Plugin:            "reporting",
+			Level:             "critical",
+			Summary:           "reporting dry-run plan",
+			WouldRun:          false,
+			SkipReason:        "preflight_failed",
+			RequiredFreeBytes: 42,
+			Steps:             []string{"inspect", "verify"},
+			Metadata: map[string]string{
+				"provider": "test",
+			},
+		},
+	}
+	daemon := newTestDaemon(t, mock, &output)
+	daemon.dryRun = true
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelCritical); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	report := decodeCycleReport(t, output.Bytes())
+	if len(report.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin report, got %d", len(report.Plugins))
+	}
+	if report.Plugins[0].Plan == nil {
+		t.Fatal("expected plugin dry-run plan")
+	}
+	if report.Plugins[0].Plan.SkipReason != "preflight_failed" {
+		t.Fatalf("expected preflight_failed plan skip reason, got %q", report.Plugins[0].Plan.SkipReason)
+	}
+	if report.Plugins[0].SkipReason != "dry_run" {
+		t.Fatalf("expected dry_run plugin skip reason, got %q", report.Plugins[0].SkipReason)
 	}
 }
 
@@ -153,4 +192,13 @@ func (p *reportingPlugin) Enabled(*config.Config) bool {
 func (p *reportingPlugin) Cleanup(context.Context, plugins.CleanupLevel, *config.Config, *slog.Logger) plugins.CleanupResult {
 	p.called = true
 	return p.result
+}
+
+type planningPlugin struct {
+	reportingPlugin
+	plan plugins.CleanupPlan
+}
+
+func (p *planningPlugin) PlanCleanup(context.Context, plugins.CleanupLevel, *config.Config, *slog.Logger) plugins.CleanupPlan {
+	return p.plan
 }

--- a/plugins/fs.go
+++ b/plugins/fs.go
@@ -148,6 +148,22 @@ func getFreeDiskSpace(path string) (uint64, error) {
 	return stat.Bavail * uint64(stat.Bsize), nil
 }
 
+// getFileAllocatedBytes returns physical blocks allocated on disk for a file.
+// It falls back to apparent size if the filesystem does not report blocks.
+func getFileAllocatedBytes(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Blocks <= 0 {
+		return info.Size(), nil
+	}
+
+	return stat.Blocks * 512, nil
+}
+
 // safeBytesDiff returns the difference between two sizes, floored at 0.
 // Prevents negative BytesFreed when files are added during cleanup.
 func safeBytesDiff(before, after int64) int64 {

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -63,6 +63,30 @@ type CleanupResult struct {
 	Error error
 }
 
+// CleanupPlan describes what a dry-run cleanup cycle would do.
+type CleanupPlan struct {
+	// Plugin is the plugin that produced the plan.
+	Plugin string `json:"plugin"`
+	// Level is the cleanup level being planned.
+	Level string `json:"level"`
+	// Summary is a short human-readable plan summary.
+	Summary string `json:"summary"`
+	// WouldRun reports whether the planned action is currently eligible.
+	WouldRun bool `json:"would_run"`
+	// SkipReason explains why the planned action is not eligible.
+	SkipReason string `json:"skip_reason,omitempty"`
+	// EstimatedBytesFreed is the best available reclaim estimate.
+	EstimatedBytesFreed int64 `json:"estimated_bytes_freed,omitempty"`
+	// RequiredFreeBytes is the host free space needed before the action.
+	RequiredFreeBytes int64 `json:"required_free_bytes,omitempty"`
+	// Steps lists the operator-visible steps the cleanup would perform.
+	Steps []string `json:"steps,omitempty"`
+	// Warnings lists safety warnings or lossy accounting caveats.
+	Warnings []string `json:"warnings,omitempty"`
+	// Metadata carries plugin-specific plan facts.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
 // Plugin is the interface that cleanup plugins must implement.
 type Plugin interface {
 	// Name returns the plugin's unique identifier
@@ -82,6 +106,11 @@ type Plugin interface {
 	// level indicates the severity of cleanup needed
 	// ctx allows cancellation of long-running operations
 	Cleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupResult
+}
+
+// Planner is implemented by plugins that can produce a detailed dry-run plan.
+type Planner interface {
+	PlanCleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupPlan
 }
 
 // Registry holds registered cleanup plugins.

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -40,6 +40,48 @@ type PodmanEnvironment struct {
 	SocketPath string
 }
 
+const podmanCompactionGiB = int64(1024 * 1024 * 1024)
+
+type podmanCompactionPlan struct {
+	MachineName               string
+	Provider                  string
+	DiskFormat                string
+	DiskPath                  string
+	TempPath                  string
+	BackupPath                string
+	ConfigEnabled             bool
+	QemuImgAvailable          bool
+	ActiveContainers          bool
+	ActiveContainerCheckError string
+	DiskPathExpected          bool
+	BackupExists              bool
+	LogicalBytes              int64
+	PhysicalBytes             int64
+	FreeBytes                 int64
+	RequiredFreeBytes         int64
+	EstimatedReclaimBytes     int64
+	CanCompact                bool
+	SkipReason                string
+	Warnings                  []string
+	Steps                     []string
+}
+
+type podmanCompactionPlanInput struct {
+	MachineName               string
+	Provider                  string
+	DiskPath                  string
+	ConfigEnabled             bool
+	QemuImgAvailable          bool
+	ActiveContainers          bool
+	ActiveContainerCheckError string
+	DiskPathExpected          bool
+	BackupExists              bool
+	LogicalBytes              int64
+	PhysicalBytes             int64
+	FreeBytes                 int64
+	Config                    config.PodmanConfig
+}
+
 // NewPodmanPlugin creates a new Podman cleanup plugin.
 func NewPodmanPlugin() *PodmanPlugin {
 	return &PodmanPlugin{}
@@ -63,6 +105,106 @@ func (p *PodmanPlugin) SupportedPlatforms() []string {
 // Enabled checks if Podman cleanup is enabled.
 func (p *PodmanPlugin) Enabled(cfg *config.Config) bool {
 	return cfg.Enable.Podman
+}
+
+// PlanCleanup returns a dry-run plan without mutating Podman state.
+func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupPlan {
+	plan := CleanupPlan{
+		Plugin:   p.Name(),
+		Level:    level.String(),
+		Summary:  "Podman cleanup plan",
+		WouldRun: true,
+		Metadata: map[string]string{
+			"cleanup_level": level.String(),
+		},
+	}
+
+	if p.environment == nil {
+		env, err := detectPodmanEnvironment()
+		if err != nil {
+			plan.WouldRun = false
+			plan.SkipReason = "environment_detection_failed"
+			plan.Summary = "Podman environment could not be inspected"
+			plan.Warnings = append(plan.Warnings, err.Error())
+			return plan
+		}
+		p.environment = env
+	}
+
+	if p.environment.Runtime != "podman" {
+		plan.WouldRun = false
+		plan.SkipReason = "podman_not_available"
+		plan.Summary = "Podman is not available"
+		return plan
+	}
+
+	plan.Metadata["needs_vm"] = strconv.FormatBool(p.environment.NeedsVM)
+	plan.Metadata["vm_provider"] = p.environment.VMProvider
+	plan.Metadata["vm_running"] = strconv.FormatBool(p.environment.VMRunning)
+	plan.Metadata["machine_name"] = p.environment.MachineName
+
+	if p.environment.NeedsVM && !p.environment.VMRunning {
+		plan.WouldRun = false
+		plan.SkipReason = "podman_machine_not_running"
+		plan.Summary = "Podman machine is not running"
+		return plan
+	}
+
+	switch level {
+	case LevelWarning:
+		plan.Steps = append(plan.Steps, "Prune dangling Podman images")
+	case LevelModerate:
+		plan.Steps = append(plan.Steps,
+			"Prune dangling Podman images",
+			fmt.Sprintf("Prune Podman images older than %s", cfg.Podman.PruneImagesAge),
+			"Prune old stopped Podman containers",
+			"Prune Podman build cache",
+		)
+	case LevelAggressive:
+		plan.Steps = append(plan.Steps,
+			"Run moderate Podman cleanup",
+			"Prune unused Podman volumes",
+			"Prune Podman build containers",
+		)
+		if runtime.GOOS == "darwin" && p.environment.VMRunning && cfg.Podman.TrimVMDisk && !p.fstrimReclaimsHostSpace() {
+			plan.Warnings = append(plan.Warnings, "guest fstrim is not counted as host reclaim for this provider")
+		}
+	case LevelCritical:
+		plan.Steps = append(plan.Steps,
+			"Run full Podman system prune with volumes",
+			"Prune external Podman storage when supported",
+		)
+		if runtime.GOOS == "darwin" && p.environment.VMRunning {
+			if cfg.Podman.CleanInsideVM {
+				plan.Steps = append(plan.Steps, "Run critical cleanup inside the Podman VM")
+			}
+			if cfg.Podman.TrimVMDisk && !p.fstrimReclaimsHostSpace() {
+				plan.Warnings = append(plan.Warnings, "guest fstrim is not counted as host reclaim for this provider")
+			}
+
+			compaction := p.planOfflineCompaction(ctx, cfg, logger)
+			plan.RequiredFreeBytes = compaction.RequiredFreeBytes
+			plan.EstimatedBytesFreed = compaction.EstimatedReclaimBytes
+			plan.Warnings = append(plan.Warnings, compaction.Warnings...)
+			plan.Steps = append(plan.Steps, compaction.Steps...)
+			plan.Metadata["offline_compaction_enabled"] = strconv.FormatBool(compaction.ConfigEnabled)
+			plan.Metadata["offline_compaction_can_run"] = strconv.FormatBool(compaction.CanCompact)
+			plan.Metadata["offline_compaction_skip_reason"] = compaction.SkipReason
+			plan.Metadata["offline_compaction_provider"] = compaction.Provider
+			plan.Metadata["offline_compaction_format"] = compaction.DiskFormat
+			plan.Metadata["offline_compaction_disk_path"] = compaction.DiskPath
+			plan.Metadata["offline_compaction_temp_path"] = compaction.TempPath
+			plan.Metadata["offline_compaction_backup_path"] = compaction.BackupPath
+			plan.Metadata["offline_compaction_logical_bytes"] = strconv.FormatInt(compaction.LogicalBytes, 10)
+			plan.Metadata["offline_compaction_physical_bytes"] = strconv.FormatInt(compaction.PhysicalBytes, 10)
+			plan.Metadata["offline_compaction_free_bytes"] = strconv.FormatInt(compaction.FreeBytes, 10)
+			plan.Metadata["offline_compaction_required_free_bytes"] = strconv.FormatInt(compaction.RequiredFreeBytes, 10)
+			plan.Metadata["offline_compaction_estimated_reclaim_bytes"] = strconv.FormatInt(compaction.EstimatedReclaimBytes, 10)
+			plan.Metadata["offline_compaction_active_containers"] = strconv.FormatBool(compaction.ActiveContainers)
+		}
+	}
+
+	return plan
 }
 
 // Cleanup performs Podman cleanup at the specified level.
@@ -268,11 +410,12 @@ func (p *PodmanPlugin) cleanCritical(ctx context.Context, cfg *config.Config, lo
 
 		// Offline disk compaction (opt-in only)
 		if cfg.Podman.CompactDiskOffline {
-			compactFreed, err := p.compactRawDisk(ctx, logger)
+			compactFreed, err := p.compactRawDisk(ctx, cfg, logger)
 			if err != nil {
 				logger.Warn("Podman disk compaction failed", "error", err)
 			} else if compactFreed > 0 {
 				result.BytesFreed += compactFreed
+				result.HostBytesFreed += compactFreed
 				result.ItemsCleaned++
 			}
 		} else if p.environment.VMProvider == "qemu" {
@@ -486,66 +629,287 @@ func parseFstrimOutput(output string) int64 {
 	return total
 }
 
+func (p *PodmanPlugin) planOfflineCompaction(ctx context.Context, cfg *config.Config, logger *slog.Logger) podmanCompactionPlan {
+	input := podmanCompactionPlanInput{
+		MachineName:      p.environment.MachineName,
+		Provider:         p.environment.VMProvider,
+		ConfigEnabled:    cfg.Podman.CompactDiskOffline,
+		QemuImgAvailable: commandAvailable("qemu-img"),
+		Config:           cfg.Podman,
+	}
+
+	diskPath, err := p.getMachineDiskPath(ctx)
+	if err != nil {
+		logger.Debug("Podman disk path preflight failed", "error", err)
+		input.DiskPathExpected = false
+		plan := buildPodmanCompactionPlan(input)
+		plan.SkipReason = "disk_path_unavailable"
+		plan.Warnings = append(plan.Warnings, err.Error())
+		return plan
+	}
+	input.DiskPath = diskPath
+	input.DiskPathExpected = expectedPodmanMachineDiskPath(diskPath)
+	input.BackupExists = pathExists(diskPath + ".backup")
+
+	if stat, err := os.Stat(diskPath); err == nil {
+		input.LogicalBytes = stat.Size()
+	} else {
+		logger.Debug("Podman disk stat preflight failed", "disk", diskPath, "error", err)
+		plan := buildPodmanCompactionPlan(input)
+		plan.SkipReason = "disk_stat_failed"
+		plan.Warnings = append(plan.Warnings, err.Error())
+		return plan
+	}
+
+	if allocated, err := getFileAllocatedBytes(diskPath); err == nil {
+		input.PhysicalBytes = allocated
+	} else {
+		logger.Debug("Podman disk allocation preflight failed", "disk", diskPath, "error", err)
+		input.PhysicalBytes = input.LogicalBytes
+	}
+
+	if free, err := getFreeDiskSpace(filepath.Dir(diskPath)); err == nil {
+		input.FreeBytes = int64FromUint64(free)
+	} else {
+		logger.Debug("Podman disk free-space preflight failed", "disk", diskPath, "error", err)
+		plan := buildPodmanCompactionPlan(input)
+		plan.SkipReason = "free_space_check_failed"
+		plan.Warnings = append(plan.Warnings, err.Error())
+		return plan
+	}
+
+	if cfg.Podman.CompactRequireNoActiveContainers {
+		active, err := p.hasActiveContainers(ctx)
+		input.ActiveContainers = active
+		if err != nil {
+			input.ActiveContainerCheckError = err.Error()
+		}
+	}
+
+	return buildPodmanCompactionPlan(input)
+}
+
+func buildPodmanCompactionPlan(input podmanCompactionPlanInput) podmanCompactionPlan {
+	diskFormat, supportedProvider := podmanDiskFormat(input.Provider)
+	tempPath := ""
+	backupPath := ""
+	if input.DiskPath != "" {
+		tempPath = input.DiskPath + ".compact"
+		backupPath = input.DiskPath + ".backup"
+	}
+
+	physicalBytes := input.PhysicalBytes
+	if physicalBytes <= 0 {
+		physicalBytes = input.LogicalBytes
+	}
+
+	requiredFreeBytes := podmanCompactionRequiredFreeBytes(physicalBytes)
+	minReclaimBytes := int64(input.Config.CompactMinReclaimGB) * podmanCompactionGiB
+	estimatedReclaimBytes := physicalBytes
+	if minReclaimBytes > 0 && estimatedReclaimBytes > 0 && estimatedReclaimBytes > minReclaimBytes {
+		estimatedReclaimBytes -= minReclaimBytes
+	} else {
+		estimatedReclaimBytes = 0
+	}
+
+	plan := podmanCompactionPlan{
+		MachineName:               input.MachineName,
+		Provider:                  input.Provider,
+		DiskFormat:                diskFormat,
+		DiskPath:                  input.DiskPath,
+		TempPath:                  tempPath,
+		BackupPath:                backupPath,
+		ConfigEnabled:             input.ConfigEnabled,
+		QemuImgAvailable:          input.QemuImgAvailable,
+		ActiveContainers:          input.ActiveContainers,
+		ActiveContainerCheckError: input.ActiveContainerCheckError,
+		DiskPathExpected:          input.DiskPathExpected,
+		BackupExists:              input.BackupExists,
+		LogicalBytes:              input.LogicalBytes,
+		PhysicalBytes:             physicalBytes,
+		FreeBytes:                 input.FreeBytes,
+		RequiredFreeBytes:         requiredFreeBytes,
+		EstimatedReclaimBytes:     estimatedReclaimBytes,
+		Steps: []string{
+			fmt.Sprintf("Inspect Podman machine %q disk metadata", input.MachineName),
+			"Confirm no active containers are running",
+			fmt.Sprintf("Stop Podman machine %q", input.MachineName),
+			fmt.Sprintf("Convert %s to %s with qemu-img convert -f %s -O %s", input.DiskPath, tempPath, diskFormat, diskFormat),
+			"Verify the compacted image before replacing the original",
+			"Preserve the original disk image as rollback backup until restart succeeds",
+			fmt.Sprintf("Replace %s with compacted image", input.DiskPath),
+			fmt.Sprintf("Start Podman machine %q and verify it boots", input.MachineName),
+		},
+	}
+
+	if input.Provider == "applehv" {
+		plan.Warnings = append(plan.Warnings, "applehv/raw guest fstrim does not prove host APFS allocation was reclaimed")
+	}
+	if input.Config.CompactMinReclaimGB > 0 {
+		plan.Warnings = append(plan.Warnings,
+			fmt.Sprintf("offline compaction is skipped below %dGiB physical allocation", input.Config.CompactMinReclaimGB))
+	}
+
+	switch {
+	case !input.ConfigEnabled:
+		plan.SkipReason = "compact_disk_offline_disabled"
+	case input.MachineName == "":
+		plan.SkipReason = "machine_unknown"
+	case input.DiskPath == "":
+		plan.SkipReason = "disk_path_unavailable"
+	case !input.DiskPathExpected:
+		plan.SkipReason = "disk_path_outside_podman_machine_dirs"
+	case input.BackupExists:
+		plan.SkipReason = "backup_path_exists"
+	case !supportedProvider:
+		plan.SkipReason = "unsupported_provider"
+	case !providerAllowed(input.Provider, input.Config.CompactProviderAllowlist):
+		plan.SkipReason = "provider_not_allowlisted"
+	case input.ActiveContainerCheckError != "":
+		plan.SkipReason = "active_container_check_failed"
+	case input.Config.CompactRequireNoActiveContainers && input.ActiveContainers:
+		plan.SkipReason = "active_containers"
+	case !input.QemuImgAvailable:
+		plan.SkipReason = "qemu_img_missing"
+	case physicalBytes <= 0:
+		plan.SkipReason = "physical_size_unknown"
+	case minReclaimBytes > 0 && physicalBytes < minReclaimBytes:
+		plan.SkipReason = "below_minimum_physical_allocation"
+	case input.FreeBytes < requiredFreeBytes:
+		plan.SkipReason = "insufficient_free_space"
+	default:
+		plan.CanCompact = true
+	}
+
+	return plan
+}
+
+func podmanDiskFormat(provider string) (string, bool) {
+	switch provider {
+	case "applehv", "libkrun":
+		return "raw", true
+	case "qemu":
+		return "qcow2", true
+	default:
+		return "", false
+	}
+}
+
+func providerAllowed(provider string, allowlist []string) bool {
+	if len(allowlist) == 0 {
+		return true
+	}
+	for _, allowed := range allowlist {
+		if provider == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func podmanCompactionRequiredFreeBytes(physicalBytes int64) int64 {
+	if physicalBytes <= 0 {
+		return podmanCompactionGiB
+	}
+
+	headroom := physicalBytes / 10
+	if headroom < podmanCompactionGiB {
+		headroom = podmanCompactionGiB
+	}
+	return physicalBytes + headroom
+}
+
+func expectedPodmanMachineDiskPath(path string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+
+	roots := []string{
+		filepath.Join(home, ".local/share/containers/podman/machine"),
+		filepath.Join(home, ".config/containers/podman/machine"),
+	}
+	return pathWithinRoots(path, roots)
+}
+
+func pathWithinRoots(path string, roots []string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	for _, root := range roots {
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(absRoot, absPath)
+		if err != nil {
+			continue
+		}
+		if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func (p *PodmanPlugin) hasActiveContainers(ctx context.Context) (bool, error) {
+	output, err := p.runPodmanCommand(ctx, "ps", "-q")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(output) != "", nil
+}
+
+func commandAvailable(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func int64FromUint64(value uint64) int64 {
+	maxInt64 := uint64(^uint64(0) >> 1)
+	if value > maxInt64 {
+		return int64(maxInt64)
+	}
+	return int64(value)
+}
+
+func restorePodmanDiskBackup(diskPath, backupPath string) error {
+	if pathExists(diskPath) {
+		failedPath := diskPath + ".failed"
+		if err := os.Rename(diskPath, failedPath); err != nil {
+			return err
+		}
+	}
+	return os.Rename(backupPath, diskPath)
+}
+
 // compactRawDisk performs offline disk compaction for the Podman machine VM.
 // For raw disk images (applehv, libkrun): creates a sparse copy via qemu-img.
 // For qcow2 (qemu): converts to reclaim space.
 // ONLY runs at Critical level with explicit opt-in via config.
-func (p *PodmanPlugin) compactRawDisk(ctx context.Context, logger *slog.Logger) (int64, error) {
+func (p *PodmanPlugin) compactRawDisk(ctx context.Context, cfg *config.Config, logger *slog.Logger) (int64, error) {
 	if !p.environment.VMRunning || p.environment.MachineName == "" {
 		return 0, nil
 	}
 
-	// Check if qemu-img is available
-	if _, err := exec.LookPath("qemu-img"); err != nil {
-		return 0, fmt.Errorf("qemu-img not available: %w", err)
-	}
-
-	// Get raw disk file path from podman machine inspect
-	diskPath, err := p.getMachineDiskPath(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("cannot determine disk path: %w", err)
-	}
-	if diskPath == "" {
-		return 0, fmt.Errorf("empty disk path for machine %s", p.environment.MachineName)
-	}
-
-	// Get current size
-	stat, err := os.Stat(diskPath)
-	if err != nil {
-		return 0, fmt.Errorf("cannot stat disk: %w", err)
-	}
-	sizeBefore := stat.Size()
-
-	// Safety check: ensure enough free space for the temporary copy.
-	// qemu-img convert writes a full copy before we can remove the original,
-	// so we need at least the disk image size in free space.
-	diskDir := filepath.Dir(diskPath)
-	freeSpace, err := getFreeDiskSpace(diskDir)
-	if err != nil {
-		return 0, fmt.Errorf("cannot check free space: %w", err)
-	}
-	if freeSpace < uint64(sizeBefore) {
-		logger.Warn("skipping Podman disk compaction: insufficient free space",
-			"disk_size_gb", fmt.Sprintf("%.1f", float64(sizeBefore)/(1024*1024*1024)),
-			"free_gb", fmt.Sprintf("%.1f", float64(freeSpace)/(1024*1024*1024)))
+	plan := p.planOfflineCompaction(ctx, cfg, logger)
+	if !plan.CanCompact {
+		logger.Warn("skipping Podman disk compaction",
+			"machine", plan.MachineName,
+			"provider", plan.Provider,
+			"reason", plan.SkipReason)
 		return 0, nil
 	}
 
-	// Determine disk format based on provider
-	var diskFormat string
-	switch p.environment.VMProvider {
-	case "applehv", "libkrun":
-		diskFormat = "raw"
-	case "qemu":
-		diskFormat = "qcow2"
-	default:
-		return 0, fmt.Errorf("unsupported VM provider for compaction: %s", p.environment.VMProvider)
-	}
-
-	sparsePath := diskPath + ".sparse"
-
 	logger.Warn("CRITICAL: stopping Podman machine for disk compaction",
-		"machine", p.environment.MachineName, "format", diskFormat)
+		"machine", p.environment.MachineName,
+		"format", plan.DiskFormat,
+		"logical_gb", fmt.Sprintf("%.1f", float64(plan.LogicalBytes)/float64(podmanCompactionGiB)),
+		"physical_gb", fmt.Sprintf("%.1f", float64(plan.PhysicalBytes)/float64(podmanCompactionGiB)),
+		"required_free_gb", fmt.Sprintf("%.1f", float64(plan.RequiredFreeBytes)/float64(podmanCompactionGiB)))
 
 	// 1. Stop machine
 	stopCmd := exec.CommandContext(ctx, "podman", "machine", "stop", p.environment.MachineName)
@@ -557,9 +921,9 @@ func (p *PodmanPlugin) compactRawDisk(ctx context.Context, logger *slog.Logger) 
 	// 2. Convert to sparse copy
 	logger.Info("compacting Podman machine disk", "machine", p.environment.MachineName)
 	convertCmd := exec.CommandContext(ctx, "qemu-img", "convert",
-		"-f", diskFormat, "-O", diskFormat, diskPath, sparsePath)
+		"-f", plan.DiskFormat, "-O", plan.DiskFormat, plan.DiskPath, plan.TempPath)
 	if output, err := convertCmd.CombinedOutput(); err != nil {
-		os.Remove(sparsePath)
+		os.Remove(plan.TempPath)
 		// Restart machine before returning
 		exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()
 		p.environment.VMRunning = true
@@ -567,10 +931,10 @@ func (p *PodmanPlugin) compactRawDisk(ctx context.Context, logger *slog.Logger) 
 	}
 
 	// 3. Verify if qcow2 format
-	if diskFormat == "qcow2" {
-		checkCmd := exec.CommandContext(ctx, "qemu-img", "check", sparsePath)
+	if plan.DiskFormat == "qcow2" {
+		checkCmd := exec.CommandContext(ctx, "qemu-img", "check", plan.TempPath)
 		if output, err := checkCmd.CombinedOutput(); err != nil {
-			os.Remove(sparsePath)
+			os.Remove(plan.TempPath)
 			exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()
 			p.environment.VMRunning = true
 			return 0, fmt.Errorf("qemu-img check failed: %w (output: %s)", err, string(output))
@@ -578,17 +942,41 @@ func (p *PodmanPlugin) compactRawDisk(ctx context.Context, logger *slog.Logger) 
 	}
 
 	// 4. Get compacted size
-	sparseStat, err := os.Stat(sparsePath)
+	sparseStat, err := os.Stat(plan.TempPath)
 	if err != nil {
-		os.Remove(sparsePath)
+		os.Remove(plan.TempPath)
 		exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()
 		p.environment.VMRunning = true
 		return 0, fmt.Errorf("cannot stat compacted disk: %w", err)
 	}
+	physicalAfter, err := getFileAllocatedBytes(plan.TempPath)
+	if err != nil {
+		os.Remove(plan.TempPath)
+		exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()
+		p.environment.VMRunning = true
+		return 0, fmt.Errorf("cannot stat compacted disk allocation: %w", err)
+	}
 
 	// 5. Replace original
-	if err := os.Rename(sparsePath, diskPath); err != nil {
-		os.Remove(sparsePath)
+	if cfg.Podman.CompactKeepBackupUntilRestart {
+		if err := os.Rename(plan.DiskPath, plan.BackupPath); err != nil {
+			os.Remove(plan.TempPath)
+			exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()
+			p.environment.VMRunning = true
+			return 0, fmt.Errorf("failed to preserve original disk backup: %w", err)
+		}
+		if err := os.Rename(plan.TempPath, plan.DiskPath); err != nil {
+			restoreErr := os.Rename(plan.BackupPath, plan.DiskPath)
+			os.Remove(plan.TempPath)
+			exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()
+			p.environment.VMRunning = true
+			if restoreErr != nil {
+				return 0, fmt.Errorf("failed to replace disk and restore backup: replace=%w restore=%v", err, restoreErr)
+			}
+			return 0, fmt.Errorf("failed to replace disk: %w", err)
+		}
+	} else if err := os.Rename(plan.TempPath, plan.DiskPath); err != nil {
+		os.Remove(plan.TempPath)
 		exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()
 		p.environment.VMRunning = true
 		return 0, fmt.Errorf("failed to replace disk: %w", err)
@@ -600,16 +988,32 @@ func (p *PodmanPlugin) compactRawDisk(ctx context.Context, logger *slog.Logger) 
 	if output, err := startCmd.CombinedOutput(); err != nil {
 		logger.Error("failed to restart machine after compaction",
 			"machine", p.environment.MachineName, "error", err, "output", string(output))
+		if cfg.Podman.CompactKeepBackupUntilRestart {
+			if restoreErr := restorePodmanDiskBackup(plan.DiskPath, plan.BackupPath); restoreErr != nil {
+				return 0, fmt.Errorf("failed to restart machine after compaction and restore backup: restart=%w restore=%v", err, restoreErr)
+			}
+			exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()
+		}
+		p.environment.VMRunning = true
+		return 0, fmt.Errorf("failed to restart machine after compaction: %w", err)
 	}
 	p.environment.VMRunning = true
 
-	freed := sizeBefore - sparseStat.Size()
+	if cfg.Podman.CompactKeepBackupUntilRestart {
+		if err := os.Remove(plan.BackupPath); err != nil {
+			return 0, fmt.Errorf("compacted disk verified but backup remains at %s: %w", plan.BackupPath, err)
+		}
+	}
+
+	freed := safeBytesDiff(plan.PhysicalBytes, physicalAfter)
 	if freed > 0 {
 		logger.Info("Podman disk compaction complete",
 			"machine", p.environment.MachineName,
-			"freed_gb", fmt.Sprintf("%.1f", float64(freed)/(1024*1024*1024)),
-			"before_gb", fmt.Sprintf("%.1f", float64(sizeBefore)/(1024*1024*1024)),
-			"after_gb", fmt.Sprintf("%.1f", float64(sparseStat.Size())/(1024*1024*1024)),
+			"freed_gb", fmt.Sprintf("%.1f", float64(freed)/float64(podmanCompactionGiB)),
+			"logical_before_gb", fmt.Sprintf("%.1f", float64(plan.LogicalBytes)/float64(podmanCompactionGiB)),
+			"physical_before_gb", fmt.Sprintf("%.1f", float64(plan.PhysicalBytes)/float64(podmanCompactionGiB)),
+			"logical_after_gb", fmt.Sprintf("%.1f", float64(sparseStat.Size())/float64(podmanCompactionGiB)),
+			"physical_after_gb", fmt.Sprintf("%.1f", float64(physicalAfter)/float64(podmanCompactionGiB)),
 		)
 		return freed, nil
 	}

--- a/plugins/podman_compaction_test.go
+++ b/plugins/podman_compaction_test.go
@@ -1,0 +1,184 @@
+package plugins
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Jesssullivan/tinyland-cleanup/config"
+)
+
+func TestPodmanCompactionPlanUsesPhysicalAllocationForAppleHVRaw(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+	cfg.CompactProviderAllowlist = []string{"applehv"}
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:      "podman-machine-default",
+		Provider:         "applehv",
+		DiskPath:         "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ConfigEnabled:    true,
+		QemuImgAvailable: true,
+		DiskPathExpected: true,
+		LogicalBytes:     100 * podmanCompactionGiB,
+		PhysicalBytes:    12 * podmanCompactionGiB,
+		FreeBytes:        14 * podmanCompactionGiB,
+		Config:           cfg,
+	})
+
+	if !plan.CanCompact {
+		t.Fatalf("expected compaction to be eligible, got skip reason %q", plan.SkipReason)
+	}
+	if plan.DiskFormat != "raw" {
+		t.Fatalf("expected raw disk format, got %q", plan.DiskFormat)
+	}
+	if plan.RequiredFreeBytes >= plan.LogicalBytes {
+		t.Fatalf("required free space should use physical allocation, required=%d logical=%d", plan.RequiredFreeBytes, plan.LogicalBytes)
+	}
+	if plan.RequiredFreeBytes <= plan.PhysicalBytes {
+		t.Fatalf("required free space should include headroom, required=%d physical=%d", plan.RequiredFreeBytes, plan.PhysicalBytes)
+	}
+}
+
+func TestPodmanCompactionPlanSupportsQemuQCow2(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+	cfg.CompactProviderAllowlist = []string{"qemu"}
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:      "podman-machine-default",
+		Provider:         "qemu",
+		DiskPath:         "/Users/test/.local/share/containers/podman/machine/qemu/podman-machine-default.qcow2",
+		ConfigEnabled:    true,
+		QemuImgAvailable: true,
+		DiskPathExpected: true,
+		LogicalBytes:     30 * podmanCompactionGiB,
+		PhysicalBytes:    20 * podmanCompactionGiB,
+		FreeBytes:        24 * podmanCompactionGiB,
+		Config:           cfg,
+	})
+
+	if !plan.CanCompact {
+		t.Fatalf("expected compaction to be eligible, got skip reason %q", plan.SkipReason)
+	}
+	if plan.DiskFormat != "qcow2" {
+		t.Fatalf("expected qcow2 disk format, got %q", plan.DiskFormat)
+	}
+}
+
+func TestPodmanCompactionPlanInsufficientFreeSpace(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:      "podman-machine-default",
+		Provider:         "applehv",
+		DiskPath:         "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ConfigEnabled:    true,
+		QemuImgAvailable: true,
+		DiskPathExpected: true,
+		LogicalBytes:     100 * podmanCompactionGiB,
+		PhysicalBytes:    12 * podmanCompactionGiB,
+		FreeBytes:        4 * podmanCompactionGiB,
+		Config:           cfg,
+	})
+
+	if plan.CanCompact {
+		t.Fatal("expected insufficient free space to block compaction")
+	}
+	if plan.SkipReason != "insufficient_free_space" {
+		t.Fatalf("expected insufficient_free_space, got %q", plan.SkipReason)
+	}
+}
+
+func TestPodmanCompactionPlanRejectsUnknownProvider(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:      "podman-machine-default",
+		Provider:         "mystery",
+		DiskPath:         "/Users/test/.local/share/containers/podman/machine/mystery/podman-machine-default.raw",
+		ConfigEnabled:    true,
+		QemuImgAvailable: true,
+		DiskPathExpected: true,
+		LogicalBytes:     20 * podmanCompactionGiB,
+		PhysicalBytes:    12 * podmanCompactionGiB,
+		FreeBytes:        20 * podmanCompactionGiB,
+		Config:           cfg,
+	})
+
+	if plan.CanCompact {
+		t.Fatal("expected unknown provider to block compaction")
+	}
+	if plan.SkipReason != "unsupported_provider" {
+		t.Fatalf("expected unsupported_provider, got %q", plan.SkipReason)
+	}
+}
+
+func TestPodmanCompactionPlanRejectsActiveContainers(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+	cfg.CompactRequireNoActiveContainers = true
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:      "podman-machine-default",
+		Provider:         "applehv",
+		DiskPath:         "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ConfigEnabled:    true,
+		QemuImgAvailable: true,
+		ActiveContainers: true,
+		DiskPathExpected: true,
+		LogicalBytes:     100 * podmanCompactionGiB,
+		PhysicalBytes:    12 * podmanCompactionGiB,
+		FreeBytes:        20 * podmanCompactionGiB,
+		Config:           cfg,
+	})
+
+	if plan.CanCompact {
+		t.Fatal("expected active containers to block compaction")
+	}
+	if plan.SkipReason != "active_containers" {
+		t.Fatalf("expected active_containers, got %q", plan.SkipReason)
+	}
+}
+
+func TestPodmanCompactionPlanRejectsMissingQemuImg(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:      "podman-machine-default",
+		Provider:         "applehv",
+		DiskPath:         "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ConfigEnabled:    true,
+		QemuImgAvailable: false,
+		DiskPathExpected: true,
+		LogicalBytes:     100 * podmanCompactionGiB,
+		PhysicalBytes:    12 * podmanCompactionGiB,
+		FreeBytes:        20 * podmanCompactionGiB,
+		Config:           cfg,
+	})
+
+	if plan.CanCompact {
+		t.Fatal("expected missing qemu-img to block compaction")
+	}
+	if plan.SkipReason != "qemu_img_missing" {
+		t.Fatalf("expected qemu_img_missing, got %q", plan.SkipReason)
+	}
+}
+
+func TestPathWithinRoots(t *testing.T) {
+	root := t.TempDir()
+	diskPath := filepath.Join(root, "applehv", "podman-machine-default.raw")
+
+	if !pathWithinRoots(diskPath, []string{root}) {
+		t.Fatalf("expected %s to be within %s", diskPath, root)
+	}
+	if pathWithinRoots(filepath.Join(t.TempDir(), "outside.raw"), []string{root}) {
+		t.Fatal("expected unrelated path to be outside root")
+	}
+}
+
+func testPodmanCompactionConfig() config.PodmanConfig {
+	cfg := config.DefaultConfig().Podman
+	cfg.CompactDiskOffline = true
+	cfg.CompactMinReclaimGB = 8
+	cfg.CompactRequireNoActiveContainers = true
+	cfg.CompactKeepBackupUntilRestart = true
+	cfg.CompactProviderAllowlist = []string{"applehv", "libkrun", "qemu"}
+	return cfg
+}


### PR DESCRIPTION
## Summary
- Add a generic plugin dry-run plan hook and include plugin plans in JSON reports.
- Add Podman offline compaction preflight for Darwin VM disks: provider/path/format checks, physical allocation accounting, active-container gating, qemu-img availability, backup detection, and physical-free-space requirements.
- Harden opt-in compaction rollback by preserving the original disk until restart verifies the compacted image.
- Add docs for macOS Podman applehv/raw compaction and include the new tests in the Bazel graph.

## Issue
Refs #6. This lands the preflight and reporting foundation for safe offline compaction. It does not close every remaining operator policy question around real-host smoke execution.

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...