### PR TITLE
Add opt-in Darwin cache enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,17 @@ All notable changes to this project will be documented in this file.
 - Structured dry-run targets for development artifacts such as stale
   `node_modules`, Python virtualenvs, Rust `target/` directories, Go build
   cache, Haskell caches, and opt-in LM Studio model caches.
+- Opt-in Darwin developer-cache enforcement for typed JetBrains, Playwright,
+  Bazelisk, and pip cache targets.
 
 ### Changed
 
 - Go module path moved to `github.com/Jesssullivan/tinyland-cleanup`.
 - Clarified that the legacy `target_free` config key represents the target
   maximum used-space percentage after cleanup.
+- Critical Darwin cache cleanup now prefers typed developer-cache targets when
+  `darwin_dev_caches.enabled` is true, avoiding broad `~/Library/Caches`
+  sweeps unless the typed policy is disabled.
 
 ## [0.2.0]
 

--- a/config/config.go
+++ b/config/config.go
@@ -258,6 +258,9 @@ type DevArtifactsConfig struct {
 type DarwinDevCachesConfig struct {
 	// Enabled controls typed Darwin developer-cache planning.
 	Enabled bool `yaml:"enabled"`
+	// Enforce enables real deletion of eligible Darwin developer-cache targets.
+	// Defaults false so the typed target surface remains review-only unless operators opt in.
+	Enforce bool `yaml:"enforce"`
 	// MaxTotalGB is the review budget across known Darwin developer caches.
 	MaxTotalGB int `yaml:"max_total_gb"`
 	// JetBrains controls JetBrains cache planning.
@@ -410,6 +413,7 @@ func DefaultConfig() *Config {
 		},
 		DarwinDevCaches: DarwinDevCachesConfig{
 			Enabled:    runtime.GOOS == "darwin",
+			Enforce:    false,
 			MaxTotalGB: 15,
 			JetBrains: DarwinDevCacheToolConfig{
 				Enabled:            true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -311,6 +311,9 @@ func TestDarwinDevCacheDefaults(t *testing.T) {
 	if runtime.GOOS != "darwin" && cfg.DarwinDevCaches.Enabled {
 		t.Error("DarwinDevCaches.Enabled should default to false outside Darwin")
 	}
+	if cfg.DarwinDevCaches.Enforce {
+		t.Error("DarwinDevCaches.Enforce should default to false")
+	}
 	if cfg.DarwinDevCaches.MaxTotalGB != 15 {
 		t.Errorf("DarwinDevCaches.MaxTotalGB should default to 15, got %d", cfg.DarwinDevCaches.MaxTotalGB)
 	}
@@ -388,6 +391,7 @@ bazel:
   allow_delete_active_output_bases: true
 darwin_dev_caches:
   enabled: true
+  enforce: true
   max_total_gb: 20
   jetbrains:
     enabled: true
@@ -514,6 +518,9 @@ darwin_dev_caches:
 	}
 	if !cfg.DarwinDevCaches.Enabled {
 		t.Error("DarwinDevCaches.Enabled should be true per config")
+	}
+	if !cfg.DarwinDevCaches.Enforce {
+		t.Error("DarwinDevCaches.Enforce should be true per config")
 	}
 	if cfg.DarwinDevCaches.MaxTotalGB != 20 {
 		t.Errorf("DarwinDevCaches.MaxTotalGB should be 20 per config, got %d", cfg.DarwinDevCaches.MaxTotalGB)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -103,6 +103,27 @@ bazel:
   allow_stop_idle_servers: true
   allow_delete_active_output_bases: false
 
+# Darwin developer-cache review settings.
+# Enforcement is opt-in; keep false until dry-run targets are reviewed.
+darwin_dev_caches:
+  enabled: true
+  enforce: false
+  max_total_gb: 15
+  jetbrains:
+    enabled: true
+    max_gb: 8
+    stale_after_days: 14
+    keep_active_versions: true
+  playwright:
+    enabled: true
+    keep_latest_per_family: true
+  bazelisk:
+    enabled: true
+    keep_latest: 2
+  pip:
+    enabled: true
+    stale_after_days: 14
+
 # Lima VM settings (macOS)
 lima:
   vm_names:

--- a/docs/darwin-dev-caches.md
+++ b/docs/darwin-dev-caches.md
@@ -29,6 +29,17 @@ Safety boundaries:
 - protect newest Playwright browser revisions per browser family;
 - protect the newest Bazelisk cache entries.
 
-This surface is currently a review and classification layer. Budget enforcement
-for these typed targets should remain a separate opt-in policy pass after the
-dry-run evidence is proven on real Darwin developer machines.
+Real deletion for these typed targets is opt-in. Leave enforcement disabled
+until a dry-run has been reviewed:
+
+```yaml
+darwin_dev_caches:
+  enabled: true
+  enforce: false
+```
+
+When `enforce: true`, moderate cleanup can delete unprotected Playwright and
+Bazelisk entries outside the keep-latest policy and stale pip caches. Aggressive
+cleanup can delete inactive stale JetBrains cache versions. Critical cleanup can
+delete inactive unprotected JetBrains cache versions regardless of age. The same
+protected target rules from dry-run planning are used for real cleanup.

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -76,7 +76,7 @@ space.
 
 For Darwin IDE and tool caches, review
 [darwin-dev-caches.md](darwin-dev-caches.md). These targets are reported for
-operator review before budget enforcement is enabled.
+operator review, and real deletion requires `darwin_dev_caches.enforce: true`.
 
 For workspace build artifacts, the `dev-artifacts` plan reports rebuildable
 targets such as `node_modules`, Python virtualenvs, Rust `target/` directories,

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -452,6 +452,7 @@ func (p *CachePlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *
 		},
 		Metadata: map[string]string{
 			"darwin_dev_caches_enabled": strconv.FormatBool(cfg.DarwinDevCaches.Enabled),
+			"darwin_dev_caches_enforce": strconv.FormatBool(cfg.DarwinDevCaches.Enforce),
 			"max_total_gb":              strconv.Itoa(cfg.DarwinDevCaches.MaxTotalGB),
 		},
 	}
@@ -464,7 +465,7 @@ func (p *CachePlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *
 
 	home, _ := os.UserHomeDir()
 	activeProcesses := darwinActiveProcessNames(ctx)
-	targets := p.darwinDeveloperCacheTargets(home, cfg.DarwinDevCaches, activeProcesses)
+	targets := p.darwinDeveloperCacheTargets(home, cfg.DarwinDevCaches, activeProcesses, level)
 	sort.Slice(targets, func(i, j int) bool {
 		if targets[i].Bytes == targets[j].Bytes {
 			return targets[i].Path < targets[j].Path
@@ -473,18 +474,27 @@ func (p *CachePlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *
 	})
 
 	var total int64
+	var estimated int64
 	for _, target := range targets {
 		total += target.Bytes
+		if target.Action == "delete" {
+			estimated += target.Bytes
+		}
 	}
 
 	plan.Targets = targets
+	plan.EstimatedBytesFreed = estimated
 	plan.Metadata["target_count"] = strconv.Itoa(len(targets))
 	plan.Metadata["total_physical_bytes"] = strconv.FormatInt(total, 10)
 
 	if cfg.DarwinDevCaches.MaxTotalGB > 0 && total > int64(cfg.DarwinDevCaches.MaxTotalGB)*1024*1024*1024 {
 		plan.Warnings = append(plan.Warnings, "known Darwin developer caches exceed configured review budget")
 	}
-	plan.Warnings = append(plan.Warnings, "this slice reports typed cache candidates only; budget enforcement remains opt-in follow-up work")
+	if !cfg.DarwinDevCaches.Enforce {
+		plan.Warnings = append(plan.Warnings, "Darwin developer-cache enforcement is disabled; targets are review-only until darwin_dev_caches.enforce is true")
+	} else if level < LevelModerate {
+		plan.Warnings = append(plan.Warnings, "Darwin developer-cache enforcement requires moderate or higher cleanup level")
+	}
 
 	return plan
 }
@@ -589,7 +599,7 @@ func (p *CachePlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *conf
 	}
 
 	// macOS Library/Caches (only at critical)
-	if level >= LevelCritical {
+	if level >= LevelCritical && !cfg.DarwinDevCaches.Enabled {
 		libraryCaches := filepath.Join(home, "Library", "Caches")
 		if _, err := os.Stat(libraryCaches); err == nil {
 			sizeBefore := getDirSize(libraryCaches)
@@ -598,6 +608,16 @@ func (p *CachePlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *conf
 			sizeAfter := getDirSize(libraryCaches)
 			result.BytesFreed += sizeBefore - sizeAfter
 			logger.Debug("cleaned macOS Library/Caches", "freed_mb", (sizeBefore-sizeAfter)/(1024*1024))
+		}
+	}
+
+	if cfg.DarwinDevCaches.Enabled && cfg.DarwinDevCaches.Enforce && level >= LevelModerate {
+		darwinResult := p.cleanupDarwinDeveloperCacheTargets(ctx, level, home, cfg.DarwinDevCaches, logger)
+		result.BytesFreed += darwinResult.BytesFreed
+		result.EstimatedBytesFreed += darwinResult.EstimatedBytesFreed
+		result.ItemsCleaned += darwinResult.ItemsCleaned
+		if darwinResult.Error != nil {
+			result.Error = darwinResult.Error
 		}
 	}
 
@@ -612,14 +632,17 @@ type darwinCacheEntry struct {
 	bytes   int64
 }
 
-func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.DarwinDevCachesConfig, activeProcesses map[string]bool) []CleanupTarget {
+func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.DarwinDevCachesConfig, activeProcesses map[string]bool, level CleanupLevel) []CleanupTarget {
 	var targets []CleanupTarget
+	enforce := cfg.Enforce && level >= LevelModerate
 
 	if cfg.JetBrains.Enabled {
 		jetBrainsRoot := filepath.Join(home, "Library", "Caches", "JetBrains")
 		jetBrainsActive := cfg.JetBrains.KeepActiveVersions && darwinAnyProcessActive(activeProcesses,
 			"appcode", "clion", "datagrip", "goland", "idea", "intellij", "phpstorm", "pycharm", "rider", "rubymine", "webstorm")
 		for _, entry := range listDarwinCacheEntries(jetBrainsRoot) {
+			stale := darwinCacheEntryStale(entry, cfg.JetBrains.StaleAfterDays)
+			eligible := !jetBrainsActive && (level >= LevelCritical || (level >= LevelAggressive && stale))
 			targets = append(targets, CleanupTarget{
 				Type:      "jetbrains",
 				Name:      entry.name,
@@ -627,9 +650,9 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 				Path:      entry.path,
 				Bytes:     entry.bytes,
 				Active:    jetBrainsActive,
-				Protected: jetBrainsActive,
-				Action:    darwinReviewAction(jetBrainsActive),
-				Reason:    darwinReviewReason(jetBrainsActive, "JetBrains cache version"),
+				Protected: darwinCacheProtected(jetBrainsActive, enforce, eligible),
+				Action:    darwinCacheAction(jetBrainsActive, enforce, eligible),
+				Reason:    darwinCacheReason(jetBrainsActive, enforce, eligible, "JetBrains cache version", "requires aggressive stale-cache enforcement or critical pressure"),
 			})
 		}
 	}
@@ -640,6 +663,7 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 		protected := newestPerFamily(entries, cfg.Playwright.KeepLatestPerFamily)
 		for _, entry := range entries {
 			isProtected := protected[entry.path]
+			eligible := !isProtected && level >= LevelModerate
 			targets = append(targets, CleanupTarget{
 				Type:      "playwright",
 				Name:      entry.name,
@@ -647,8 +671,8 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 				Path:      entry.path,
 				Bytes:     entry.bytes,
 				Protected: isProtected,
-				Action:    darwinReviewAction(isProtected),
-				Reason:    darwinReviewReason(isProtected, "Playwright browser revision"),
+				Action:    darwinCacheAction(isProtected, enforce, eligible),
+				Reason:    darwinCacheReason(isProtected, enforce, eligible, "Playwright browser revision", "older than keep-latest-per-family policy"),
 			})
 		}
 	}
@@ -662,6 +686,7 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 		keepLatest := cfg.Bazelisk.KeepLatest
 		for idx, entry := range entries {
 			isProtected := keepLatest > 0 && idx < keepLatest
+			eligible := !isProtected && level >= LevelModerate
 			targets = append(targets, CleanupTarget{
 				Type:      "bazelisk",
 				Name:      entry.name,
@@ -669,8 +694,8 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 				Path:      entry.path,
 				Bytes:     entry.bytes,
 				Protected: isProtected,
-				Action:    darwinReviewAction(isProtected),
-				Reason:    darwinReviewReason(isProtected, "Bazelisk download cache"),
+				Action:    darwinCacheAction(isProtected, enforce, eligible),
+				Reason:    darwinCacheReason(isProtected, enforce, eligible, "Bazelisk download cache", "older than keep-latest policy"),
 			})
 		}
 	}
@@ -683,18 +708,56 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 			if !pathExistsAndIsDir(pipPath) {
 				continue
 			}
+			stale := dirModTimeStale(pipPath, cfg.Pip.StaleAfterDays)
+			eligible := level >= LevelModerate && stale
 			targets = append(targets, CleanupTarget{
-				Type:   "pip",
-				Name:   filepath.Base(pipPath),
-				Path:   pipPath,
-				Bytes:  getDirAllocatedBytes(pipPath),
-				Action: "review",
-				Reason: fmt.Sprintf("pip cache; stale-after review budget is %d days", cfg.Pip.StaleAfterDays),
+				Type:      "pip",
+				Name:      filepath.Base(pipPath),
+				Path:      pipPath,
+				Bytes:     getDirAllocatedBytes(pipPath),
+				Protected: darwinCacheProtected(false, enforce, eligible),
+				Action:    darwinCacheAction(false, enforce, eligible),
+				Reason:    darwinCacheReason(false, enforce, eligible, "pip cache", fmt.Sprintf("stale-after policy is %d days", cfg.Pip.StaleAfterDays)),
 			})
 		}
 	}
 
 	return targets
+}
+
+func (p *CachePlugin) cleanupDarwinDeveloperCacheTargets(ctx context.Context, level CleanupLevel, home string, cfg config.DarwinDevCachesConfig, logger *slog.Logger) CleanupResult {
+	result := CleanupResult{
+		Plugin: p.Name(),
+		Level:  level,
+	}
+	targets := p.darwinDeveloperCacheTargets(home, cfg, darwinActiveProcessNames(ctx), level)
+	for _, target := range targets {
+		if target.Action != "delete" || target.Protected || target.Path == "" {
+			continue
+		}
+		sizeBefore := target.Bytes
+		if sizeBefore == 0 {
+			sizeBefore = getDirAllocatedBytes(target.Path)
+		}
+		result.EstimatedBytesFreed += sizeBefore
+		if err := os.RemoveAll(target.Path); err != nil {
+			result.Error = err
+			logger.Warn("failed to delete Darwin developer cache target", "path", target.Path, "type", target.Type, "error", err)
+			continue
+		}
+		sizeAfter := int64(0)
+		if pathExistsAndIsDir(target.Path) {
+			sizeAfter = getDirAllocatedBytes(target.Path)
+		}
+		freed := safeBytesDiff(sizeBefore, sizeAfter)
+		result.BytesFreed += freed
+		result.ItemsCleaned++
+		logger.Info("deleted Darwin developer cache target",
+			"type", target.Type,
+			"path", target.Path,
+			"freed_mb", freed/(1024*1024))
+	}
+	return result
 }
 
 func listDarwinCacheEntries(root string) []darwinCacheEntry {
@@ -759,18 +822,49 @@ func darwinCacheFamily(name string) string {
 	return name
 }
 
-func darwinReviewAction(protected bool) string {
-	if protected {
+func darwinCacheProtected(protected bool, enforce bool, eligible bool) bool {
+	return protected || (enforce && !eligible)
+}
+
+func darwinCacheAction(protected bool, enforce bool, eligible bool) string {
+	if protected || (enforce && !eligible) {
 		return "protect"
+	}
+	if enforce && eligible {
+		return "delete"
 	}
 	return "review"
 }
 
-func darwinReviewReason(protected bool, label string) string {
+func darwinCacheReason(protected bool, enforce bool, eligible bool, label string, eligibility string) string {
 	if protected {
 		return label + " is protected by active-use or keep-latest policy"
 	}
-	return label + " is a cleanup candidate for a future budget-enforcement pass"
+	if enforce && eligible {
+		return label + " is eligible for opt-in deletion: " + eligibility
+	}
+	if enforce {
+		return label + " is preserved by opt-in enforcement policy: " + eligibility
+	}
+	return label + " is a cleanup candidate for opt-in budget enforcement"
+}
+
+func darwinCacheEntryStale(entry darwinCacheEntry, staleAfterDays int) bool {
+	if staleAfterDays <= 0 {
+		return true
+	}
+	return entry.modTime.Before(time.Now().Add(-time.Duration(staleAfterDays) * 24 * time.Hour))
+}
+
+func dirModTimeStale(path string, staleAfterDays int) bool {
+	if staleAfterDays <= 0 {
+		return true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.ModTime().Before(time.Now().Add(-time.Duration(staleAfterDays) * 24 * time.Hour))
 }
 
 func darwinActiveProcessNames(ctx context.Context) map[string]bool {

--- a/plugins/darwin_dev_cache_test.go
+++ b/plugins/darwin_dev_cache_test.go
@@ -3,6 +3,9 @@
 package plugins
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +34,7 @@ func TestDarwinDeveloperCacheTargetsClassifyProtectedVersions(t *testing.T) {
 	mustChtimes(t, filepath.Join(home, "Library/Caches/bazelisk/v3"), now)
 
 	plugin := &CachePlugin{}
-	targets := plugin.darwinDeveloperCacheTargets(home, cfg, map[string]bool{"goland": true})
+	targets := plugin.darwinDeveloperCacheTargets(home, cfg, map[string]bool{"goland": true}, LevelWarning)
 
 	jetbrains := findCleanupTarget(t, targets, "jetbrains", "IntelliJIdea2024.3")
 	if !jetbrains.Active || !jetbrains.Protected {
@@ -63,6 +66,79 @@ func TestDarwinDeveloperCacheTargetsClassifyProtectedVersions(t *testing.T) {
 	}
 }
 
+func TestDarwinDeveloperCacheTargetsOptInEnforcement(t *testing.T) {
+	home := t.TempDir()
+	cfg := config.DefaultConfig().DarwinDevCaches
+	cfg.Enforce = true
+
+	writeCacheFile(t, home, "Library/Caches/ms-playwright/chromium-1148/browser.bin", "old chromium")
+	writeCacheFile(t, home, "Library/Caches/ms-playwright/chromium-1149/browser.bin", "new chromium")
+	writeCacheFile(t, home, "Library/Caches/bazelisk/v1/bin/bazel", "v1")
+	writeCacheFile(t, home, "Library/Caches/bazelisk/v2/bin/bazel", "v2")
+	writeCacheFile(t, home, "Library/Caches/bazelisk/v3/bin/bazel", "v3")
+	writeCacheFile(t, home, "Library/Caches/JetBrains/IntelliJIdea2024.3/cache.bin", "jetbrains")
+
+	now := time.Now()
+	mustChtimes(t, filepath.Join(home, "Library/Caches/ms-playwright/chromium-1148"), now.Add(-2*time.Hour))
+	mustChtimes(t, filepath.Join(home, "Library/Caches/ms-playwright/chromium-1149"), now)
+	mustChtimes(t, filepath.Join(home, "Library/Caches/bazelisk/v1"), now.Add(-3*time.Hour))
+	mustChtimes(t, filepath.Join(home, "Library/Caches/bazelisk/v2"), now.Add(-2*time.Hour))
+	mustChtimes(t, filepath.Join(home, "Library/Caches/bazelisk/v3"), now)
+
+	plugin := &CachePlugin{}
+	targets := plugin.darwinDeveloperCacheTargets(home, cfg, map[string]bool{}, LevelModerate)
+
+	oldChromium := findCleanupTarget(t, targets, "playwright", "chromium-1148")
+	if oldChromium.Action != "delete" || oldChromium.Protected {
+		t.Fatalf("expected old Playwright revision to be an opt-in delete target: %#v", oldChromium)
+	}
+	newChromium := findCleanupTarget(t, targets, "playwright", "chromium-1149")
+	if newChromium.Action != "protect" || !newChromium.Protected {
+		t.Fatalf("expected newest Playwright revision to be protected: %#v", newChromium)
+	}
+	bazeliskV1 := findCleanupTarget(t, targets, "bazelisk", "v1")
+	if bazeliskV1.Action != "delete" || bazeliskV1.Protected {
+		t.Fatalf("expected oldest Bazelisk cache to be an opt-in delete target: %#v", bazeliskV1)
+	}
+	jetbrains := findCleanupTarget(t, targets, "jetbrains", "IntelliJIdea2024.3")
+	if jetbrains.Action != "protect" || !jetbrains.Protected {
+		t.Fatalf("expected JetBrains cache to require aggressive or critical level: %#v", jetbrains)
+	}
+}
+
+func TestCleanupDarwinDeveloperCacheTargetsDeletesOnlyEligibleTargets(t *testing.T) {
+	home := t.TempDir()
+	cfg := config.DefaultConfig().DarwinDevCaches
+	cfg.Enforce = true
+
+	oldBrowser := filepath.Join(home, "Library/Caches/ms-playwright/chromium-1148")
+	newBrowser := filepath.Join(home, "Library/Caches/ms-playwright/chromium-1149")
+	writeCacheFile(t, home, "Library/Caches/ms-playwright/chromium-1148/browser.bin", "old chromium")
+	writeCacheFile(t, home, "Library/Caches/ms-playwright/chromium-1149/browser.bin", "new chromium")
+
+	now := time.Now()
+	mustChtimes(t, oldBrowser, now.Add(-2*time.Hour))
+	mustChtimes(t, newBrowser, now)
+
+	plugin := &CachePlugin{}
+	result := plugin.cleanupDarwinDeveloperCacheTargets(context.Background(), LevelModerate, home, cfg, nilLogger())
+	if result.Error != nil {
+		t.Fatalf("cleanup failed: %v", result.Error)
+	}
+	if result.ItemsCleaned != 1 {
+		t.Fatalf("expected one deleted target, got %d", result.ItemsCleaned)
+	}
+	if pathExists(oldBrowser) {
+		t.Fatalf("expected old Playwright revision to be deleted")
+	}
+	if !pathExists(newBrowser) {
+		t.Fatalf("expected newest Playwright revision to remain")
+	}
+	if result.EstimatedBytesFreed <= 0 || result.BytesFreed <= 0 {
+		t.Fatalf("expected positive byte accounting, got %#v", result)
+	}
+}
+
 func writeCacheFile(t *testing.T, home, relPath, content string) {
 	t.Helper()
 
@@ -80,6 +156,10 @@ func mustChtimes(t *testing.T, path string, modTime time.Time) {
 	if err := os.Chtimes(path, modTime, modTime); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func nilLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func findCleanupTarget(t *testing.T, targets []CleanupTarget, targetType, name string) CleanupTarget {


### PR DESCRIPTION
## Summary
- add darwin_dev_caches.enforce, defaulting false
- mark eligible typed Darwin developer-cache dry-run targets as delete only when enforcement is explicitly enabled
- add real deletion for eligible typed Playwright, Bazelisk, pip, and JetBrains cache targets using the same protected-target policy
- avoid broad critical ~/Library/Caches sweeps when typed Darwin cache policy is enabled
- document the opt-in enforcement workflow and defaults

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./config ./plugins
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...