### PR TITLE
Delete stale Bazel output bases safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
   space, and cleanup target count.
 - Target-free report fields and real-cleanup stop behavior once the configured
   target is reached.
+- Bazel real-cleanup deletion for stale inactive output bases, guarded by
+  active-process inspection and permission normalization.
 
 ### Changed
 

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -1,9 +1,8 @@
 # Bazel Cache Policy
 
-Bazel cleanup is currently a dry-run planning surface. It reports output bases,
-repository caches, disk caches, and Bazelisk downloads without deleting them.
-Deletion and permission normalization should be enabled only after the dry-run
-evidence is proven on real developer and runner hosts.
+Bazel cleanup reports output bases, repository caches, disk caches, and
+Bazelisk downloads. Real cleanup mode deletes only stale inactive output bases
+after active-process inspection succeeds.
 
 Review with:
 
@@ -50,12 +49,17 @@ Runtime boundary:
 
 - warning reports footprint only;
 - moderate, aggressive, and critical classify stale inactive output bases as
-  `delete_output_base` candidates in dry-run output;
+  `delete_output_base` candidates in dry-run output and delete those output
+  bases in real cleanup mode;
+- real cleanup skips Bazel mutation if active Bazel process inspection fails;
+- deletion normalizes writable permissions first, and on Darwin attempts to
+  clear `uchg` file flags with `chflags -R nouchg`;
 - byte counts use top-level allocation estimates so dry-run remains responsive
   on very large generated trees;
 - repository cache, disk cache, and Bazelisk entries are reported for budget
   review but not deleted yet;
-- real cleanup mode logs that Bazel cleanup is planning-only.
+- repo-local `bazel-*` symlink cleanup remains a follow-up after output-base
+  deletion evidence is proven on real hosts.
 
 Do not disable active-output-base protection on developer machines or shared
 runners unless an operator has already drained the relevant jobs and accepted

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -49,7 +50,7 @@ func (p *BazelPlugin) Name() string {
 
 // Description returns the plugin description.
 func (p *BazelPlugin) Description() string {
-	return "Plans Bazel output base, repository cache, disk cache, and Bazelisk cleanup"
+	return "Cleans stale Bazel output bases and reports repository, disk, and Bazelisk cache policy"
 }
 
 // SupportedPlatforms returns supported platforms (all).
@@ -64,8 +65,11 @@ func (p *BazelPlugin) Enabled(cfg *config.Config) bool {
 
 // PlanCleanup returns a dry-run plan without mutating Bazel state.
 func (p *BazelPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupPlan {
-	_ = logger
+	plan, _ := p.buildCleanupPlan(ctx, level, cfg, logger)
+	return plan
+}
 
+func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) (CleanupPlan, error) {
 	plan := CleanupPlan{
 		Plugin:   p.Name(),
 		Level:    level.String(),
@@ -75,7 +79,7 @@ func (p *BazelPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *
 			"Discover Bazel output bases, repository caches, disk caches, and Bazelisk downloads",
 			"Measure logical and physical bytes without following repo-local bazel-* symlinks",
 			"Protect active output bases, protected workspace output bases, and newest output bases",
-			"Report cleanup candidates with reasons before enabling deletion",
+			"Delete only stale inactive output bases in real cleanup mode at moderate or higher levels",
 		},
 		Metadata: map[string]string{
 			"cleanup_level":                    level.String(),
@@ -106,18 +110,31 @@ func (p *BazelPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *
 	if cfg.Bazel.MaxTotalGB > 0 && totalPhysical > int64(cfg.Bazel.MaxTotalGB)*bazelGiB {
 		plan.Warnings = append(plan.Warnings, "detected Bazel cache footprint exceeds configured review budget")
 	}
-	plan.Warnings = append(plan.Warnings, "Bazel cleanup is planning-only in this slice; deletion and permission normalization remain follow-up work")
+	plan.Warnings = append(plan.Warnings, "Bazel cleanup deletes only stale inactive output bases; repository, disk, and Bazelisk cache budget enforcement remains follow-up work")
 	plan.Warnings = append(plan.Warnings, "Bazel byte counts use bounded top-level allocation estimates so dry-run stays responsive on very large output bases")
 
-	return plan
+	return plan, activeErr
 }
 
-// Cleanup is intentionally planning-only until Bazel deletion policy is proven.
+// Cleanup deletes stale inactive Bazel output bases after active-use inspection.
 func (p *BazelPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupResult {
-	_ = ctx
-	_ = cfg
-	logger.Info("Bazel cleanup is planning-only; use --dry-run --output json to review candidates", "level", level.String())
-	return CleanupResult{Plugin: p.Name(), Level: level}
+	result := CleanupResult{Plugin: p.Name(), Level: level}
+	if level == LevelWarning {
+		logger.Info("Bazel cleanup is report-only at warning level", "level", level.String())
+		return result
+	}
+
+	plan, activeErr := p.buildCleanupPlan(ctx, level, cfg, logger)
+	if activeErr != nil {
+		logger.Warn("skipping Bazel cleanup because active process inspection failed", "error", activeErr)
+		return result
+	}
+
+	result = applyBazelCleanupTargets(ctx, p.Name(), level, plan.Targets, logger)
+	if result.ItemsCleaned == 0 {
+		logger.Info("Bazel cleanup found no eligible stale inactive output bases", "level", level.String())
+	}
+	return result
 }
 
 func (p *BazelPlugin) activeBazelProcesses(ctx context.Context) ([]string, error) {
@@ -476,6 +493,75 @@ func bazelEstimatedCandidateBytes(targets []CleanupTarget) int64 {
 		}
 	}
 	return total
+}
+
+func applyBazelCleanupTargets(ctx context.Context, plugin string, level CleanupLevel, targets []CleanupTarget, logger *slog.Logger) CleanupResult {
+	result := CleanupResult{Plugin: plugin, Level: level}
+	for _, target := range targets {
+		if !bazelTargetEligibleForDeletion(target) {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			result.Error = err
+			return result
+		}
+		if err := deleteBazelOutputBase(target.Path, logger); err != nil {
+			logger.Warn("failed to delete Bazel output base", "path", target.Path, "error", err)
+			continue
+		}
+		result.BytesFreed += target.Bytes
+		result.EstimatedBytesFreed += target.Bytes
+		result.ItemsCleaned++
+		logger.Info("deleted stale Bazel output base", "path", target.Path, "estimated_bytes", target.Bytes)
+	}
+	return result
+}
+
+func bazelTargetEligibleForDeletion(target CleanupTarget) bool {
+	return target.Type == "output_base" &&
+		target.Action == "delete_output_base" &&
+		target.Path != "" &&
+		!target.Active &&
+		!target.Protected
+}
+
+func deleteBazelOutputBase(path string, logger *slog.Logger) error {
+	if !isBazelOutputBase(path) {
+		return fmt.Errorf("refusing to delete non-Bazel output base: %s", path)
+	}
+	if err := normalizeBazelDeletionPermissions(path, logger); err != nil {
+		return err
+	}
+	return os.RemoveAll(path)
+}
+
+func normalizeBazelDeletionPermissions(root string, logger *slog.Logger) error {
+	if runtime.GOOS == "darwin" {
+		if _, err := exec.LookPath("chflags"); err == nil {
+			cmd := exec.Command("chflags", "-R", "nouchg", root)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				logger.Warn("failed to clear Darwin file flags before Bazel deletion", "path", root, "error", err, "output", strings.TrimSpace(string(output)))
+			}
+		}
+	}
+
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		mode := info.Mode()
+		if entry.IsDir() {
+			return os.Chmod(path, mode|0700)
+		}
+		return os.Chmod(path, mode|0600)
+	})
 }
 
 func bazelBusyProcessReasons(output string) []string {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -1,6 +1,9 @@
 package plugins
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -128,6 +131,83 @@ func TestBazelBusyProcessReasons(t *testing.T) {
 	for i := range want {
 		if reasons[i] != want[i] {
 			t.Fatalf("got %v, want %v", reasons, want)
+		}
+	}
+}
+
+func TestApplyBazelCleanupTargetsDeletesEligibleOutputBase(t *testing.T) {
+	root := t.TempDir()
+	outputBase := filepath.Join(root, "_bazel_jess", "stale")
+	makeBazelOutputBase(t, outputBase)
+	generated := filepath.Join(outputBase, "execroot", "_main", "bazel-out", "bin", "artifact")
+	if err := os.MkdirAll(filepath.Dir(generated), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(generated, []byte("artifact"), 0400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Dir(generated), 0500); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := applyBazelCleanupTargets(context.Background(), "bazel", LevelModerate, []CleanupTarget{
+		{
+			Type:   "output_base",
+			Name:   "stale",
+			Path:   outputBase,
+			Bytes:  123,
+			Action: "delete_output_base",
+		},
+	}, logger)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.ItemsCleaned != 1 {
+		t.Fatalf("items cleaned = %d, want 1", result.ItemsCleaned)
+	}
+	if result.EstimatedBytesFreed != 123 || result.BytesFreed != 123 {
+		t.Fatalf("unexpected bytes: estimated=%d legacy=%d", result.EstimatedBytesFreed, result.BytesFreed)
+	}
+	if _, err := os.Stat(outputBase); !os.IsNotExist(err) {
+		t.Fatalf("expected output base to be deleted, stat err=%v", err)
+	}
+}
+
+func TestApplyBazelCleanupTargetsSkipsProtectedAndActiveTargets(t *testing.T) {
+	root := t.TempDir()
+	active := filepath.Join(root, "_bazel_jess", "active")
+	protected := filepath.Join(root, "_bazel_jess", "protected")
+	makeBazelOutputBase(t, active)
+	makeBazelOutputBase(t, protected)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := applyBazelCleanupTargets(context.Background(), "bazel", LevelModerate, []CleanupTarget{
+		{
+			Type:   "output_base",
+			Name:   "active",
+			Path:   active,
+			Bytes:  10,
+			Active: true,
+			Action: "delete_output_base",
+		},
+		{
+			Type:      "output_base",
+			Name:      "protected",
+			Path:      protected,
+			Bytes:     20,
+			Protected: true,
+			Action:    "delete_output_base",
+		},
+	}, logger)
+
+	if result.ItemsCleaned != 0 {
+		t.Fatalf("items cleaned = %d, want 0", result.ItemsCleaned)
+	}
+	for _, path := range []string{active, protected} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected %s to remain, err=%v", path, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- enable real cleanup deletion for stale inactive Bazel output bases at moderate+ levels
- skip all Bazel mutation when active process inspection fails
- normalize writable permissions before deletion and clear Darwin file flags when chflags is available
- keep repository cache, disk cache, Bazelisk budget enforcement, and repo-local bazel-* symlink cleanup as follow-up work
- document the narrower runtime boundary

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- env HOME=/tmp/tinyland-cleanup-home GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go run . --once --dry-run --level critical --output json
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...