### PR TITLE
Add Bazel cache dry-run planning

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -88,6 +88,7 @@ go_test(
 go_library(
     name = "plugins",
     srcs = [
+        "plugins/bazel.go",
         "plugins/cache.go",
         "plugins/devartifacts.go",
         "plugins/docker.go",
@@ -120,6 +121,7 @@ go_library(
 go_test(
     name = "plugins_test",
     srcs = [
+        "plugins/bazel_test.go",
         "plugins/devartifacts_test.go",
         "plugins/nix_test.go",
         "plugins/podman_compaction_test.go",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
   Playwright, Bazelisk, and pip.
 - Nix cleanup preflight plans with dry-run reclaim estimates, generation
   retention targets, daemon-contention detection, and opt-in store optimization.
+- Bazel cache and output-base dry-run planning with active-use detection,
+  protected workspace symlink detection, and budget metadata.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Darwin developer cache review is documented in
 Nix store and generation cleanup policy is documented in
 [docs/nix-cleanup-policy.md](docs/nix-cleanup-policy.md).
 
+Bazel cache and output-base review is documented in
+[docs/bazel-cache-policy.md](docs/bazel-cache-policy.md).
+
 ## Distribution Status
 
 Current package authority is the Nix flake package `.#tinyland-cleanup`.

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,9 @@ type Config struct {
 	// Podman-specific settings
 	Podman PodmanConfig `yaml:"podman"`
 
+	// Bazel-specific cache settings
+	Bazel BazelConfig `yaml:"bazel"`
+
 	// Nix-specific cleanup settings
 	Nix NixConfig `yaml:"nix"`
 
@@ -120,6 +123,8 @@ type EnableFlags struct {
 	Photos bool `yaml:"photos"`
 	// DevArtifacts for stale development artifact cleanup
 	DevArtifacts bool `yaml:"dev_artifacts"`
+	// Bazel for Bazel output base and cache cleanup planning
+	Bazel bool `yaml:"bazel"`
 	// APFSSnapshots for APFS snapshot thinning (Darwin)
 	APFSSnapshots bool `yaml:"apfs_snapshots"`
 }
@@ -164,6 +169,28 @@ type PodmanConfig struct {
 	CompactKeepBackupUntilRestart bool `yaml:"compact_keep_backup_until_restart"`
 	// CompactProviderAllowlist restricts offline compaction to known providers
 	CompactProviderAllowlist []string `yaml:"compact_provider_allowlist"`
+}
+
+// BazelConfig holds Bazel output base and cache cleanup settings.
+type BazelConfig struct {
+	// Roots are directories that may contain Bazel output-user-root trees or caches.
+	Roots []string `yaml:"roots"`
+	// BazeliskCache is the Bazelisk download cache path.
+	BazeliskCache string `yaml:"bazelisk_cache"`
+	// MaxTotalGB is the review budget across detected Bazel caches.
+	MaxTotalGB int `yaml:"max_total_gb"`
+	// KeepRecentOutputBases preserves this many newest output bases.
+	KeepRecentOutputBases int `yaml:"keep_recent_output_bases"`
+	// StaleAfter is the normal age threshold for output-base deletion candidates.
+	StaleAfter string `yaml:"stale_after"`
+	// CriticalStaleAfter is the critical-level age threshold.
+	CriticalStaleAfter string `yaml:"critical_stale_after"`
+	// ProtectWorkspaces preserves output bases reachable from these workspaces.
+	ProtectWorkspaces []string `yaml:"protect_workspaces"`
+	// AllowStopIdleServers allows future cleanup to stop idle Bazel servers.
+	AllowStopIdleServers bool `yaml:"allow_stop_idle_servers"`
+	// AllowDeleteActiveOutputBases allows future cleanup to delete active output bases.
+	AllowDeleteActiveOutputBases bool `yaml:"allow_delete_active_output_bases"`
 }
 
 // NixConfig holds Nix store and profile generation cleanup settings.
@@ -278,6 +305,10 @@ func DefaultConfig() *Config {
 		filepath.Join(home, "src"),
 		filepath.Join(home, "projects"),
 	}
+	bazeliskCache := filepath.Join(home, ".cache", "bazelisk")
+	if runtime.GOOS == "darwin" {
+		bazeliskCache = filepath.Join(home, "Library", "Caches", "bazelisk")
+	}
 
 	config := &Config{
 		PollInterval: 60,
@@ -301,6 +332,7 @@ func DefaultConfig() *Config {
 			ICloud:        runtime.GOOS == "darwin",
 			Photos:        runtime.GOOS == "darwin",
 			DevArtifacts:  true,
+			Bazel:         true,
 			APFSSnapshots: runtime.GOOS == "darwin",
 		},
 		Docker: DockerConfig{
@@ -317,6 +349,20 @@ func DefaultConfig() *Config {
 			CompactRequireNoActiveContainers: true,
 			CompactKeepBackupUntilRestart:    true,
 			CompactProviderAllowlist:         []string{"applehv", "libkrun", "qemu"},
+		},
+		Bazel: BazelConfig{
+			Roots:                 defaultBazelRoots(home),
+			BazeliskCache:         bazeliskCache,
+			MaxTotalGB:            20,
+			KeepRecentOutputBases: 5,
+			StaleAfter:            "14d",
+			CriticalStaleAfter:    "3d",
+			ProtectWorkspaces: []string{
+				filepath.Join(home, "git", "lab"),
+				filepath.Join(home, "git", "GloriousFlywheel"),
+			},
+			AllowStopIdleServers:         true,
+			AllowDeleteActiveOutputBases: false,
 		},
 		Nix: NixConfig{
 			MinUserGenerations:                 5,
@@ -387,6 +433,19 @@ func DefaultConfig() *Config {
 	}
 
 	return config
+}
+
+func defaultBazelRoots(home string) []string {
+	roots := []string{filepath.Join(home, ".cache", "bazel")}
+	if runtime.GOOS == "darwin" {
+		if user := os.Getenv("USER"); user != "" {
+			roots = append(roots,
+				filepath.Join("/private", "var", "tmp", "_bazel_"+user),
+				filepath.Join("/var", "tmp", "_bazel_"+user),
+			)
+		}
+	}
+	return roots
 }
 
 // LoadConfig loads configuration from a YAML file, merging with defaults.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -202,6 +202,9 @@ func TestEnableFlagsNewPlugins(t *testing.T) {
 	if !cfg.Enable.DevArtifacts {
 		t.Error("Enable.DevArtifacts should be true by default")
 	}
+	if !cfg.Enable.Bazel {
+		t.Error("Enable.Bazel should be true by default")
+	}
 	if runtime.GOOS == "darwin" && !cfg.Enable.APFSSnapshots {
 		t.Error("Enable.APFSSnapshots should be true on Darwin")
 	}
@@ -262,6 +265,38 @@ func TestNixPolicyDefaults(t *testing.T) {
 	}
 }
 
+func TestBazelPolicyDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if len(cfg.Bazel.Roots) == 0 {
+		t.Fatal("Bazel.Roots should have defaults")
+	}
+	if cfg.Bazel.BazeliskCache == "" {
+		t.Fatal("Bazel.BazeliskCache should have a default")
+	}
+	if cfg.Bazel.MaxTotalGB != 20 {
+		t.Errorf("Bazel.MaxTotalGB should be 20, got %d", cfg.Bazel.MaxTotalGB)
+	}
+	if cfg.Bazel.KeepRecentOutputBases != 5 {
+		t.Errorf("Bazel.KeepRecentOutputBases should be 5, got %d", cfg.Bazel.KeepRecentOutputBases)
+	}
+	if cfg.Bazel.StaleAfter != "14d" {
+		t.Errorf("Bazel.StaleAfter should be 14d, got %q", cfg.Bazel.StaleAfter)
+	}
+	if cfg.Bazel.CriticalStaleAfter != "3d" {
+		t.Errorf("Bazel.CriticalStaleAfter should be 3d, got %q", cfg.Bazel.CriticalStaleAfter)
+	}
+	if len(cfg.Bazel.ProtectWorkspaces) == 0 {
+		t.Fatal("Bazel.ProtectWorkspaces should have defaults")
+	}
+	if !cfg.Bazel.AllowStopIdleServers {
+		t.Error("Bazel.AllowStopIdleServers should be true by default")
+	}
+	if cfg.Bazel.AllowDeleteActiveOutputBases {
+		t.Error("Bazel.AllowDeleteActiveOutputBases should be false by default")
+	}
+}
+
 func TestDarwinDevCacheDefaults(t *testing.T) {
 	cfg := DefaultConfig()
 	if runtime.GOOS == "darwin" && !cfg.DarwinDevCaches.Enabled {
@@ -296,6 +331,7 @@ func TestLoadConfigWithNewFields(t *testing.T) {
 	content := `
 enable:
   dev_artifacts: true
+  bazel: true
   apfs_snapshots: true
 dev_artifacts:
   scan_paths:
@@ -332,6 +368,18 @@ nix:
   skip_when_daemon_busy: false
   daemon_busy_backoff: 45m
   max_gc_duration: 10m
+bazel:
+  roots:
+    - ~/custom-bazel
+  bazelisk_cache: ~/custom-bazelisk
+  max_total_gb: 30
+  keep_recent_output_bases: 2
+  stale_after: 10d
+  critical_stale_after: 2d
+  protect_workspaces:
+    - ~/git/important
+  allow_stop_idle_servers: false
+  allow_delete_active_output_bases: true
 darwin_dev_caches:
   enabled: true
   max_total_gb: 20
@@ -361,6 +409,9 @@ darwin_dev_caches:
 
 	if !cfg.Enable.DevArtifacts {
 		t.Error("Enable.DevArtifacts should be true")
+	}
+	if !cfg.Enable.Bazel {
+		t.Error("Enable.Bazel should be true")
 	}
 	if !cfg.Enable.APFSSnapshots {
 		t.Error("Enable.APFSSnapshots should be true")
@@ -427,6 +478,33 @@ darwin_dev_caches:
 	}
 	if cfg.Nix.MaxGCDuration != "10m" {
 		t.Errorf("Nix.MaxGCDuration should be 10m per config, got %q", cfg.Nix.MaxGCDuration)
+	}
+	if len(cfg.Bazel.Roots) != 1 || cfg.Bazel.Roots[0] != "~/custom-bazel" {
+		t.Errorf("unexpected Bazel.Roots: %#v", cfg.Bazel.Roots)
+	}
+	if cfg.Bazel.BazeliskCache != "~/custom-bazelisk" {
+		t.Errorf("Bazel.BazeliskCache should be custom path, got %q", cfg.Bazel.BazeliskCache)
+	}
+	if cfg.Bazel.MaxTotalGB != 30 {
+		t.Errorf("Bazel.MaxTotalGB should be 30 per config, got %d", cfg.Bazel.MaxTotalGB)
+	}
+	if cfg.Bazel.KeepRecentOutputBases != 2 {
+		t.Errorf("Bazel.KeepRecentOutputBases should be 2 per config, got %d", cfg.Bazel.KeepRecentOutputBases)
+	}
+	if cfg.Bazel.StaleAfter != "10d" {
+		t.Errorf("Bazel.StaleAfter should be 10d per config, got %q", cfg.Bazel.StaleAfter)
+	}
+	if cfg.Bazel.CriticalStaleAfter != "2d" {
+		t.Errorf("Bazel.CriticalStaleAfter should be 2d per config, got %q", cfg.Bazel.CriticalStaleAfter)
+	}
+	if len(cfg.Bazel.ProtectWorkspaces) != 1 || cfg.Bazel.ProtectWorkspaces[0] != "~/git/important" {
+		t.Errorf("unexpected Bazel.ProtectWorkspaces: %#v", cfg.Bazel.ProtectWorkspaces)
+	}
+	if cfg.Bazel.AllowStopIdleServers {
+		t.Error("Bazel.AllowStopIdleServers should be false per config")
+	}
+	if !cfg.Bazel.AllowDeleteActiveOutputBases {
+		t.Error("Bazel.AllowDeleteActiveOutputBases should be true per config")
 	}
 	if !cfg.DarwinDevCaches.Enabled {
 		t.Error("DarwinDevCaches.Enabled should be true per config")

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -26,6 +26,7 @@ enable:
   gitlab_runner: true   # GitLab runner cache cleanup
   github_runner: true   # GitHub Actions runner cleanup (Linux only)
   yum: true             # DNF/YUM package cache cleanup (Linux only)
+  bazel: true           # Bazel output base and cache cleanup planning
 
 # GitHub Actions runner settings (Linux only)
 github_runner:
@@ -77,6 +78,22 @@ nix:
   skip_when_daemon_busy: true
   daemon_busy_backoff: 30m
   max_gc_duration: 20m
+
+# Bazel output base and cache review settings
+bazel:
+  roots:
+    - ~/.cache/bazel
+  # Darwin default; Linux operators commonly use ~/.cache/bazelisk
+  bazelisk_cache: ~/Library/Caches/bazelisk
+  max_total_gb: 20
+  keep_recent_output_bases: 5
+  stale_after: 14d
+  critical_stale_after: 3d
+  protect_workspaces:
+    - ~/git/lab
+    - ~/git/GloriousFlywheel
+  allow_stop_idle_servers: true
+  allow_delete_active_output_bases: false
 
 # Lima VM settings (macOS)
 lima:

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -1,0 +1,62 @@
+# Bazel Cache Policy
+
+Bazel cleanup is currently a dry-run planning surface. It reports output bases,
+repository caches, disk caches, and Bazelisk downloads without deleting them.
+Deletion and permission normalization should be enabled only after the dry-run
+evidence is proven on real developer and runner hosts.
+
+Review with:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --output json
+```
+
+The Bazel plan includes targets for:
+
+- `output_base`: Bazel output bases under configured roots such as
+  `~/.cache/bazel/_bazel_$USER/*` or Darwin `/private/var/tmp/_bazel_$USER/*`;
+- `repository_cache`: shared external repository artifacts;
+- `disk_cache`: local action cache entries;
+- `bazelisk`: Bazelisk download cache entries.
+
+Targets include bounded physical byte estimates, active-use evidence, protected
+status, the planned action, and a reason. Output bases are protected when:
+
+- a Bazel or Bazelisk process is active;
+- an output-base lock or server PID file is visible;
+- a configured protected workspace has `bazel-*` symlinks into that output base;
+- the output base is within `keep_recent_output_bases`;
+- the output base is newer than the configured stale threshold.
+
+Default policy:
+
+```yaml
+bazel:
+  roots:
+    - ~/.cache/bazel
+  bazelisk_cache: ~/Library/Caches/bazelisk
+  max_total_gb: 20
+  keep_recent_output_bases: 5
+  stale_after: 14d
+  critical_stale_after: 3d
+  protect_workspaces:
+    - ~/git/lab
+    - ~/git/GloriousFlywheel
+  allow_stop_idle_servers: true
+  allow_delete_active_output_bases: false
+```
+
+Runtime boundary:
+
+- warning reports footprint only;
+- moderate, aggressive, and critical classify stale inactive output bases as
+  `delete_output_base` candidates in dry-run output;
+- byte counts use top-level allocation estimates so dry-run remains responsive
+  on very large generated trees;
+- repository cache, disk cache, and Bazelisk entries are reported for budget
+  review but not deleted yet;
+- real cleanup mode logs that Bazel cleanup is planning-only.
+
+Do not disable active-output-base protection on developer machines or shared
+runners unless an operator has already drained the relevant jobs and accepted
+the risk.

--- a/main.go
+++ b/main.go
@@ -518,6 +518,7 @@ func registerPlugins(registry *plugins.Registry) {
 	registry.Register(plugins.NewDockerPlugin())
 	registry.Register(plugins.NewPodmanPlugin())
 	registry.Register(plugins.NewNixPlugin())
+	registry.Register(plugins.NewBazelPlugin())
 	registry.Register(plugins.NewCachePlugin())
 	registry.Register(plugins.NewGitLabRunnerPlugin())
 

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -1,0 +1,507 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Jesssullivan/tinyland-cleanup/config"
+)
+
+const bazelGiB = int64(1024 * 1024 * 1024)
+
+var bazelCommandPattern = regexp.MustCompile(`\b(bazel|bazelisk)\s+(build|test|run|coverage|query|sync|fetch|clean|mobile-install|aquery|cquery)\b`)
+
+// BazelPlugin reports Bazel output bases and cache tiers.
+type BazelPlugin struct{}
+
+type bazelCandidate struct {
+	Type      string
+	Name      string
+	Path      string
+	ModTime   time.Time
+	Logical   int64
+	Physical  int64
+	Active    bool
+	Protected bool
+	Action    string
+	Reason    string
+}
+
+// NewBazelPlugin creates a new Bazel cleanup plugin.
+func NewBazelPlugin() *BazelPlugin {
+	return &BazelPlugin{}
+}
+
+// Name returns the plugin identifier.
+func (p *BazelPlugin) Name() string {
+	return "bazel"
+}
+
+// Description returns the plugin description.
+func (p *BazelPlugin) Description() string {
+	return "Plans Bazel output base, repository cache, disk cache, and Bazelisk cleanup"
+}
+
+// SupportedPlatforms returns supported platforms (all).
+func (p *BazelPlugin) SupportedPlatforms() []string {
+	return nil
+}
+
+// Enabled checks if Bazel cleanup planning is enabled.
+func (p *BazelPlugin) Enabled(cfg *config.Config) bool {
+	return cfg.Enable.Bazel
+}
+
+// PlanCleanup returns a dry-run plan without mutating Bazel state.
+func (p *BazelPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupPlan {
+	_ = logger
+
+	plan := CleanupPlan{
+		Plugin:   p.Name(),
+		Level:    level.String(),
+		Summary:  "Bazel cache and output-base review plan",
+		WouldRun: true,
+		Steps: []string{
+			"Discover Bazel output bases, repository caches, disk caches, and Bazelisk downloads",
+			"Measure logical and physical bytes without following repo-local bazel-* symlinks",
+			"Protect active output bases, protected workspace output bases, and newest output bases",
+			"Report cleanup candidates with reasons before enabling deletion",
+		},
+		Metadata: map[string]string{
+			"cleanup_level":                    level.String(),
+			"max_total_gb":                     strconv.Itoa(cfg.Bazel.MaxTotalGB),
+			"keep_recent_output_bases":         strconv.Itoa(cfg.Bazel.KeepRecentOutputBases),
+			"stale_after":                      cfg.Bazel.StaleAfter,
+			"critical_stale_after":             cfg.Bazel.CriticalStaleAfter,
+			"allow_stop_idle_servers":          strconv.FormatBool(cfg.Bazel.AllowStopIdleServers),
+			"allow_delete_active_output_bases": strconv.FormatBool(cfg.Bazel.AllowDeleteActiveOutputBases),
+		},
+	}
+
+	home, _ := os.UserHomeDir()
+	activeReasons, activeErr := p.activeBazelProcesses(ctx)
+	if activeErr != nil {
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("could not inspect active Bazel processes: %v", activeErr))
+	} else if len(activeReasons) > 0 {
+		plan.Metadata["active_bazel_processes"] = strings.Join(activeReasons, ", ")
+	}
+
+	candidates := p.discoverCandidates(home, cfg.Bazel)
+	targets, totalPhysical := bazelPlanTargets(candidates, cfg.Bazel, level, time.Now(), len(activeReasons) > 0)
+	plan.Targets = targets
+	plan.EstimatedBytesFreed = bazelEstimatedCandidateBytes(targets)
+	plan.Metadata["target_count"] = strconv.Itoa(len(targets))
+	plan.Metadata["total_physical_bytes"] = strconv.FormatInt(totalPhysical, 10)
+
+	if cfg.Bazel.MaxTotalGB > 0 && totalPhysical > int64(cfg.Bazel.MaxTotalGB)*bazelGiB {
+		plan.Warnings = append(plan.Warnings, "detected Bazel cache footprint exceeds configured review budget")
+	}
+	plan.Warnings = append(plan.Warnings, "Bazel cleanup is planning-only in this slice; deletion and permission normalization remain follow-up work")
+	plan.Warnings = append(plan.Warnings, "Bazel byte counts use bounded top-level allocation estimates so dry-run stays responsive on very large output bases")
+
+	return plan
+}
+
+// Cleanup is intentionally planning-only until Bazel deletion policy is proven.
+func (p *BazelPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupResult {
+	_ = ctx
+	_ = cfg
+	logger.Info("Bazel cleanup is planning-only; use --dry-run --output json to review candidates", "level", level.String())
+	return CleanupResult{Plugin: p.Name(), Level: level}
+}
+
+func (p *BazelPlugin) activeBazelProcesses(ctx context.Context) ([]string, error) {
+	psCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(psCtx, "ps", "-axo", "comm=,args=")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return bazelBusyProcessReasons(string(output)), nil
+}
+
+func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig) []bazelCandidate {
+	var candidates []bazelCandidate
+	seen := map[string]bool{}
+
+	add := func(candidate bazelCandidate) {
+		if candidate.Path == "" || seen[candidate.Path] {
+			return
+		}
+		seen[candidate.Path] = true
+		candidates = append(candidates, candidate)
+	}
+
+	for _, root := range cfg.Roots {
+		expanded := expandHome(root, home)
+		for _, candidate := range discoverBazelRootCandidates(expanded) {
+			add(candidate)
+		}
+	}
+
+	if cfg.BazeliskCache != "" {
+		for _, candidate := range discoverBazeliskCandidates(expandHome(cfg.BazeliskCache, home)) {
+			add(candidate)
+		}
+	}
+
+	protectedOutputBases := outputBasesProtectedByWorkspaces(cfg.ProtectWorkspaces, home)
+	for i := range candidates {
+		if candidates[i].Type == "output_base" && protectedOutputBases[candidates[i].Path] {
+			candidates[i].Protected = true
+			candidates[i].Reason = "reachable from configured protected workspace"
+		}
+		if candidates[i].Type == "output_base" && bazelOutputBaseHasActiveLock(candidates[i].Path) {
+			candidates[i].Active = true
+		}
+	}
+
+	return candidates
+}
+
+func discoverBazelRootCandidates(root string) []bazelCandidate {
+	info, err := os.Stat(root)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	var candidates []bazelCandidate
+	if isBazelOutputBase(root) {
+		return []bazelCandidate{newBazelCandidate("output_base", filepath.Base(root), root, info.ModTime())}
+	}
+
+	base := filepath.Base(root)
+	if strings.HasPrefix(base, "_bazel_") {
+		return discoverBazelOutputBases(root)
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		switch {
+		case strings.HasPrefix(entry.Name(), "_bazel_"):
+			candidates = append(candidates, discoverBazelOutputBases(path)...)
+		case entry.Name() == "repository_cache":
+			if info, err := entry.Info(); err == nil {
+				candidates = append(candidates, newBazelCandidate("repository_cache", entry.Name(), path, info.ModTime()))
+			}
+		case entry.Name() == "disk_cache":
+			if info, err := entry.Info(); err == nil {
+				candidates = append(candidates, newBazelCandidate("disk_cache", entry.Name(), path, info.ModTime()))
+			}
+		}
+	}
+
+	return candidates
+}
+
+func discoverBazelOutputBases(outputUserRoot string) []bazelCandidate {
+	entries, err := os.ReadDir(outputUserRoot)
+	if err != nil {
+		return nil
+	}
+
+	var candidates []bazelCandidate
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(outputUserRoot, entry.Name())
+		if !isBazelOutputBase(path) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, newBazelCandidate("output_base", entry.Name(), path, info.ModTime()))
+	}
+	return candidates
+}
+
+func discoverBazeliskCandidates(root string) []bazelCandidate {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+
+	var candidates []bazelCandidate
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, newBazelCandidate("bazelisk", entry.Name(), path, info.ModTime()))
+	}
+	return candidates
+}
+
+func newBazelCandidate(candidateType, name, path string, modTime time.Time) bazelCandidate {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	logical, physical := estimateBazelCandidateBytes(path)
+	return bazelCandidate{
+		Type:     candidateType,
+		Name:     name,
+		Path:     path,
+		ModTime:  modTime,
+		Logical:  logical,
+		Physical: physical,
+	}
+}
+
+func estimateBazelCandidateBytes(path string) (int64, int64) {
+	var logical int64
+	var physical int64
+
+	if info, err := os.Stat(path); err == nil {
+		logical += info.Size()
+		if allocated, err := getFileAllocatedBytes(path); err == nil {
+			physical += allocated
+		}
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return logical, physical
+	}
+	for _, entry := range entries {
+		entryPath := filepath.Join(path, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		logical += info.Size()
+		if allocated, err := getFileAllocatedBytes(entryPath); err == nil {
+			physical += allocated
+		}
+	}
+
+	return logical, physical
+}
+
+func isBazelOutputBase(path string) bool {
+	required := []string{"execroot", "action_cache", "server"}
+	for _, name := range required {
+		if !pathExistsAndIsDir(filepath.Join(path, name)) {
+			return false
+		}
+	}
+	return true
+}
+
+func bazelOutputBaseHasActiveLock(path string) bool {
+	if bazelServerPIDIsAlive(filepath.Join(path, "server", "server.pid")) {
+		return true
+	}
+	if info, err := os.Stat(filepath.Join(path, "lock")); err == nil {
+		return time.Since(info.ModTime()) < 15*time.Minute
+	}
+	return false
+}
+
+func bazelServerPIDIsAlive(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return false
+	}
+	err = syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	if err == syscall.EPERM {
+		return true
+	}
+	return false
+}
+
+func outputBasesProtectedByWorkspaces(workspaces []string, home string) map[string]bool {
+	protected := map[string]bool{}
+	for _, workspace := range workspaces {
+		expanded := expandHome(workspace, home)
+		for _, linkName := range []string{"bazel-bin", "bazel-out", "bazel-testlogs", "bazel-" + filepath.Base(expanded)} {
+			target, err := filepath.EvalSymlinks(filepath.Join(expanded, linkName))
+			if err != nil {
+				continue
+			}
+			if outputBase := outputBaseFromSymlinkTarget(target); outputBase != "" {
+				protected[outputBase] = true
+			}
+		}
+	}
+	return protected
+}
+
+func outputBaseFromSymlinkTarget(target string) string {
+	target = filepath.Clean(target)
+	parts := strings.Split(target, string(os.PathSeparator))
+	for i, part := range parts {
+		if part != "execroot" || i == 0 {
+			continue
+		}
+		outputBase := strings.Join(parts[:i], string(os.PathSeparator))
+		if strings.HasPrefix(target, string(os.PathSeparator)) {
+			outputBase = string(os.PathSeparator) + outputBase
+		}
+		return filepath.Clean(outputBase)
+	}
+	return ""
+}
+
+func bazelPlanTargets(candidates []bazelCandidate, cfg config.BazelConfig, level CleanupLevel, now time.Time, globalActive bool) ([]CleanupTarget, int64) {
+	staleAfter := parseNixPolicyDuration(cfg.StaleAfter, 14*24*time.Hour)
+	if level == LevelCritical {
+		staleAfter = parseNixPolicyDuration(cfg.CriticalStaleAfter, 3*24*time.Hour)
+	}
+
+	recentOutputBases := newestBazelOutputBases(candidates, cfg.KeepRecentOutputBases)
+	var totalPhysical int64
+	targets := make([]CleanupTarget, 0, len(candidates))
+	for _, candidate := range candidates {
+		totalPhysical += candidate.Physical
+		target := bazelTargetForCandidate(candidate, staleAfter, now, recentOutputBases[candidate.Path], globalActive, level, cfg)
+		targets = append(targets, target)
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].Bytes == targets[j].Bytes {
+			return targets[i].Path < targets[j].Path
+		}
+		return targets[i].Bytes > targets[j].Bytes
+	})
+	return targets, totalPhysical
+}
+
+func newestBazelOutputBases(candidates []bazelCandidate, keep int) map[string]bool {
+	protected := map[string]bool{}
+	if keep <= 0 {
+		return protected
+	}
+
+	var outputBases []bazelCandidate
+	for _, candidate := range candidates {
+		if candidate.Type == "output_base" {
+			outputBases = append(outputBases, candidate)
+		}
+	}
+
+	sort.Slice(outputBases, func(i, j int) bool {
+		return outputBases[i].ModTime.After(outputBases[j].ModTime)
+	})
+	for idx, candidate := range outputBases {
+		if idx >= keep {
+			break
+		}
+		protected[candidate.Path] = true
+	}
+	return protected
+}
+
+func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration, now time.Time, protectedByRecent bool, globalActive bool, level CleanupLevel, cfg config.BazelConfig) CleanupTarget {
+	active := candidate.Active || globalActive
+	protected := candidate.Protected || protectedByRecent || (active && !cfg.AllowDeleteActiveOutputBases)
+	action := "review"
+	reason := "Bazel cache candidate requires operator review"
+
+	switch {
+	case candidate.Protected:
+		action = "keep"
+		reason = candidate.Reason
+	case protectedByRecent:
+		action = "keep"
+		reason = "within configured newest output-base retention"
+	case active && !cfg.AllowDeleteActiveOutputBases:
+		action = "keep"
+		reason = "active Bazel process or output-base lock detected"
+	case level == LevelWarning:
+		action = "review"
+		reason = "warning level reports Bazel cache footprint only"
+	case candidate.Type != "output_base":
+		action = "review_cache_budget"
+		reason = "cache tier budget enforcement is not enabled yet"
+	case candidate.ModTime.After(now.Add(-staleAfter)):
+		action = "keep"
+		protected = true
+		reason = "newer than configured Bazel stale threshold"
+	default:
+		action = "delete_output_base"
+		reason = "stale inactive output base outside retention policy"
+	}
+
+	return CleanupTarget{
+		Type:      candidate.Type,
+		Name:      candidate.Name,
+		Path:      candidate.Path,
+		Bytes:     candidate.Physical,
+		Active:    active,
+		Protected: protected,
+		Action:    action,
+		Reason:    reason,
+	}
+}
+
+func bazelEstimatedCandidateBytes(targets []CleanupTarget) int64 {
+	var total int64
+	for _, target := range targets {
+		if strings.HasPrefix(target.Action, "delete_") && !target.Protected && !target.Active {
+			total += target.Bytes
+		}
+	}
+	return total
+}
+
+func bazelBusyProcessReasons(output string) []string {
+	seen := map[string]bool{}
+	var reasons []string
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(strings.ToLower(line))
+		if len(fields) < 2 {
+			continue
+		}
+		command := filepath.Base(fields[0])
+		arg0 := filepath.Base(fields[1])
+		if command != "bazel" && command != "bazelisk" && arg0 != "bazel" && arg0 != "bazelisk" {
+			continue
+		}
+		normalized := strings.Join(fields[1:], " ")
+		matches := bazelCommandPattern.FindStringSubmatch(normalized)
+		if len(matches) < 3 {
+			continue
+		}
+		reason := matches[1] + " " + matches[2]
+		if !seen[reason] {
+			seen[reason] = true
+			reasons = append(reasons, reason)
+		}
+	}
+	sort.Strings(reasons)
+	return reasons
+}

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -1,0 +1,147 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Jesssullivan/tinyland-cleanup/config"
+)
+
+func TestDiscoverBazelRootCandidates(t *testing.T) {
+	root := t.TempDir()
+	outputBase := filepath.Join(root, "_bazel_jess", "abc123")
+	makeBazelOutputBase(t, outputBase)
+	mustMkdir(t, filepath.Join(root, "repository_cache"))
+	mustMkdir(t, filepath.Join(root, "disk_cache"))
+
+	candidates := discoverBazelRootCandidates(root)
+	byType := map[string]bool{}
+	for _, candidate := range candidates {
+		byType[candidate.Type] = true
+	}
+
+	for _, candidateType := range []string{"output_base", "repository_cache", "disk_cache"} {
+		if !byType[candidateType] {
+			t.Fatalf("expected %s candidate, got %#v", candidateType, candidates)
+		}
+	}
+}
+
+func TestBazelPlanTargetsProtectsRecentActiveAndWorkspaces(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cfg := config.BazelConfig{
+		KeepRecentOutputBases:        1,
+		StaleAfter:                   "14d",
+		CriticalStaleAfter:           "3d",
+		AllowDeleteActiveOutputBases: false,
+	}
+	candidates := []bazelCandidate{
+		{
+			Type:     "output_base",
+			Name:     "old",
+			Path:     "/tmp/old",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 10,
+		},
+		{
+			Type:     "output_base",
+			Name:     "new",
+			Path:     "/tmp/new",
+			ModTime:  now.Add(-1 * 24 * time.Hour),
+			Physical: 20,
+		},
+		{
+			Type:     "output_base",
+			Name:     "active",
+			Path:     "/tmp/active",
+			ModTime:  now.Add(-40 * 24 * time.Hour),
+			Physical: 30,
+			Active:   true,
+		},
+		{
+			Type:      "output_base",
+			Name:      "protected",
+			Path:      "/tmp/protected",
+			ModTime:   now.Add(-50 * 24 * time.Hour),
+			Physical:  40,
+			Protected: true,
+			Reason:    "reachable from configured protected workspace",
+		},
+	}
+
+	targets, total := bazelPlanTargets(candidates, cfg, LevelModerate, now, false)
+	if total != 100 {
+		t.Fatalf("total physical = %d, want 100", total)
+	}
+
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Name] = target
+	}
+
+	if actions["old"].Action != "delete_output_base" {
+		t.Fatalf("old action = %q, want delete_output_base", actions["old"].Action)
+	}
+	for _, name := range []string{"new", "active", "protected"} {
+		if actions[name].Action != "keep" || !actions[name].Protected {
+			t.Fatalf("%s target not protected as expected: %#v", name, actions[name])
+		}
+	}
+}
+
+func TestOutputBasesProtectedByWorkspaces(t *testing.T) {
+	root := t.TempDir()
+	outputBase := filepath.Join(root, "_bazel_jess", "abc123")
+	execrootBin := filepath.Join(outputBase, "execroot", "_main", "bazel-out", "darwin-fastbuild", "bin")
+	mustMkdir(t, execrootBin)
+
+	workspace := filepath.Join(root, "workspace")
+	mustMkdir(t, workspace)
+	if err := os.Symlink(execrootBin, filepath.Join(workspace, "bazel-bin")); err != nil {
+		t.Fatal(err)
+	}
+
+	protected := outputBasesProtectedByWorkspaces([]string{workspace}, root)
+	resolvedOutputBase, err := filepath.EvalSymlinks(outputBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !protected[resolvedOutputBase] {
+		t.Fatalf("expected %s to be protected, got %#v", resolvedOutputBase, protected)
+	}
+}
+
+func TestBazelBusyProcessReasons(t *testing.T) {
+	ps := `
+/nix/store/abc/bin/bazel bazel build //...
+/Users/test/bin/bazelisk bazelisk test //...
+/usr/bin/zsh zsh -lc echo bazel query docs
+`
+	reasons := bazelBusyProcessReasons(ps)
+	want := []string{"bazel build", "bazelisk test"}
+
+	if len(reasons) != len(want) {
+		t.Fatalf("got %v, want %v", reasons, want)
+	}
+	for i := range want {
+		if reasons[i] != want[i] {
+			t.Fatalf("got %v, want %v", reasons, want)
+		}
+	}
+}
+
+func makeBazelOutputBase(t *testing.T, path string) {
+	t.Helper()
+	for _, name := range []string{"execroot", "action_cache", "server"} {
+		mustMkdir(t, filepath.Join(path, name))
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a Bazel plugin with dry-run planning for output bases, repository caches, disk caches, and Bazelisk downloads
- add Bazel config defaults for roots, budgets, stale thresholds, protected workspaces, and active-output-base safety gates
- classify output-base targets with active-use evidence, protected workspace symlink detection, recent retention, and cleanup candidate reasons
- keep real Bazel cleanup planning-only until deletion and permission-normalization gates are proven

## Validation

- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
- env HOME=/tmp/tinyland-cleanup-home GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go run . --once --dry-run --level critical --output json