### PR TITLE
Add RPM packaging surface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Install Nix
+        if: matrix.goos == 'linux'
+        uses: DeterminateSystems/nix-installer-action@v22
       - name: Build
         run: |
           mkdir -p dist
@@ -45,11 +48,30 @@ jobs:
           GOFLAGS: -mod=vendor
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+      - name: RPM
+        if: matrix.goos == 'linux'
+        run: |
+          artifact="tinyland-cleanup-${GITHUB_REF_NAME}-${GOOS}-${GOARCH}"
+          version="${GITHUB_REF_NAME#v}"
+          case "${version}" in
+            [0-9]*) ;;
+            *) version="0.0.0" ;;
+          esac
+          NFPM_BINARY="dist/${artifact}/tinyland-cleanup" \
+            NFPM_VERSION="${version}" \
+            NFPM_RELEASE="${GITHUB_RUN_NUMBER}" \
+            NFPM_ARCH="${GOARCH}" \
+            nix shell nixpkgs#nfpm --command nfpm package --packager rpm --config packaging/nfpm.yaml --target dist/
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: tinyland-cleanup-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/*.tar.gz
+          path: |
+            dist/*.tar.gz
+            dist/*.rpm
 
   release:
     name: Publish release
@@ -61,11 +83,12 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Checksums
-        run: sha256sum dist/*.tar.gz > dist/SHA256SUMS
+        run: sha256sum dist/*.tar.gz dist/*.rpm > dist/SHA256SUMS
       - name: Publish
         uses: softprops/action-gh-release@v3
         with:
           draft: true
           files: |
             dist/*.tar.gz
+            dist/*.rpm
             dist/SHA256SUMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file.
   target is reached.
 - Bazel real-cleanup deletion for stale inactive output bases, guarded by
   active-process inspection and permission normalization.
+- Linux RPM packaging configuration, systemd unit, packaged config defaults,
+  and release workflow RPM artifacts.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Bazel cache and output-base review is documented in
 ## Distribution Status
 
 Current package authority is the Nix flake package `.#tinyland-cleanup`.
-Release archives are produced from GitHub tags. RPM and broader Linux package
-publication are planned but should be added only after service/user contracts
-and upgrade semantics are explicit.
+Release archives are produced from GitHub tags. Linux RPM packaging is
+documented in [docs/rpm-packaging.md](docs/rpm-packaging.md); the RPM installs a
+systemd unit but leaves enable/start as an explicit operator action.
 
 ## Roadmap
 

--- a/docs/rpm-packaging.md
+++ b/docs/rpm-packaging.md
@@ -1,0 +1,47 @@
+# RPM Packaging
+
+The RPM package is a Linux/Rocky distribution surface for hosts that should not
+consume the Nix flake directly. Nix remains the local tool authority: release
+CI invokes `nfpm` through `nix shell nixpkgs#nfpm`.
+
+Tagged releases produce:
+
+- cross-platform tarballs;
+- Linux RPMs for `amd64` and `arm64`;
+- `SHA256SUMS` covering all release artifacts.
+
+The RPM installs:
+
+- `/usr/bin/tinyland-cleanup`;
+- `/etc/tinyland-cleanup/config.yaml` as a noreplace config file;
+- `/usr/lib/systemd/system/tinyland-cleanup.service`;
+- `/var/lib/tinyland-cleanup`;
+- `/var/log/tinyland-cleanup`.
+
+The systemd service is installed but not enabled or started automatically.
+Operators should review the config and run a dry-run first:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --output json --config /etc/tinyland-cleanup/config.yaml
+```
+
+Enable the service only after the dry-run plan matches the host policy:
+
+```sh
+systemctl enable --now tinyland-cleanup.service
+```
+
+Build an RPM locally with:
+
+```sh
+mkdir -p dist/package-test
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o dist/package-test/tinyland-cleanup .
+NFPM_BINARY=dist/package-test/tinyland-cleanup \
+  NFPM_VERSION=0.2.0 \
+  NFPM_RELEASE=1 \
+  NFPM_ARCH=amd64 \
+  nix shell nixpkgs#nfpm --command nfpm package --packager rpm --config packaging/nfpm.yaml --target dist/package-test
+```
+
+The RPM config uses Linux defaults. Darwin launchd packaging and Home Manager
+module ingestion remain separate distribution surfaces.

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -1,0 +1,96 @@
+# tinyland-cleanup Linux/Rocky package configuration
+#
+# The RPM installs this file as /etc/tinyland-cleanup/config.yaml with
+# noreplace semantics. Review with:
+#
+#   tinyland-cleanup --once --dry-run --level critical --output json --config /etc/tinyland-cleanup/config.yaml
+
+poll_interval: 60
+log_file: /var/log/tinyland-cleanup/tinyland-cleanup.log
+target_free: 70
+
+thresholds:
+  warning: 80
+  moderate: 85
+  aggressive: 90
+  critical: 95
+
+enable:
+  cache: true
+  nix_gc: true
+  docker: true
+  podman: true
+  lima: false
+  homebrew: false
+  ios_simulator: false
+  gitlab_runner: true
+  github_runner: true
+  yum: true
+  icloud: false
+  photos: false
+  dev_artifacts: true
+  bazel: true
+  apfs_snapshots: false
+
+monitored_mounts:
+  - path: /
+    label: root
+
+docker:
+  prune_images_age: 24h
+  protect_running_containers: true
+
+podman:
+  prune_images_age: 24h
+  protect_running_containers: true
+  clean_inside_vm: false
+  trim_vm_disk: false
+  compact_disk_offline: false
+  compact_min_reclaim_gb: 10
+  compact_require_no_active_containers: true
+  compact_keep_backup_until_restart: true
+  compact_provider_allowlist:
+    - applehv
+
+nix:
+  min_user_generations: 5
+  min_system_generations: 3
+  delete_generations_older_than: 14d
+  critical_delete_generations_older_than: 3d
+  allow_store_optimize: false
+  skip_when_daemon_busy: true
+  daemon_busy_backoff: 30m
+  max_gc_duration: 20m
+
+bazel:
+  roots:
+    - ~/.cache/bazel
+  bazelisk_cache: ~/.cache/bazelisk
+  max_total_gb: 20
+  keep_recent_output_bases: 5
+  stale_after: 14d
+  critical_stale_after: 3d
+  protect_workspaces:
+    - ~/git/lab
+    - ~/git/GloriousFlywheel
+  allow_stop_idle_servers: true
+  allow_delete_active_output_bases: false
+
+github_runner:
+  home: /home/github-runner
+  work_dir: ""
+
+dev_artifacts:
+  scan_paths:
+    - ~/git
+    - ~/src
+    - ~/projects
+  node_modules: true
+  python_venvs: true
+  rust_targets: false
+  go_build_cache: true
+  haskell_cache: true
+  lmstudio_models: false
+
+notify:
+  enabled: false

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,52 @@
+name: tinyland-cleanup
+arch: ${NFPM_ARCH}
+platform: linux
+version: ${NFPM_VERSION}
+release: ${NFPM_RELEASE}
+section: utils
+priority: optional
+maintainer: Jess Sullivan <jess@sulliwood.org>
+description: Conservative disk-pressure cleanup daemon for developer machines and CI hosts.
+vendor: tinyland-cleanup
+homepage: https://github.com/Jesssullivan/tinyland-cleanup
+license: MIT
+
+contents:
+  - src: ${NFPM_BINARY}
+    dst: /usr/bin/tinyland-cleanup
+    expand: true
+    file_info:
+      mode: 0755
+
+  - src: packaging/linux/config.yaml
+    dst: /etc/tinyland-cleanup/config.yaml
+    type: config|noreplace
+    file_info:
+      mode: 0644
+
+  - src: packaging/systemd/tinyland-cleanup.service
+    dst: /usr/lib/systemd/system/tinyland-cleanup.service
+    file_info:
+      mode: 0644
+
+  - dst: /etc/tinyland-cleanup
+    type: dir
+    file_info:
+      mode: 0755
+
+  - dst: /var/lib/tinyland-cleanup
+    type: dir
+    file_info:
+      mode: 0755
+
+  - dst: /var/log/tinyland-cleanup
+    type: dir
+    file_info:
+      mode: 0755
+
+scripts:
+  postinstall: packaging/rpm/postinstall.sh
+  postremove: packaging/rpm/postremove.sh
+
+rpm:
+  compression: zstd

--- a/packaging/rpm/postinstall.sh
+++ b/packaging/rpm/postinstall.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+set -eu
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload >/dev/null 2>&1 || true
+fi
+
+cat <<'MSG'
+tinyland-cleanup installed.
+
+Review configuration:
+  /etc/tinyland-cleanup/config.yaml
+
+Run a dry-run before enabling the daemon:
+  tinyland-cleanup --once --dry-run --level critical --output json --config /etc/tinyland-cleanup/config.yaml
+
+Enable manually when ready:
+  systemctl enable --now tinyland-cleanup.service
+MSG

--- a/packaging/rpm/postremove.sh
+++ b/packaging/rpm/postremove.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload >/dev/null 2>&1 || true
+fi

--- a/packaging/systemd/tinyland-cleanup.service
+++ b/packaging/systemd/tinyland-cleanup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=tinyland-cleanup disk-pressure daemon
+Documentation=https://github.com/Jesssullivan/tinyland-cleanup
+After=network-online.target
+ConditionPathExists=/etc/tinyland-cleanup/config.yaml
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/tinyland-cleanup --daemon --config /etc/tinyland-cleanup/config.yaml
+Restart=on-failure
+RestartSec=30s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add nFPM RPM config, Linux package config, systemd unit, and RPM lifecycle scripts
- extend release workflow to publish Linux RPMs alongside tarballs and checksums
- document RPM install/enable workflow with dry-run-first operator gate
- keep Nix as the tool authority by invoking nfpm through nix shell

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build -trimpath -o dist/package-test/tinyland-cleanup .
- env NFPM_BINARY=dist/package-test/tinyland-cleanup NFPM_VERSION=0.2.0 NFPM_RELEASE=1 NFPM_ARCH=amd64 nix shell nixpkgs#nfpm --command nfpm package --packager rpm --config packaging/nfpm.yaml --target dist/package-test
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...