### PR TITLE
Stop cleanup after target free space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,14 @@ All notable changes to this project will be documented in this file.
   protected workspace symlink detection, and budget metadata.
 - Top-level dry-run summary fields for planned estimated reclaim, required free
   space, and cleanup target count.
+- Target-free report fields and real-cleanup stop behavior once the configured
+  target is reached.
 
 ### Changed
 
 - Go module path moved to `github.com/Jesssullivan/tinyland-cleanup`.
+- Clarified that the legacy `target_free` config key represents the target
+  maximum used-space percentage after cleanup.
 
 ## [0.2.0]
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ builder and runner machines.
 - Dry-run behavior must stay useful enough for operator review.
 - Cleanup policy should explain what it plans to remove and why.
 - Host free-space accounting should be measured before and after cleanup.
+- Real cleanup should stop once the configured host free-space target is met.
 - Privileged actions, offline compaction, and service disruption must remain
   explicit policy choices.
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	// Thresholds for disk usage (percentage)
 	Thresholds Thresholds `yaml:"thresholds"`
 
-	// TargetFree percentage of disk space to achieve after cleanup
+	// TargetFree is the legacy config key for target maximum used percentage after cleanup.
 	TargetFree int `yaml:"target_free"`
 
 	// LogFile path for cleanup logs

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -12,7 +12,8 @@ thresholds:
   aggressive: 90   # Level 3: Prune volumes
   critical: 95     # Level 4: Emergency cleanup
 
-# Target free space percentage after cleanup
+# Target maximum used-space percentage after cleanup.
+# Historical key name is target_free.
 target_free: 70
 
 # Enable/disable specific cleanup plugins

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -15,6 +15,8 @@ The JSON report includes:
 - the selected cleanup level;
 - monitored mount status;
 - host free-space before and after the cycle;
+- the configured target maximum used percentage and equivalent free-space
+  deficit;
 - top-level dry-run totals for planned estimated reclaim, required free space,
   and cleanup target count;
 - enabled plugins that would run;
@@ -41,6 +43,13 @@ The report distinguishes:
   available;
 - `host_bytes_freed`: plugin-isolated host free-space measurement, when
   available;
+- `target_used_percent`: the legacy `target_free` config value, interpreted as
+  the desired maximum used percentage after cleanup;
+- `target_free_bytes`: the host free-space equivalent of that target;
+- `target_free_deficit_bytes`: remaining bytes needed to satisfy the target;
+- `target_free_met`: whether the current host free space satisfies the target;
+- `stop_reason`: why remaining plugins were skipped, currently
+  `target_free_met` when a real cleanup cycle reaches the target;
 - `planned_estimated_bytes_freed`: aggregate dry-run reclaim estimate from
   plugin plans;
 - `planned_required_free_bytes`: largest free-space preflight requirement
@@ -66,6 +75,7 @@ operator review before budget enforcement is enabled.
 ## Current Boundary
 
 This is the first stable reporting surface. It now exposes typed targets for
-selected plugins, but not per-file cleanup candidates for every plugin. Treat
-broader candidate planning, active-use evidence, cooldown state, and
-target-free stop behavior as the next policy layer.
+selected plugins, but not per-file cleanup candidates for every plugin. Real
+cleanup cycles stop remaining plugins after the host reaches the configured
+target. Treat broader candidate planning, active-use evidence, cooldown state,
+and CLI target-free overrides as the next policy layer.

--- a/main.go
+++ b/main.go
@@ -121,13 +121,14 @@ func main() {
 
 	// Create cleanup daemon
 	d := &daemon{
-		config:   cfg,
-		registry: registry,
-		monitor:  diskMon,
-		logger:   logger,
-		dryRun:   *dryRun,
-		output:   *output,
-		report:   os.Stdout,
+		config:    cfg,
+		registry:  registry,
+		monitor:   diskMon,
+		logger:    logger,
+		dryRun:    *dryRun,
+		output:    *output,
+		report:    os.Stdout,
+		diskStats: monitor.GetDiskStats,
 	}
 
 	// Determine operation mode
@@ -178,13 +179,14 @@ func main() {
 }
 
 type daemon struct {
-	config   *config.Config
-	registry *plugins.Registry
-	monitor  *monitor.DiskMonitor
-	logger   *slog.Logger
-	dryRun   bool
-	output   string
-	report   io.Writer
+	config    *config.Config
+	registry  *plugins.Registry
+	monitor   *monitor.DiskMonitor
+	logger    *slog.Logger
+	dryRun    bool
+	output    string
+	report    io.Writer
+	diskStats func(path string) (*monitor.DiskStats, error)
 }
 
 func (d *daemon) run(ctx context.Context) error {
@@ -225,12 +227,13 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 		Mounts:      assessment.Mounts,
 	}
 
-	beforeStats, beforeErr := monitor.GetDiskStats(report.MonitorPath)
+	beforeStats, beforeErr := d.getDiskStats(report.MonitorPath)
 	if beforeErr != nil {
 		report.HostFreeError = beforeErr.Error()
 		d.logger.Warn("failed to measure host free space before cleanup", "path", report.MonitorPath, "error", beforeErr)
 	} else {
 		report.HostFreeBeforeBytes = beforeStats.Free
+		d.updateTargetFreeStatus(&report, beforeStats)
 	}
 
 	if level == monitor.LevelNone {
@@ -253,6 +256,16 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 			Level:       level.String(),
 			DryRun:      d.dryRun,
 			WouldRun:    true,
+		}
+
+		if !d.dryRun && report.TargetFreeMet {
+			pluginReport.WouldRun = false
+			pluginReport.SkipReason = "target_free_met"
+			if report.StopReason == "" {
+				report.StopReason = "target_free_met"
+			}
+			report.Plugins = append(report.Plugins, pluginReport)
+			continue
 		}
 
 		if d.dryRun {
@@ -298,21 +311,14 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 			totalFreed += result.BytesFreed
 			totalItems += result.ItemsCleaned
 		}
+
+		d.updateHostFreeAfter(&report, beforeStats, beforeErr)
 	}
 
 	report.TotalBytesFreed = totalFreed
 	report.TotalItemsCleaned = totalItems
 
-	afterStats, afterErr := monitor.GetDiskStats(report.MonitorPath)
-	if afterErr != nil {
-		report.HostFreeError = afterErr.Error()
-		d.logger.Warn("failed to measure host free space after cleanup", "path", report.MonitorPath, "error", afterErr)
-	} else {
-		report.HostFreeAfterBytes = afterStats.Free
-		if beforeErr == nil {
-			report.HostFreeDeltaBytes = int64(afterStats.Free) - int64(beforeStats.Free)
-		}
-	}
+	d.updateHostFreeAfter(&report, beforeStats, beforeErr)
 
 	d.logger.Info("cleanup cycle host free-space",
 		"path", report.MonitorPath,
@@ -342,6 +348,16 @@ type cycleReport struct {
 	HostFreeAfterBytes  uint64 `json:"host_free_after_bytes"`
 	HostFreeDeltaBytes  int64  `json:"host_free_delta_bytes"`
 	HostFreeError       string `json:"host_free_error,omitempty"`
+	// TargetUsedPercent is the legacy target_free config value as a maximum used percentage.
+	TargetUsedPercent int `json:"target_used_percent"`
+	// TargetFreeBytes is the free-space equivalent required to satisfy TargetUsedPercent.
+	TargetFreeBytes uint64 `json:"target_free_bytes"`
+	// TargetFreeDeficitBytes is the remaining free-space gap to the target.
+	TargetFreeDeficitBytes int64 `json:"target_free_deficit_bytes"`
+	// TargetFreeMet reports whether the host already satisfies the target.
+	TargetFreeMet bool `json:"target_free_met"`
+	// StopReason explains why remaining cleanup plugins were skipped.
+	StopReason string `json:"stop_reason,omitempty"`
 	// PlannedEstimatedBytesFreed aggregates dry-run plugin plan estimates.
 	PlannedEstimatedBytesFreed int64 `json:"planned_estimated_bytes_freed,omitempty"`
 	// PlannedRequiredFreeBytes is the largest free-space preflight requirement across plugin plans.
@@ -394,7 +410,7 @@ func (d *daemon) assessMounts() mountAssessment {
 	if len(d.config.MonitoredMounts) > 0 {
 		// Multi-mount monitoring: check each configured mount point
 		for _, mount := range d.config.MonitoredMounts {
-			stats, err := monitor.GetDiskStats(mount.Path)
+			stats, err := d.getDiskStats(mount.Path)
 			label := mount.Label
 			if label == "" {
 				label = mount.Path
@@ -457,7 +473,7 @@ func (d *daemon) assessMounts() mountAssessment {
 			monitorPath = home
 		}
 
-		stats, detectedLevel, err := d.monitor.Check(monitorPath)
+		stats, err := d.getDiskStats(monitorPath)
 		if err != nil {
 			d.logger.Error("failed to check disk", "error", err)
 			assessment.Mounts = append(assessment.Mounts, mountReport{
@@ -468,6 +484,7 @@ func (d *daemon) assessMounts() mountAssessment {
 			})
 			return assessment
 		}
+		detectedLevel := d.monitor.CheckLevel(stats)
 
 		assessment.Mounts = append(assessment.Mounts, mountReport{
 			Label:       monitorPath,
@@ -518,6 +535,55 @@ func (d *daemon) writeReport(report cycleReport) error {
 	encoder := json.NewEncoder(d.report)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(report)
+}
+
+func (d *daemon) getDiskStats(path string) (*monitor.DiskStats, error) {
+	if d.diskStats != nil {
+		return d.diskStats(path)
+	}
+	return monitor.GetDiskStats(path)
+}
+
+func (d *daemon) updateHostFreeAfter(report *cycleReport, beforeStats *monitor.DiskStats, beforeErr error) {
+	afterStats, afterErr := d.getDiskStats(report.MonitorPath)
+	if afterErr != nil {
+		report.HostFreeError = afterErr.Error()
+		d.logger.Warn("failed to measure host free space after cleanup", "path", report.MonitorPath, "error", afterErr)
+		return
+	}
+
+	report.HostFreeAfterBytes = afterStats.Free
+	if beforeErr == nil && beforeStats != nil {
+		report.HostFreeDeltaBytes = int64(afterStats.Free) - int64(beforeStats.Free)
+	}
+	d.updateTargetFreeStatus(report, afterStats)
+}
+
+func (d *daemon) updateTargetFreeStatus(report *cycleReport, stats *monitor.DiskStats) {
+	targetFreeBytes, ok := targetFreeBytes(stats.Total, d.config.TargetFree)
+	if !ok {
+		return
+	}
+
+	report.TargetUsedPercent = d.config.TargetFree
+	report.TargetFreeBytes = targetFreeBytes
+	if stats.Free >= targetFreeBytes {
+		report.TargetFreeDeficitBytes = 0
+		report.TargetFreeMet = true
+		return
+	}
+
+	report.TargetFreeDeficitBytes = int64(targetFreeBytes - stats.Free)
+	report.TargetFreeMet = false
+}
+
+func targetFreeBytes(totalBytes uint64, targetUsedPercent int) (uint64, bool) {
+	if totalBytes == 0 || targetUsedPercent <= 0 || targetUsedPercent >= 100 {
+		return 0, false
+	}
+
+	freePercent := 100 - targetUsedPercent
+	return totalBytes * uint64(freePercent) / 100, true
 }
 
 func bytesToGB(bytes uint64) string {

--- a/main_test.go
+++ b/main_test.go
@@ -120,6 +120,12 @@ func TestRunOnceCleanupJSONReport(t *testing.T) {
 		},
 	}
 	daemon := newTestDaemon(t, mock, &output)
+	daemon.diskStats = sequenceDiskStats(t,
+		diskStats(1000, 20, 98),
+		diskStats(1000, 20, 98),
+		diskStats(1000, 20, 98),
+		diskStats(1000, 20, 98),
+	)
 
 	if err := daemon.runOnce(context.Background(), monitor.LevelCritical); err != nil {
 		t.Fatalf("runOnce failed: %v", err)
@@ -155,20 +161,116 @@ func TestRunOnceCleanupJSONReport(t *testing.T) {
 	}
 }
 
+func TestRunOnceStopsAfterTargetFreeMet(t *testing.T) {
+	var output bytes.Buffer
+	first := &reportingPlugin{
+		name: "first",
+		result: plugins.CleanupResult{
+			Plugin:     "first",
+			Level:      plugins.LevelCritical,
+			BytesFreed: 1,
+		},
+	}
+	second := &reportingPlugin{name: "second"}
+	daemon := newTestDaemonWithPlugins(t, &output, first, second)
+	daemon.config.TargetFree = 70
+	daemon.diskStats = sequenceDiskStats(t,
+		diskStats(1000, 20, 98),
+		diskStats(1000, 20, 98),
+		diskStats(1000, 400, 60),
+		diskStats(1000, 400, 60),
+	)
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelNone); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	if !first.called {
+		t.Fatal("expected first plugin cleanup to run")
+	}
+	if second.called {
+		t.Fatal("second plugin should stop after target free is met")
+	}
+
+	report := decodeCycleReport(t, output.Bytes())
+	if !report.TargetFreeMet {
+		t.Fatal("expected target free to be met")
+	}
+	if report.TargetUsedPercent != 70 {
+		t.Fatalf("expected target used percent 70, got %d", report.TargetUsedPercent)
+	}
+	if report.TargetFreeBytes != 300 {
+		t.Fatalf("expected target free bytes 300, got %d", report.TargetFreeBytes)
+	}
+	if report.TargetFreeDeficitBytes != 0 {
+		t.Fatalf("expected no target free deficit, got %d", report.TargetFreeDeficitBytes)
+	}
+	if report.StopReason != "target_free_met" {
+		t.Fatalf("expected target_free_met stop reason, got %q", report.StopReason)
+	}
+	if len(report.Plugins) != 2 {
+		t.Fatalf("expected 2 plugin reports, got %d", len(report.Plugins))
+	}
+	if report.Plugins[1].WouldRun {
+		t.Fatal("expected second plugin to be marked would_run=false")
+	}
+	if report.Plugins[1].SkipReason != "target_free_met" {
+		t.Fatalf("expected target_free_met skip reason, got %q", report.Plugins[1].SkipReason)
+	}
+}
+
 func newTestDaemon(t *testing.T, plugin plugins.Plugin, output io.Writer) *daemon {
+	t.Helper()
+
+	return newTestDaemonWithPlugins(t, output, plugin)
+}
+
+func newTestDaemonWithPlugins(t *testing.T, output io.Writer, registeredPlugins ...plugins.Plugin) *daemon {
 	t.Helper()
 
 	cfg := config.DefaultConfig()
 	registry := plugins.NewRegistry()
-	registry.Register(plugin)
+	for _, plugin := range registeredPlugins {
+		registry.Register(plugin)
+	}
 
 	return &daemon{
-		config:   cfg,
-		registry: registry,
-		monitor:  monitor.NewDiskMonitor(80, 85, 90, 95),
-		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-		output:   "json",
-		report:   output,
+		config:    cfg,
+		registry:  registry,
+		monitor:   monitor.NewDiskMonitor(80, 85, 90, 95),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		output:    "json",
+		report:    output,
+		diskStats: monitor.GetDiskStats,
+	}
+}
+
+func diskStats(total, free uint64, usedPercent float64) *monitor.DiskStats {
+	return &monitor.DiskStats{
+		Total:       total,
+		Used:        total - free,
+		Free:        free,
+		UsedPercent: usedPercent,
+		FreePercent: 100 - usedPercent,
+		FreeGB:      float64(free) / (1024 * 1024 * 1024),
+	}
+}
+
+func sequenceDiskStats(t *testing.T, stats ...*monitor.DiskStats) func(string) (*monitor.DiskStats, error) {
+	t.Helper()
+
+	index := 0
+	return func(path string) (*monitor.DiskStats, error) {
+		if len(stats) == 0 {
+			t.Fatal("sequenceDiskStats requires at least one stats sample")
+		}
+		if index >= len(stats) {
+			index = len(stats) - 1
+		}
+		next := *stats[index]
+		index++
+		next.Path = path
+		return &next, nil
 	}
 }
 
@@ -184,10 +286,14 @@ func decodeCycleReport(t *testing.T, data []byte) cycleReport {
 
 type reportingPlugin struct {
 	called bool
+	name   string
 	result plugins.CleanupResult
 }
 
 func (p *reportingPlugin) Name() string {
+	if p.name != "" {
+		return p.name
+	}
 	return "reporting"
 }
 


### PR DESCRIPTION
## Summary
- report target-free progress in JSON using the existing legacy target_free config value as target maximum used percentage
- stop remaining real-cleanup plugins once the host reaches the configured target
- add deterministic runOnce coverage for target-free stop behavior
- document target-free report fields and clarify target_free semantics

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- env HOME=/tmp/tinyland-cleanup-home GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go run . --once --dry-run --level critical --output json
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...