### PR TITLE
Add dry-run plan summary totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
   retention targets, daemon-contention detection, and opt-in store optimization.
 - Bazel cache and output-base dry-run planning with active-use detection,
   protected workspace symlink detection, and budget metadata.
+- Top-level dry-run summary fields for planned estimated reclaim, required free
+  space, and cleanup target count.
 
 ### Changed
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -15,6 +15,8 @@ The JSON report includes:
 - the selected cleanup level;
 - monitored mount status;
 - host free-space before and after the cycle;
+- top-level dry-run totals for planned estimated reclaim, required free space,
+  and cleanup target count;
 - enabled plugins that would run;
 - plugin descriptions and dry-run skip reasons.
 
@@ -39,6 +41,11 @@ The report distinguishes:
   available;
 - `host_bytes_freed`: plugin-isolated host free-space measurement, when
   available;
+- `planned_estimated_bytes_freed`: aggregate dry-run reclaim estimate from
+  plugin plans;
+- `planned_required_free_bytes`: largest free-space preflight requirement
+  across plugin plans;
+- `planned_targets`: total number of dry-run targets across plugin plans;
 - `host_free_delta_bytes`: cycle-level host free-space delta for the monitored
   path.
 

--- a/main.go
+++ b/main.go
@@ -259,6 +259,11 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 			if planner, ok := p.(plugins.Planner); ok {
 				plan := planner.PlanCleanup(ctx, pluginLevel, d.config, d.logger)
 				pluginReport.Plan = &plan
+				report.PlannedEstimatedBytesFreed += plan.EstimatedBytesFreed
+				report.PlannedTargets += len(plan.Targets)
+				if plan.RequiredFreeBytes > report.PlannedRequiredFreeBytes {
+					report.PlannedRequiredFreeBytes = plan.RequiredFreeBytes
+				}
 			}
 			pluginReport.SkipReason = "dry_run"
 			d.logger.Info("dry-run plugin plan",
@@ -328,19 +333,25 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 }
 
 type cycleReport struct {
-	Timestamp           string              `json:"timestamp"`
-	DryRun              bool                `json:"dry_run"`
-	ForcedLevel         bool                `json:"forced_level"`
-	Level               string              `json:"level"`
-	MonitorPath         string              `json:"monitor_path"`
-	HostFreeBeforeBytes uint64              `json:"host_free_before_bytes"`
-	HostFreeAfterBytes  uint64              `json:"host_free_after_bytes"`
-	HostFreeDeltaBytes  int64               `json:"host_free_delta_bytes"`
-	HostFreeError       string              `json:"host_free_error,omitempty"`
-	TotalBytesFreed     int64               `json:"total_bytes_freed"`
-	TotalItemsCleaned   int                 `json:"total_items_cleaned"`
-	Mounts              []mountReport       `json:"mounts"`
-	Plugins             []pluginCycleReport `json:"plugins"`
+	Timestamp           string `json:"timestamp"`
+	DryRun              bool   `json:"dry_run"`
+	ForcedLevel         bool   `json:"forced_level"`
+	Level               string `json:"level"`
+	MonitorPath         string `json:"monitor_path"`
+	HostFreeBeforeBytes uint64 `json:"host_free_before_bytes"`
+	HostFreeAfterBytes  uint64 `json:"host_free_after_bytes"`
+	HostFreeDeltaBytes  int64  `json:"host_free_delta_bytes"`
+	HostFreeError       string `json:"host_free_error,omitempty"`
+	// PlannedEstimatedBytesFreed aggregates dry-run plugin plan estimates.
+	PlannedEstimatedBytesFreed int64 `json:"planned_estimated_bytes_freed,omitempty"`
+	// PlannedRequiredFreeBytes is the largest free-space preflight requirement across plugin plans.
+	PlannedRequiredFreeBytes int64 `json:"planned_required_free_bytes,omitempty"`
+	// PlannedTargets is the total number of dry-run cleanup targets.
+	PlannedTargets    int                 `json:"planned_targets,omitempty"`
+	TotalBytesFreed   int64               `json:"total_bytes_freed"`
+	TotalItemsCleaned int                 `json:"total_items_cleaned"`
+	Mounts            []mountReport       `json:"mounts"`
+	Plugins           []pluginCycleReport `json:"plugins"`
 }
 
 type mountReport struct {

--- a/main_test.go
+++ b/main_test.go
@@ -58,13 +58,18 @@ func TestRunOnceDryRunJSONReportIncludesPluginPlan(t *testing.T) {
 	mock := &planningPlugin{
 		reportingPlugin: reportingPlugin{},
 		plan: plugins.CleanupPlan{
-			Plugin:            "reporting",
-			Level:             "critical",
-			Summary:           "reporting dry-run plan",
-			WouldRun:          false,
-			SkipReason:        "preflight_failed",
-			RequiredFreeBytes: 42,
-			Steps:             []string{"inspect", "verify"},
+			Plugin:              "reporting",
+			Level:               "critical",
+			Summary:             "reporting dry-run plan",
+			WouldRun:            false,
+			SkipReason:          "preflight_failed",
+			EstimatedBytesFreed: 100,
+			RequiredFreeBytes:   42,
+			Steps:               []string{"inspect", "verify"},
+			Targets: []plugins.CleanupTarget{
+				{Type: "cache", Name: "one", Action: "review"},
+				{Type: "cache", Name: "two", Action: "review"},
+			},
 			Metadata: map[string]string{
 				"provider": "test",
 			},
@@ -89,6 +94,15 @@ func TestRunOnceDryRunJSONReportIncludesPluginPlan(t *testing.T) {
 	}
 	if report.Plugins[0].SkipReason != "dry_run" {
 		t.Fatalf("expected dry_run plugin skip reason, got %q", report.Plugins[0].SkipReason)
+	}
+	if report.PlannedEstimatedBytesFreed != 100 {
+		t.Fatalf("expected planned estimated bytes 100, got %d", report.PlannedEstimatedBytesFreed)
+	}
+	if report.PlannedRequiredFreeBytes != 42 {
+		t.Fatalf("expected planned required bytes 42, got %d", report.PlannedRequiredFreeBytes)
+	}
+	if report.PlannedTargets != 2 {
+		t.Fatalf("expected 2 planned targets, got %d", report.PlannedTargets)
 	}
 }
 


### PR DESCRIPTION
## Summary
- aggregate dry-run plan reclaim estimate, required free-space preflight, and target count at the top-level JSON report
- cover the aggregation in the existing dry-run report test
- document the operator-facing fields and changelog entry

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...