### PR TITLE
Add daemon cleanup cooldown state

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,10 @@ go_binary(
 
 go_library(
     name = "tinyland-cleanup_lib",
-    srcs = ["main.go"] + select({
+    srcs = [
+        "main.go",
+        "state.go",
+    ] + select({
         "@platforms//os:macos": ["plugins_darwin.go"],
         "//conditions:default": ["plugins_other.go"],
     }),
@@ -40,7 +43,10 @@ go_library(
 
 go_test(
     name = "tinyland-cleanup_test",
-    srcs = ["main_test.go"],
+    srcs = [
+        "main_test.go",
+        "state_test.go",
+    ],
     embed = [":tinyland-cleanup_lib"],
     deps = [
         ":config",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file.
   active-process inspection and permission normalization.
 - Linux RPM packaging configuration, systemd unit, packaged config defaults,
   and release workflow RPM artifacts.
+- Persistent daemon cleanup state with per-plugin cooldowns for non-critical
+  daemon-triggered cleanup cycles.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ builder and runner machines.
 - Cleanup policy should explain what it plans to remove and why.
 - Host free-space accounting should be measured before and after cleanup.
 - Real cleanup should stop once the configured host free-space target is met.
+- Daemon-triggered non-critical cleanup should honor cooldown state.
 - Privileged actions, offline compaction, and service disruption must remain
   explicit policy choices.
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,9 @@ type Config struct {
 	// TargetFree is the legacy config key for target maximum used percentage after cleanup.
 	TargetFree int `yaml:"target_free"`
 
+	// Policy controls daemon-level cleanup policy such as cooldown state.
+	Policy PolicyConfig `yaml:"policy"`
+
 	// LogFile path for cleanup logs
 	LogFile string `yaml:"log_file"`
 
@@ -127,6 +130,14 @@ type EnableFlags struct {
 	Bazel bool `yaml:"bazel"`
 	// APFSSnapshots for APFS snapshot thinning (Darwin)
 	APFSSnapshots bool `yaml:"apfs_snapshots"`
+}
+
+// PolicyConfig holds daemon-level cleanup policy settings.
+type PolicyConfig struct {
+	// Cooldown skips repeated non-critical daemon-triggered plugin cleanup within this duration.
+	Cooldown string `yaml:"cooldown"`
+	// StateFile stores daemon cleanup state such as per-plugin last-run timestamps.
+	StateFile string `yaml:"state_file"`
 }
 
 // DockerConfig holds Docker-specific cleanup settings.
@@ -299,6 +310,7 @@ type NotifyConfig struct {
 func DefaultConfig() *Config {
 	home, _ := os.UserHomeDir()
 	logFile := filepath.Join(home, ".local", "log", "disk-cleanup.log")
+	stateFile := filepath.Join(home, ".local", "state", "tinyland-cleanup", "state.json")
 
 	defaultScanPaths := []string{
 		filepath.Join(home, "git"),
@@ -319,7 +331,11 @@ func DefaultConfig() *Config {
 			Critical:   95,
 		},
 		TargetFree: 70,
-		LogFile:    logFile,
+		Policy: PolicyConfig{
+			Cooldown:  "30m",
+			StateFile: stateFile,
+		},
+		LogFile: logFile,
 		Enable: EnableFlags{
 			Cache:         true,
 			NixGC:         true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,6 +28,12 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Thresholds.Critical != 95 {
 		t.Errorf("expected Critical=95, got %d", cfg.Thresholds.Critical)
 	}
+	if cfg.Policy.Cooldown != "30m" {
+		t.Errorf("expected cooldown=30m, got %q", cfg.Policy.Cooldown)
+	}
+	if cfg.Policy.StateFile == "" {
+		t.Error("expected default state file")
+	}
 
 	// Test enable flags
 	if !cfg.Enable.Cache {

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -16,6 +16,13 @@ thresholds:
 # Historical key name is target_free.
 target_free: 70
 
+# Daemon-level cleanup policy
+policy:
+  # Skip repeated non-critical daemon-triggered plugin cleanup within this window.
+  # Explicit --level runs and critical pressure bypass cooldown.
+  cooldown: 30m
+  state_file: ~/.local/state/tinyland-cleanup/state.json
+
 # Enable/disable specific cleanup plugins
 enable:
   cache: true           # pip, npm, go, cargo, maven, gradle caches

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -17,6 +17,7 @@ The JSON report includes:
 - host free-space before and after the cycle;
 - the configured target maximum used percentage and equivalent free-space
   deficit;
+- daemon state file and configured cleanup cooldown;
 - top-level dry-run totals for planned estimated reclaim, required free space,
   and cleanup target count;
 - enabled plugins that would run;
@@ -43,6 +44,11 @@ The report distinguishes:
   available;
 - `host_bytes_freed`: plugin-isolated host free-space measurement, when
   available;
+- `state_file`: path used for persistent daemon cleanup state;
+- `state_error`: load/save failure for daemon cleanup state, when present;
+- `cooldown_seconds`: configured per-plugin cleanup cooldown;
+- `cooldown_remaining_seconds`: per-plugin remaining cooldown when a plugin is
+  skipped with `skip_reason: "cooldown"`;
 - `target_used_percent`: the legacy `target_free` config value, interpreted as
   the desired maximum used percentage after cleanup;
 - `target_free_bytes`: the host free-space equivalent of that target;
@@ -77,5 +83,7 @@ operator review before budget enforcement is enabled.
 This is the first stable reporting surface. It now exposes typed targets for
 selected plugins, but not per-file cleanup candidates for every plugin. Real
 cleanup cycles stop remaining plugins after the host reaches the configured
-target. Treat broader candidate planning, active-use evidence, cooldown state,
-and CLI target-free overrides as the next policy layer.
+target. Daemon-triggered non-critical cleanup also honors per-plugin cooldown
+state; explicit `--level` runs and critical pressure bypass cooldown. Treat
+broader candidate planning, active-use evidence, and CLI target-free overrides
+as the next policy layer.

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -129,6 +130,7 @@ func main() {
 		output:    *output,
 		report:    os.Stdout,
 		diskStats: monitor.GetDiskStats,
+		now:       time.Now,
 	}
 
 	// Determine operation mode
@@ -187,6 +189,7 @@ type daemon struct {
 	output    string
 	report    io.Writer
 	diskStats func(path string) (*monitor.DiskStats, error)
+	now       func() time.Time
 }
 
 func (d *daemon) run(ctx context.Context) error {
@@ -218,14 +221,27 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 		level = assessment.Level
 	}
 
+	now := d.currentTime()
 	report := cycleReport{
-		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Timestamp:   now.UTC().Format(time.RFC3339),
 		DryRun:      d.dryRun,
 		ForcedLevel: forcedLevel != monitor.LevelNone,
 		Level:       level.String(),
 		MonitorPath: d.primaryMonitorPath(assessment),
 		Mounts:      assessment.Mounts,
 	}
+
+	cooldown := d.cleanupCooldown()
+	if cooldown > 0 {
+		report.CooldownSeconds = int64(cooldown / time.Second)
+	}
+	report.StateFile = expandPathHome(d.config.Policy.StateFile)
+	state, stateErr := d.loadStateForCycle()
+	if stateErr != nil {
+		report.StateError = stateErr.Error()
+		d.logger.Warn("failed to load cleanup state", "path", report.StateFile, "error", stateErr)
+	}
+	stateDirty := false
 
 	beforeStats, beforeErr := d.getDiskStats(report.MonitorPath)
 	if beforeErr != nil {
@@ -268,6 +284,16 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 			continue
 		}
 
+		if d.shouldApplyCooldown(report, level) && stateErr == nil {
+			if remaining := state.cooldownRemaining(p.Name(), pluginLevel, now, cooldown); remaining > 0 {
+				pluginReport.WouldRun = false
+				pluginReport.SkipReason = "cooldown"
+				pluginReport.CooldownRemainingSeconds = int64(remaining.Round(time.Second) / time.Second)
+				report.Plugins = append(report.Plugins, pluginReport)
+				continue
+			}
+		}
+
 		if d.dryRun {
 			if planner, ok := p.(plugins.Planner); ok {
 				plan := planner.PlanCleanup(ctx, pluginLevel, d.config, d.logger)
@@ -298,10 +324,18 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 			pluginReport.Error = result.Error.Error()
 			report.Plugins = append(report.Plugins, pluginReport)
 			d.logger.Error("plugin failed", "plugin", p.Name(), "error", result.Error)
+			if stateErr == nil {
+				state.recordPluginRun(p.Name(), pluginLevel, now, result)
+				stateDirty = true
+			}
 			continue
 		}
 
 		report.Plugins = append(report.Plugins, pluginReport)
+		if stateErr == nil {
+			state.recordPluginRun(p.Name(), pluginLevel, now, result)
+			stateDirty = true
+		}
 		if result.BytesFreed > 0 || result.ItemsCleaned > 0 {
 			d.logger.Info("plugin completed",
 				"plugin", p.Name(),
@@ -319,6 +353,12 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 	report.TotalItemsCleaned = totalItems
 
 	d.updateHostFreeAfter(&report, beforeStats, beforeErr)
+	if stateDirty {
+		if err := saveCleanupState(report.StateFile, state); err != nil {
+			report.StateError = err.Error()
+			d.logger.Warn("failed to save cleanup state", "path", report.StateFile, "error", err)
+		}
+	}
 
 	d.logger.Info("cleanup cycle host free-space",
 		"path", report.MonitorPath,
@@ -348,6 +388,9 @@ type cycleReport struct {
 	HostFreeAfterBytes  uint64 `json:"host_free_after_bytes"`
 	HostFreeDeltaBytes  int64  `json:"host_free_delta_bytes"`
 	HostFreeError       string `json:"host_free_error,omitempty"`
+	StateFile           string `json:"state_file,omitempty"`
+	StateError          string `json:"state_error,omitempty"`
+	CooldownSeconds     int64  `json:"cooldown_seconds,omitempty"`
 	// TargetUsedPercent is the legacy target_free config value as a maximum used percentage.
 	TargetUsedPercent int `json:"target_used_percent"`
 	// TargetFreeBytes is the free-space equivalent required to satisfy TargetUsedPercent.
@@ -381,19 +424,20 @@ type mountReport struct {
 }
 
 type pluginCycleReport struct {
-	Name                string               `json:"name"`
-	Description         string               `json:"description"`
-	Level               string               `json:"level"`
-	DryRun              bool                 `json:"dry_run"`
-	WouldRun            bool                 `json:"would_run"`
-	SkipReason          string               `json:"skip_reason,omitempty"`
-	Plan                *plugins.CleanupPlan `json:"plan,omitempty"`
-	BytesFreed          int64                `json:"bytes_freed"`
-	EstimatedBytesFreed int64                `json:"estimated_bytes_freed"`
-	CommandBytesFreed   int64                `json:"command_bytes_freed"`
-	HostBytesFreed      int64                `json:"host_bytes_freed"`
-	ItemsCleaned        int                  `json:"items_cleaned"`
-	Error               string               `json:"error,omitempty"`
+	Name                     string               `json:"name"`
+	Description              string               `json:"description"`
+	Level                    string               `json:"level"`
+	DryRun                   bool                 `json:"dry_run"`
+	WouldRun                 bool                 `json:"would_run"`
+	SkipReason               string               `json:"skip_reason,omitempty"`
+	Plan                     *plugins.CleanupPlan `json:"plan,omitempty"`
+	BytesFreed               int64                `json:"bytes_freed"`
+	EstimatedBytesFreed      int64                `json:"estimated_bytes_freed"`
+	CommandBytesFreed        int64                `json:"command_bytes_freed"`
+	HostBytesFreed           int64                `json:"host_bytes_freed"`
+	ItemsCleaned             int                  `json:"items_cleaned"`
+	CooldownRemainingSeconds int64                `json:"cooldown_remaining_seconds,omitempty"`
+	Error                    string               `json:"error,omitempty"`
 }
 
 type mountAssessment struct {
@@ -544,6 +588,38 @@ func (d *daemon) getDiskStats(path string) (*monitor.DiskStats, error) {
 	return monitor.GetDiskStats(path)
 }
 
+func (d *daemon) currentTime() time.Time {
+	if d.now != nil {
+		return d.now()
+	}
+	return time.Now()
+}
+
+func (d *daemon) cleanupCooldown() time.Duration {
+	if d.config == nil || d.config.Policy.Cooldown == "" {
+		return 0
+	}
+	duration, err := time.ParseDuration(d.config.Policy.Cooldown)
+	if err != nil || duration < 0 {
+		return 0
+	}
+	return duration
+}
+
+func (d *daemon) loadStateForCycle() (*cleanupState, error) {
+	if d.dryRun || d.config == nil {
+		return newCleanupState(), nil
+	}
+	return loadCleanupState(expandPathHome(d.config.Policy.StateFile))
+}
+
+func (d *daemon) shouldApplyCooldown(report cycleReport, level monitor.CleanupLevel) bool {
+	return !d.dryRun &&
+		!report.ForcedLevel &&
+		level != monitor.LevelCritical &&
+		d.cleanupCooldown() > 0
+}
+
 func (d *daemon) updateHostFreeAfter(report *cycleReport, beforeStats *monitor.DiskStats, beforeErr error) {
 	afterStats, afterErr := d.getDiskStats(report.MonitorPath)
 	if afterErr != nil {
@@ -584,6 +660,24 @@ func targetFreeBytes(totalBytes uint64, targetUsedPercent int) (uint64, bool) {
 
 	freePercent := 100 - targetUsedPercent
 	return totalBytes * uint64(freePercent) / 100, true
+}
+
+func expandPathHome(path string) string {
+	if path == "" {
+		return ""
+	}
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return path
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+		}
+	}
+	return path
 }
 
 func bytesToGB(bytes uint64) string {

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Jesssullivan/tinyland-cleanup/config"
 	"github.com/Jesssullivan/tinyland-cleanup/monitor"
@@ -219,6 +221,87 @@ func TestRunOnceStopsAfterTargetFreeMet(t *testing.T) {
 	}
 }
 
+func TestRunOnceSkipsPluginDuringCooldown(t *testing.T) {
+	var output bytes.Buffer
+	mock := &reportingPlugin{}
+	daemon := newTestDaemon(t, mock, &output)
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	daemon.now = func() time.Time { return now }
+	daemon.config.Policy.Cooldown = "30m"
+	daemon.config.Policy.StateFile = filepath.Join(t.TempDir(), "state.json")
+	state := newCleanupState()
+	state.recordPluginRun("reporting", plugins.LevelAggressive, now.Add(-10*time.Minute), plugins.CleanupResult{
+		Plugin:     "reporting",
+		Level:      plugins.LevelAggressive,
+		BytesFreed: 1,
+	})
+	if err := saveCleanupState(daemon.config.Policy.StateFile, state); err != nil {
+		t.Fatal(err)
+	}
+	daemon.diskStats = sequenceDiskStats(t,
+		diskStats(1000, 100, 90),
+		diskStats(1000, 100, 90),
+		diskStats(1000, 100, 90),
+	)
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelNone); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	if mock.called {
+		t.Fatal("plugin should be skipped during cooldown")
+	}
+	report := decodeCycleReport(t, output.Bytes())
+	if report.CooldownSeconds != 1800 {
+		t.Fatalf("expected cooldown seconds 1800, got %d", report.CooldownSeconds)
+	}
+	if len(report.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin report, got %d", len(report.Plugins))
+	}
+	if report.Plugins[0].SkipReason != "cooldown" {
+		t.Fatalf("expected cooldown skip reason, got %q", report.Plugins[0].SkipReason)
+	}
+	if report.Plugins[0].CooldownRemainingSeconds != 1200 {
+		t.Fatalf("expected 1200s cooldown remaining, got %d", report.Plugins[0].CooldownRemainingSeconds)
+	}
+}
+
+func TestRunOnceCriticalBypassesCooldown(t *testing.T) {
+	var output bytes.Buffer
+	mock := &reportingPlugin{}
+	daemon := newTestDaemon(t, mock, &output)
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	daemon.now = func() time.Time { return now }
+	daemon.config.Policy.Cooldown = "30m"
+	daemon.config.Policy.StateFile = filepath.Join(t.TempDir(), "state.json")
+	state := newCleanupState()
+	state.recordPluginRun("reporting", plugins.LevelCritical, now.Add(-10*time.Minute), plugins.CleanupResult{
+		Plugin: "reporting",
+		Level:  plugins.LevelCritical,
+	})
+	if err := saveCleanupState(daemon.config.Policy.StateFile, state); err != nil {
+		t.Fatal(err)
+	}
+	daemon.diskStats = sequenceDiskStats(t,
+		diskStats(1000, 20, 98),
+		diskStats(1000, 20, 98),
+		diskStats(1000, 20, 98),
+		diskStats(1000, 20, 98),
+	)
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelNone); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	if !mock.called {
+		t.Fatal("critical cleanup should bypass cooldown")
+	}
+	report := decodeCycleReport(t, output.Bytes())
+	if report.Plugins[0].SkipReason == "cooldown" {
+		t.Fatal("critical cleanup should not report cooldown skip")
+	}
+}
+
 func newTestDaemon(t *testing.T, plugin plugins.Plugin, output io.Writer) *daemon {
 	t.Helper()
 
@@ -242,6 +325,7 @@ func newTestDaemonWithPlugins(t *testing.T, output io.Writer, registeredPlugins 
 		output:    "json",
 		report:    output,
 		diskStats: monitor.GetDiskStats,
+		now:       time.Now,
 	}
 }
 

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -9,6 +9,10 @@ poll_interval: 60
 log_file: /var/log/tinyland-cleanup/tinyland-cleanup.log
 target_free: 70
 
+policy:
+  cooldown: 30m
+  state_file: /var/lib/tinyland-cleanup/state.json
+
 thresholds:
   warning: 80
   moderate: 85

--- a/state.go
+++ b/state.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Jesssullivan/tinyland-cleanup/plugins"
+)
+
+const cleanupStateVersion = 1
+
+type cleanupState struct {
+	Version int                          `json:"version"`
+	Plugins map[string]pluginStateRecord `json:"plugins"`
+}
+
+type pluginStateRecord struct {
+	LastRun          string `json:"last_run"`
+	LastLevel        string `json:"last_level"`
+	LastLevelValue   int    `json:"last_level_value"`
+	LastBytesFreed   int64  `json:"last_bytes_freed"`
+	LastItemsCleaned int    `json:"last_items_cleaned"`
+	LastError        string `json:"last_error,omitempty"`
+}
+
+func newCleanupState() *cleanupState {
+	return &cleanupState{
+		Version: cleanupStateVersion,
+		Plugins: map[string]pluginStateRecord{},
+	}
+}
+
+func loadCleanupState(path string) (*cleanupState, error) {
+	if path == "" {
+		return newCleanupState(), nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return newCleanupState(), nil
+		}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return newCleanupState(), nil
+	}
+
+	state := newCleanupState()
+	if err := json.Unmarshal(data, state); err != nil {
+		return nil, err
+	}
+	if state.Plugins == nil {
+		state.Plugins = map[string]pluginStateRecord{}
+	}
+	if state.Version == 0 {
+		state.Version = cleanupStateVersion
+	}
+	return state, nil
+}
+
+func saveCleanupState(path string, state *cleanupState) error {
+	if path == "" || state == nil {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0644)
+}
+
+func (s *cleanupState) cooldownRemaining(plugin string, level plugins.CleanupLevel, now time.Time, cooldown time.Duration) time.Duration {
+	if s == nil || cooldown <= 0 {
+		return 0
+	}
+	record, ok := s.Plugins[plugin]
+	if !ok || record.LastLevelValue < int(level) {
+		return 0
+	}
+	lastRun, err := time.Parse(time.RFC3339, record.LastRun)
+	if err != nil {
+		return 0
+	}
+	elapsed := now.Sub(lastRun)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	if elapsed >= cooldown {
+		return 0
+	}
+	return cooldown - elapsed
+}
+
+func (s *cleanupState) recordPluginRun(plugin string, level plugins.CleanupLevel, now time.Time, result plugins.CleanupResult) {
+	if s == nil {
+		return
+	}
+	if s.Plugins == nil {
+		s.Plugins = map[string]pluginStateRecord{}
+	}
+	record := pluginStateRecord{
+		LastRun:          now.UTC().Format(time.RFC3339),
+		LastLevel:        level.String(),
+		LastLevelValue:   int(level),
+		LastBytesFreed:   result.BytesFreed,
+		LastItemsCleaned: result.ItemsCleaned,
+	}
+	if result.Error != nil {
+		record.LastError = result.Error.Error()
+	}
+	s.Plugins[plugin] = record
+}

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Jesssullivan/tinyland-cleanup/plugins"
+)
+
+func TestCleanupStateRoundTripAndCooldown(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	state := newCleanupState()
+	state.recordPluginRun("nix", plugins.LevelModerate, now.Add(-5*time.Minute), plugins.CleanupResult{
+		Plugin:       "nix",
+		Level:        plugins.LevelModerate,
+		BytesFreed:   42,
+		ItemsCleaned: 2,
+	})
+
+	if err := saveCleanupState(path, state); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := loadCleanupState(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remaining := loaded.cooldownRemaining("nix", plugins.LevelModerate, now, 30*time.Minute)
+	if remaining != 25*time.Minute {
+		t.Fatalf("remaining = %s, want 25m", remaining)
+	}
+	if loaded.cooldownRemaining("nix", plugins.LevelAggressive, now, 30*time.Minute) != 0 {
+		t.Fatal("higher cleanup level should bypass prior lower-level cooldown")
+	}
+}
+
+func TestLoadCleanupStateMissingFile(t *testing.T) {
+	state, err := loadCleanupState(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Version != cleanupStateVersion {
+		t.Fatalf("version = %d, want %d", state.Version, cleanupStateVersion)
+	}
+	if len(state.Plugins) != 0 {
+		t.Fatalf("expected empty plugin state, got %#v", state.Plugins)
+	}
+}


### PR DESCRIPTION
## Summary
- add persistent per-plugin daemon cleanup state
- skip repeated non-critical daemon-triggered plugin runs during the configured cooldown
- report state file, state errors, cooldown seconds, and per-plugin cooldown remaining in JSON output
- add Darwin/Linux config defaults and operator docs for cooldown behavior

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...