### PR TITLE
Add Darwin developer cache dry-run targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -126,7 +126,10 @@ go_test(
         "plugins/plugin_test.go",
         "plugins/sudo_test.go",
     ] + select({
-        "@platforms//os:macos": ["plugins/apfs_darwin_test.go"],
+        "@platforms//os:macos": [
+            "plugins/apfs_darwin_test.go",
+            "plugins/darwin_dev_cache_test.go",
+        ],
         "//conditions:default": [],
     }),
     embed = [":plugins"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
   accounting.
 - Podman offline compaction preflight for Darwin VM disks, including physical
   allocation accounting and active-container safety gates.
+- Structured dry-run targets for Darwin developer caches such as JetBrains,
+  Playwright, Bazelisk, and pip.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ shrink from guest `fstrim` alone. See
 [docs/podman-darwin-compaction.md](docs/podman-darwin-compaction.md) before
 enabling offline compaction.
 
+Darwin developer cache review is documented in
+[docs/darwin-dev-caches.md](docs/darwin-dev-caches.md).
+
 ## Distribution Status
 
 Current package authority is the Nix flake package `.#tinyland-cleanup`.

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// Dev artifact cleanup settings
 	DevArtifacts DevArtifactsConfig `yaml:"dev_artifacts"`
 
+	// Darwin developer cache cleanup settings
+	DarwinDevCaches DarwinDevCachesConfig `yaml:"darwin_dev_caches"`
+
 	// APFS snapshot settings (Darwin)
 	APFS APFSConfig `yaml:"apfs"`
 
@@ -190,6 +193,38 @@ type DevArtifactsConfig struct {
 	ProtectPaths []string `yaml:"protect_paths"`
 }
 
+// DarwinDevCachesConfig holds macOS developer-cache budget settings.
+type DarwinDevCachesConfig struct {
+	// Enabled controls typed Darwin developer-cache planning.
+	Enabled bool `yaml:"enabled"`
+	// MaxTotalGB is the review budget across known Darwin developer caches.
+	MaxTotalGB int `yaml:"max_total_gb"`
+	// JetBrains controls JetBrains cache planning.
+	JetBrains DarwinDevCacheToolConfig `yaml:"jetbrains"`
+	// Playwright controls Playwright browser cache planning.
+	Playwright DarwinDevCacheToolConfig `yaml:"playwright"`
+	// Bazelisk controls Bazelisk download cache planning.
+	Bazelisk DarwinDevCacheToolConfig `yaml:"bazelisk"`
+	// Pip controls pip cache planning.
+	Pip DarwinDevCacheToolConfig `yaml:"pip"`
+}
+
+// DarwinDevCacheToolConfig holds per-tool cache budget settings.
+type DarwinDevCacheToolConfig struct {
+	// Enabled controls this cache family.
+	Enabled bool `yaml:"enabled"`
+	// MaxGB is the review budget for this cache family.
+	MaxGB int `yaml:"max_gb,omitempty"`
+	// StaleAfterDays is the age after which entries become cleanup candidates.
+	StaleAfterDays int `yaml:"stale_after_days,omitempty"`
+	// KeepLatest keeps this many newest entries when versioned.
+	KeepLatest int `yaml:"keep_latest,omitempty"`
+	// KeepLatestPerFamily keeps the newest entry for each detected browser/tool family.
+	KeepLatestPerFamily bool `yaml:"keep_latest_per_family,omitempty"`
+	// KeepActiveVersions preserves versions with active-use evidence.
+	KeepActiveVersions bool `yaml:"keep_active_versions,omitempty"`
+}
+
 // APFSConfig holds APFS snapshot cleanup settings (Darwin).
 type APFSConfig struct {
 	// ThinEnabled enables APFS snapshot thinning
@@ -277,6 +312,28 @@ func DefaultConfig() *Config {
 			HaskellCache:   true,
 			LMStudioModels: false,
 			ProtectPaths:   []string{},
+		},
+		DarwinDevCaches: DarwinDevCachesConfig{
+			Enabled:    runtime.GOOS == "darwin",
+			MaxTotalGB: 15,
+			JetBrains: DarwinDevCacheToolConfig{
+				Enabled:            true,
+				MaxGB:              8,
+				StaleAfterDays:     14,
+				KeepActiveVersions: true,
+			},
+			Playwright: DarwinDevCacheToolConfig{
+				Enabled:             true,
+				KeepLatestPerFamily: true,
+			},
+			Bazelisk: DarwinDevCacheToolConfig{
+				Enabled:    true,
+				KeepLatest: 2,
+			},
+			Pip: DarwinDevCacheToolConfig{
+				Enabled:        true,
+				StaleAfterDays: 14,
+			},
 		},
 		APFS: APFSConfig{
 			ThinEnabled:     true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -233,6 +233,34 @@ func TestPodmanCompactDefaults(t *testing.T) {
 	}
 }
 
+func TestDarwinDevCacheDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+	if runtime.GOOS == "darwin" && !cfg.DarwinDevCaches.Enabled {
+		t.Error("DarwinDevCaches.Enabled should default to true on Darwin")
+	}
+	if runtime.GOOS != "darwin" && cfg.DarwinDevCaches.Enabled {
+		t.Error("DarwinDevCaches.Enabled should default to false outside Darwin")
+	}
+	if cfg.DarwinDevCaches.MaxTotalGB != 15 {
+		t.Errorf("DarwinDevCaches.MaxTotalGB should default to 15, got %d", cfg.DarwinDevCaches.MaxTotalGB)
+	}
+	if !cfg.DarwinDevCaches.JetBrains.Enabled {
+		t.Error("DarwinDevCaches.JetBrains.Enabled should default to true")
+	}
+	if cfg.DarwinDevCaches.JetBrains.MaxGB != 8 {
+		t.Errorf("DarwinDevCaches.JetBrains.MaxGB should default to 8, got %d", cfg.DarwinDevCaches.JetBrains.MaxGB)
+	}
+	if !cfg.DarwinDevCaches.JetBrains.KeepActiveVersions {
+		t.Error("DarwinDevCaches.JetBrains.KeepActiveVersions should default to true")
+	}
+	if !cfg.DarwinDevCaches.Playwright.KeepLatestPerFamily {
+		t.Error("DarwinDevCaches.Playwright.KeepLatestPerFamily should default to true")
+	}
+	if cfg.DarwinDevCaches.Bazelisk.KeepLatest != 2 {
+		t.Errorf("DarwinDevCaches.Bazelisk.KeepLatest should default to 2, got %d", cfg.DarwinDevCaches.Bazelisk.KeepLatest)
+	}
+}
+
 func TestLoadConfigWithNewFields(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
@@ -266,6 +294,23 @@ podman:
   compact_keep_backup_until_restart: false
   compact_provider_allowlist:
     - applehv
+darwin_dev_caches:
+  enabled: true
+  max_total_gb: 20
+  jetbrains:
+    enabled: true
+    max_gb: 10
+    stale_after_days: 21
+    keep_active_versions: true
+  playwright:
+    enabled: false
+    keep_latest_per_family: false
+  bazelisk:
+    enabled: true
+    keep_latest: 3
+  pip:
+    enabled: true
+    stale_after_days: 7
 `
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -320,5 +365,26 @@ podman:
 	}
 	if len(cfg.Podman.CompactProviderAllowlist) != 1 || cfg.Podman.CompactProviderAllowlist[0] != "applehv" {
 		t.Errorf("unexpected Podman.CompactProviderAllowlist: %#v", cfg.Podman.CompactProviderAllowlist)
+	}
+	if !cfg.DarwinDevCaches.Enabled {
+		t.Error("DarwinDevCaches.Enabled should be true per config")
+	}
+	if cfg.DarwinDevCaches.MaxTotalGB != 20 {
+		t.Errorf("DarwinDevCaches.MaxTotalGB should be 20 per config, got %d", cfg.DarwinDevCaches.MaxTotalGB)
+	}
+	if cfg.DarwinDevCaches.JetBrains.MaxGB != 10 {
+		t.Errorf("DarwinDevCaches.JetBrains.MaxGB should be 10 per config, got %d", cfg.DarwinDevCaches.JetBrains.MaxGB)
+	}
+	if cfg.DarwinDevCaches.JetBrains.StaleAfterDays != 21 {
+		t.Errorf("DarwinDevCaches.JetBrains.StaleAfterDays should be 21 per config, got %d", cfg.DarwinDevCaches.JetBrains.StaleAfterDays)
+	}
+	if cfg.DarwinDevCaches.Playwright.Enabled {
+		t.Error("DarwinDevCaches.Playwright.Enabled should be false per config")
+	}
+	if cfg.DarwinDevCaches.Bazelisk.KeepLatest != 3 {
+		t.Errorf("DarwinDevCaches.Bazelisk.KeepLatest should be 3 per config, got %d", cfg.DarwinDevCaches.Bazelisk.KeepLatest)
+	}
+	if cfg.DarwinDevCaches.Pip.StaleAfterDays != 7 {
+		t.Errorf("DarwinDevCaches.Pip.StaleAfterDays should be 7 per config, got %d", cfg.DarwinDevCaches.Pip.StaleAfterDays)
 	}
 }

--- a/docs/darwin-dev-caches.md
+++ b/docs/darwin-dev-caches.md
@@ -1,0 +1,34 @@
+# Darwin Developer Caches
+
+Darwin developer caches are useful but can become large enough to break local
+work and CI runner jobs. The daemon now reports typed cache candidates during
+dry-run JSON output without deleting IDE settings or project state.
+
+Review with:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --output json
+```
+
+The cache plugin plan includes `targets` for known cache families:
+
+- `jetbrains`: versioned directories under `~/Library/Caches/JetBrains`;
+- `playwright`: browser revisions under `~/Library/Caches/ms-playwright`;
+- `bazelisk`: downloads under `~/Library/Caches/bazelisk`;
+- `pip`: caches under `~/Library/Caches/pip` and `~/.cache/pip`.
+
+Targets include the cache type, name, detected version, path, physical bytes,
+active-use evidence, protected status, review action, and reason.
+
+Safety boundaries:
+
+- never remove `~/Library/Application Support/JetBrains`;
+- never remove project workspaces;
+- never remove keychains, auth databases, editor settings, or extension config;
+- protect active JetBrains IDE versions when matching processes are running;
+- protect newest Playwright browser revisions per browser family;
+- protect the newest Bazelisk cache entries.
+
+This surface is currently a review and classification layer. Budget enforcement
+for these typed targets should remain a separate opt-in policy pass after the
+dry-run evidence is proven on real Darwin developer machines.

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -52,9 +52,13 @@ For macOS Podman VM disk compaction, review
 `applehv` raw images is advisory and is not counted as host-side reclaimed
 space.
 
+For Darwin IDE and tool caches, review
+[darwin-dev-caches.md](darwin-dev-caches.md). These targets are reported for
+operator review before budget enforcement is enabled.
+
 ## Current Boundary
 
-This is the first stable reporting surface. It does not yet expose per-file
-cleanup candidates for every plugin. Treat per-plugin candidate planning,
-active-use evidence, cooldown state, and target-free stop behavior as the next
-policy layer.
+This is the first stable reporting surface. It now exposes typed targets for
+selected plugins, but not per-file cleanup candidates for every plugin. Treat
+broader candidate planning, active-use evidence, cooldown state, and
+target-free stop behavior as the next policy layer.

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -436,6 +436,59 @@ func (p *CachePlugin) Enabled(cfg *config.Config) bool {
 	return cfg.Enable.Cache
 }
 
+// PlanCleanup reports typed Darwin developer-cache candidates without deleting them.
+func (p *CachePlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupPlan {
+	_ = logger
+
+	plan := CleanupPlan{
+		Plugin:   p.Name(),
+		Level:    level.String(),
+		Summary:  "Darwin developer cache review plan",
+		WouldRun: true,
+		Steps: []string{
+			"Measure known Darwin developer caches by physical allocation",
+			"Classify versioned tool caches by cache family and active-use evidence",
+			"Protect settings, application support data, project workspaces, credentials, and active IDE versions",
+		},
+		Metadata: map[string]string{
+			"darwin_dev_caches_enabled": strconv.FormatBool(cfg.DarwinDevCaches.Enabled),
+			"max_total_gb":              strconv.Itoa(cfg.DarwinDevCaches.MaxTotalGB),
+		},
+	}
+
+	if !cfg.DarwinDevCaches.Enabled {
+		plan.WouldRun = false
+		plan.SkipReason = "darwin_dev_caches_disabled"
+		return plan
+	}
+
+	home, _ := os.UserHomeDir()
+	activeProcesses := darwinActiveProcessNames(ctx)
+	targets := p.darwinDeveloperCacheTargets(home, cfg.DarwinDevCaches, activeProcesses)
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].Bytes == targets[j].Bytes {
+			return targets[i].Path < targets[j].Path
+		}
+		return targets[i].Bytes > targets[j].Bytes
+	})
+
+	var total int64
+	for _, target := range targets {
+		total += target.Bytes
+	}
+
+	plan.Targets = targets
+	plan.Metadata["target_count"] = strconv.Itoa(len(targets))
+	plan.Metadata["total_physical_bytes"] = strconv.FormatInt(total, 10)
+
+	if cfg.DarwinDevCaches.MaxTotalGB > 0 && total > int64(cfg.DarwinDevCaches.MaxTotalGB)*1024*1024*1024 {
+		plan.Warnings = append(plan.Warnings, "known Darwin developer caches exceed configured review budget")
+	}
+	plan.Warnings = append(plan.Warnings, "this slice reports typed cache candidates only; budget enforcement remains opt-in follow-up work")
+
+	return plan
+}
+
 // Cleanup performs cache cleanup at the specified level.
 func (p *CachePlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupResult {
 	result := CleanupResult{
@@ -549,6 +602,201 @@ func (p *CachePlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *conf
 	}
 
 	return result
+}
+
+type darwinCacheEntry struct {
+	path    string
+	name    string
+	version string
+	modTime time.Time
+	bytes   int64
+}
+
+func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.DarwinDevCachesConfig, activeProcesses map[string]bool) []CleanupTarget {
+	var targets []CleanupTarget
+
+	if cfg.JetBrains.Enabled {
+		jetBrainsRoot := filepath.Join(home, "Library", "Caches", "JetBrains")
+		jetBrainsActive := cfg.JetBrains.KeepActiveVersions && darwinAnyProcessActive(activeProcesses,
+			"appcode", "clion", "datagrip", "goland", "idea", "intellij", "phpstorm", "pycharm", "rider", "rubymine", "webstorm")
+		for _, entry := range listDarwinCacheEntries(jetBrainsRoot) {
+			targets = append(targets, CleanupTarget{
+				Type:      "jetbrains",
+				Name:      entry.name,
+				Version:   entry.version,
+				Path:      entry.path,
+				Bytes:     entry.bytes,
+				Active:    jetBrainsActive,
+				Protected: jetBrainsActive,
+				Action:    darwinReviewAction(jetBrainsActive),
+				Reason:    darwinReviewReason(jetBrainsActive, "JetBrains cache version"),
+			})
+		}
+	}
+
+	if cfg.Playwright.Enabled {
+		playwrightRoot := filepath.Join(home, "Library", "Caches", "ms-playwright")
+		entries := listDarwinCacheEntries(playwrightRoot)
+		protected := newestPerFamily(entries, cfg.Playwright.KeepLatestPerFamily)
+		for _, entry := range entries {
+			isProtected := protected[entry.path]
+			targets = append(targets, CleanupTarget{
+				Type:      "playwright",
+				Name:      entry.name,
+				Version:   entry.version,
+				Path:      entry.path,
+				Bytes:     entry.bytes,
+				Protected: isProtected,
+				Action:    darwinReviewAction(isProtected),
+				Reason:    darwinReviewReason(isProtected, "Playwright browser revision"),
+			})
+		}
+	}
+
+	if cfg.Bazelisk.Enabled {
+		bazeliskRoot := filepath.Join(home, "Library", "Caches", "bazelisk")
+		entries := listDarwinCacheEntries(bazeliskRoot)
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].modTime.After(entries[j].modTime)
+		})
+		keepLatest := cfg.Bazelisk.KeepLatest
+		for idx, entry := range entries {
+			isProtected := keepLatest > 0 && idx < keepLatest
+			targets = append(targets, CleanupTarget{
+				Type:      "bazelisk",
+				Name:      entry.name,
+				Version:   entry.version,
+				Path:      entry.path,
+				Bytes:     entry.bytes,
+				Protected: isProtected,
+				Action:    darwinReviewAction(isProtected),
+				Reason:    darwinReviewReason(isProtected, "Bazelisk download cache"),
+			})
+		}
+	}
+
+	if cfg.Pip.Enabled {
+		for _, pipPath := range []string{
+			filepath.Join(home, "Library", "Caches", "pip"),
+			filepath.Join(home, ".cache", "pip"),
+		} {
+			if !pathExistsAndIsDir(pipPath) {
+				continue
+			}
+			targets = append(targets, CleanupTarget{
+				Type:   "pip",
+				Name:   filepath.Base(pipPath),
+				Path:   pipPath,
+				Bytes:  getDirAllocatedBytes(pipPath),
+				Action: "review",
+				Reason: fmt.Sprintf("pip cache; stale-after review budget is %d days", cfg.Pip.StaleAfterDays),
+			})
+		}
+	}
+
+	return targets
+}
+
+func listDarwinCacheEntries(root string) []darwinCacheEntry {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+
+	targets := make([]darwinCacheEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		targets = append(targets, darwinCacheEntry{
+			path:    path,
+			name:    entry.Name(),
+			version: darwinCacheVersion(entry.Name()),
+			modTime: info.ModTime(),
+			bytes:   getDirAllocatedBytes(path),
+		})
+	}
+	return targets
+}
+
+func newestPerFamily(entries []darwinCacheEntry, enabled bool) map[string]bool {
+	protected := map[string]bool{}
+	if !enabled {
+		return protected
+	}
+
+	newest := map[string]darwinCacheEntry{}
+	for _, entry := range entries {
+		family := darwinCacheFamily(entry.name)
+		current, ok := newest[family]
+		if !ok || entry.modTime.After(current.modTime) {
+			newest[family] = entry
+		}
+	}
+	for _, entry := range newest {
+		protected[entry.path] = true
+	}
+	return protected
+}
+
+func darwinCacheVersion(name string) string {
+	re := regexp.MustCompile(`(\d+(?:[._-]\d+)+)`)
+	if match := re.FindStringSubmatch(name); len(match) > 1 {
+		return strings.ReplaceAll(match[1], "_", ".")
+	}
+	return ""
+}
+
+func darwinCacheFamily(name string) string {
+	if idx := strings.Index(name, "-"); idx > 0 {
+		return name[:idx]
+	}
+	return name
+}
+
+func darwinReviewAction(protected bool) string {
+	if protected {
+		return "protect"
+	}
+	return "review"
+}
+
+func darwinReviewReason(protected bool, label string) string {
+	if protected {
+		return label + " is protected by active-use or keep-latest policy"
+	}
+	return label + " is a cleanup candidate for a future budget-enforcement pass"
+}
+
+func darwinActiveProcessNames(ctx context.Context) map[string]bool {
+	active := map[string]bool{}
+	output, err := exec.CommandContext(ctx, "ps", "-axo", "comm=").Output()
+	if err != nil {
+		return active
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		name := strings.ToLower(filepath.Base(strings.TrimSpace(line)))
+		if name != "" {
+			active[name] = true
+		}
+	}
+	return active
+}
+
+func darwinAnyProcessActive(active map[string]bool, names ...string) bool {
+	for process := range active {
+		for _, name := range names {
+			if strings.Contains(process, name) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Helper functions

--- a/plugins/darwin_dev_cache_test.go
+++ b/plugins/darwin_dev_cache_test.go
@@ -1,0 +1,94 @@
+//go:build darwin
+
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Jesssullivan/tinyland-cleanup/config"
+)
+
+func TestDarwinDeveloperCacheTargetsClassifyProtectedVersions(t *testing.T) {
+	home := t.TempDir()
+	cfg := config.DefaultConfig().DarwinDevCaches
+
+	writeCacheFile(t, home, "Library/Caches/JetBrains/IntelliJIdea2024.3/cache.bin", "jetbrains")
+	writeCacheFile(t, home, "Library/Caches/ms-playwright/chromium-1148/browser.bin", "old chromium")
+	writeCacheFile(t, home, "Library/Caches/ms-playwright/chromium-1149/browser.bin", "new chromium")
+	writeCacheFile(t, home, "Library/Caches/bazelisk/v1/bin/bazel", "v1")
+	writeCacheFile(t, home, "Library/Caches/bazelisk/v2/bin/bazel", "v2")
+	writeCacheFile(t, home, "Library/Caches/bazelisk/v3/bin/bazel", "v3")
+	writeCacheFile(t, home, "Library/Caches/pip/http/cache.bin", "pip")
+
+	now := time.Now()
+	mustChtimes(t, filepath.Join(home, "Library/Caches/ms-playwright/chromium-1148"), now.Add(-2*time.Hour))
+	mustChtimes(t, filepath.Join(home, "Library/Caches/ms-playwright/chromium-1149"), now)
+	mustChtimes(t, filepath.Join(home, "Library/Caches/bazelisk/v1"), now.Add(-3*time.Hour))
+	mustChtimes(t, filepath.Join(home, "Library/Caches/bazelisk/v2"), now.Add(-2*time.Hour))
+	mustChtimes(t, filepath.Join(home, "Library/Caches/bazelisk/v3"), now)
+
+	plugin := &CachePlugin{}
+	targets := plugin.darwinDeveloperCacheTargets(home, cfg, map[string]bool{"goland": true})
+
+	jetbrains := findCleanupTarget(t, targets, "jetbrains", "IntelliJIdea2024.3")
+	if !jetbrains.Active || !jetbrains.Protected {
+		t.Fatalf("expected active JetBrains cache to be protected: %#v", jetbrains)
+	}
+
+	oldChromium := findCleanupTarget(t, targets, "playwright", "chromium-1148")
+	if oldChromium.Protected {
+		t.Fatalf("expected old Playwright revision to be reviewable: %#v", oldChromium)
+	}
+	newChromium := findCleanupTarget(t, targets, "playwright", "chromium-1149")
+	if !newChromium.Protected {
+		t.Fatalf("expected newest Playwright revision to be protected: %#v", newChromium)
+	}
+
+	bazeliskV1 := findCleanupTarget(t, targets, "bazelisk", "v1")
+	if bazeliskV1.Protected {
+		t.Fatalf("expected oldest Bazelisk cache to be reviewable: %#v", bazeliskV1)
+	}
+	bazeliskV2 := findCleanupTarget(t, targets, "bazelisk", "v2")
+	bazeliskV3 := findCleanupTarget(t, targets, "bazelisk", "v3")
+	if !bazeliskV2.Protected || !bazeliskV3.Protected {
+		t.Fatalf("expected two newest Bazelisk caches to be protected: v2=%#v v3=%#v", bazeliskV2, bazeliskV3)
+	}
+
+	pip := findCleanupTarget(t, targets, "pip", "pip")
+	if pip.Bytes <= 0 {
+		t.Fatalf("expected pip cache size to be measured: %#v", pip)
+	}
+}
+
+func writeCacheFile(t *testing.T, home, relPath, content string) {
+	t.Helper()
+
+	path := filepath.Join(home, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustChtimes(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func findCleanupTarget(t *testing.T, targets []CleanupTarget, targetType, name string) CleanupTarget {
+	t.Helper()
+	for _, target := range targets {
+		if target.Type == targetType && target.Name == name {
+			return target
+		}
+	}
+	t.Fatalf("target %s/%s not found in %#v", targetType, name, targets)
+	return CleanupTarget{}
+}

--- a/plugins/fs.go
+++ b/plugins/fs.go
@@ -164,6 +164,26 @@ func getFileAllocatedBytes(path string) (int64, error) {
 	return stat.Blocks * 512, nil
 }
 
+func getDirAllocatedBytes(path string) int64 {
+	var size int64
+	filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		allocated, err := getFileAllocatedBytes(p)
+		if err != nil {
+			size += info.Size()
+			return nil
+		}
+		size += allocated
+		return nil
+	})
+	return size
+}
+
 // safeBytesDiff returns the difference between two sizes, floored at 0.
 // Prevents negative BytesFreed when files are added during cleanup.
 func safeBytesDiff(before, after int64) int64 {

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -81,10 +81,34 @@ type CleanupPlan struct {
 	RequiredFreeBytes int64 `json:"required_free_bytes,omitempty"`
 	// Steps lists the operator-visible steps the cleanup would perform.
 	Steps []string `json:"steps,omitempty"`
+	// Targets lists concrete files, directories, or resources considered by the plan.
+	Targets []CleanupTarget `json:"targets,omitempty"`
 	// Warnings lists safety warnings or lossy accounting caveats.
 	Warnings []string `json:"warnings,omitempty"`
 	// Metadata carries plugin-specific plan facts.
 	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// CleanupTarget is one concrete cleanup candidate in a dry-run plan.
+type CleanupTarget struct {
+	// Type is the cache or resource class.
+	Type string `json:"type"`
+	// Name is a short target label.
+	Name string `json:"name"`
+	// Version is the tool or cache version when detectable.
+	Version string `json:"version,omitempty"`
+	// Path is the local filesystem path for file-backed targets.
+	Path string `json:"path,omitempty"`
+	// Bytes is the measured target size.
+	Bytes int64 `json:"bytes"`
+	// Active reports whether active-use evidence was detected.
+	Active bool `json:"active"`
+	// Protected reports whether the plan should preserve the target.
+	Protected bool `json:"protected"`
+	// Action describes the planned action.
+	Action string `json:"action"`
+	// Reason explains why the action was selected.
+	Reason string `json:"reason,omitempty"`
 }
 
 // Plugin is the interface that cleanup plugins must implement.


### PR DESCRIPTION
## Summary
- Add structured dry-run targets to cleanup plans.
- Add Darwin developer-cache config defaults and typed cache classification for JetBrains, Playwright, Bazelisk, and pip.
- Report physical target size, version/name, active/protected state, review action, and reason in JSON dry-run plans.
- Document the Darwin developer cache review boundary and include the Darwin test in the Bazel graph.

## Issue
Refs #5. This is the review/classification foundation. It intentionally does not delete IDE/tool cache targets yet; budget enforcement should be a separate opt-in policy pass after dry-run evidence is proven on real Darwin machines.

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...