### PR TITLE
Add Nix GC root attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to this project will be documented in this file.
   cache, Haskell caches, and opt-in LM Studio model caches.
 - Opt-in Darwin developer-cache enforcement for typed JetBrains, Playwright,
   Bazelisk, and pip cache targets.
+- Nix low-reclaim dry-runs now emit protected GC-root attribution targets so
+  operators can see what is pinning the store before taking action.
 
 ### Changed
 

--- a/config/config.go
+++ b/config/config.go
@@ -222,6 +222,8 @@ type NixConfig struct {
 	DaemonBusyBackoff string `yaml:"daemon_busy_backoff"`
 	// MaxGCDuration bounds nix-collect-garbage and related Nix commands.
 	MaxGCDuration string `yaml:"max_gc_duration"`
+	// RootAttributionLimit limits visible GC root targets in low-reclaim dry-runs.
+	RootAttributionLimit int `yaml:"root_attribution_limit"`
 }
 
 // ICloudConfig holds iCloud-specific cleanup settings (Darwin).
@@ -392,6 +394,7 @@ func DefaultConfig() *Config {
 			SkipWhenDaemonBusy:                 true,
 			DaemonBusyBackoff:                  "30m",
 			MaxGCDuration:                      "20m",
+			RootAttributionLimit:               20,
 		},
 		Lima: LimaConfig{
 			VMNames: []string{"colima", "unified"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -269,6 +269,9 @@ func TestNixPolicyDefaults(t *testing.T) {
 	if cfg.Nix.MaxGCDuration != "20m" {
 		t.Errorf("Nix.MaxGCDuration should be 20m, got %q", cfg.Nix.MaxGCDuration)
 	}
+	if cfg.Nix.RootAttributionLimit != 20 {
+		t.Errorf("Nix.RootAttributionLimit should be 20, got %d", cfg.Nix.RootAttributionLimit)
+	}
 }
 
 func TestBazelPolicyDefaults(t *testing.T) {
@@ -377,6 +380,7 @@ nix:
   skip_when_daemon_busy: false
   daemon_busy_backoff: 45m
   max_gc_duration: 10m
+  root_attribution_limit: 8
 bazel:
   roots:
     - ~/custom-bazel
@@ -488,6 +492,9 @@ darwin_dev_caches:
 	}
 	if cfg.Nix.MaxGCDuration != "10m" {
 		t.Errorf("Nix.MaxGCDuration should be 10m per config, got %q", cfg.Nix.MaxGCDuration)
+	}
+	if cfg.Nix.RootAttributionLimit != 8 {
+		t.Errorf("Nix.RootAttributionLimit should be 8 per config, got %d", cfg.Nix.RootAttributionLimit)
 	}
 	if len(cfg.Bazel.Roots) != 1 || cfg.Bazel.Roots[0] != "~/custom-bazel" {
 		t.Errorf("unexpected Bazel.Roots: %#v", cfg.Bazel.Roots)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -86,6 +86,10 @@ nix:
   skip_when_daemon_busy: true
   daemon_busy_backoff: 30m
   max_gc_duration: 20m
+  # When dry-run GC reports no reclaimable space, show up to this many visible
+  # GC roots so operators can identify what is pinning the store. Set 0 to
+  # disable root attribution.
+  root_attribution_limit: 20
 
 # Bazel output base and cache review settings
 bazel:

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -15,6 +15,7 @@ The Nix plan includes:
 - `estimated_bytes_freed` from `nix-collect-garbage --dry-run`;
 - detected active Nix work such as `nix build`, `home-manager switch`,
   `darwin-rebuild`, `nixos-rebuild`, and worker-style `nix-daemon` activity;
+- visible GC roots when dry-run GC reports no reclaimable store space;
 - generation targets with `keep_generation`, `delete_generation`, or
   `review_privileged_generation` actions;
 - configured minimum user and system generation retention;
@@ -32,6 +33,7 @@ nix:
   skip_when_daemon_busy: true
   daemon_busy_backoff: 30m
   max_gc_duration: 20m
+  root_attribution_limit: 20
 ```
 
 Runtime behavior:
@@ -42,6 +44,10 @@ Runtime behavior:
 - critical uses the stricter age policy, then runs plain Nix garbage collection;
 - system or nix-darwin generations are reported for operator review but are not
   deleted by the unprivileged plugin path;
+- low-reclaim dry-runs run `nix-store --gc --print-roots` and emit protected
+  `nix_gc_root` targets so operators can see whether profiles, gcroots,
+  workspace `result` links, temporary roots, or active processes are pinning the
+  store;
 - `nix-store --optimize` runs only when `allow_store_optimize: true`.
 
 Recommended Darwin developer-machine defaults are the repo defaults above.
@@ -61,7 +67,10 @@ nix:
   skip_when_daemon_busy: true
   daemon_busy_backoff: 15m
   max_gc_duration: 15m
+  root_attribution_limit: 20
 ```
 
 Keep `skip_when_daemon_busy` enabled on build runners. A cleanup cycle that
 breaks an active Nix build or remote-cache proof is worse than a deferred GC.
+Set `root_attribution_limit: 0` only for hosts where dry-run root enumeration is
+too noisy or too expensive.

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -65,6 +65,7 @@ nix:
   skip_when_daemon_busy: true
   daemon_busy_backoff: 30m
   max_gc_duration: 20m
+  root_attribution_limit: 20
 
 bazel:
   roots:

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -25,6 +26,13 @@ type nixGeneration struct {
 	Current   bool
 	Scope     string
 	Profile   string
+}
+
+type nixGCRoot struct {
+	Root      string
+	StorePath string
+	Class     string
+	Active    bool
 }
 
 // NewNixPlugin creates a new Nix cleanup plugin.
@@ -70,6 +78,7 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 			"skip_when_daemon_busy":                     strconv.FormatBool(cfg.Nix.SkipWhenDaemonBusy),
 			"daemon_busy_backoff":                       cfg.Nix.DaemonBusyBackoff,
 			"max_gc_duration":                           cfg.Nix.MaxGCDuration,
+			"root_attribution_limit":                    strconv.Itoa(nixRootAttributionLimit(cfg.Nix)),
 			"generation_policy_delete_older_than_level": nixGenerationPolicyAge(level, cfg.Nix),
 		},
 	}
@@ -108,6 +117,12 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 		plan.Metadata["dry_run_store_paths"] = strconv.Itoa(paths)
 		if estimated == 0 {
 			plan.Warnings = append(plan.Warnings, "Nix dry-run reported no reclaimable store space; live roots may be retaining the store")
+			targets, metadata, warnings := p.planGCRootAttribution(ctx, cfg.Nix)
+			plan.Targets = append(plan.Targets, targets...)
+			for key, value := range metadata {
+				plan.Metadata[key] = value
+			}
+			plan.Warnings = append(plan.Warnings, warnings...)
 		}
 	}
 
@@ -188,6 +203,50 @@ func (p *NixPlugin) collectGarbageDryRun(ctx context.Context, cfg config.NixConf
 	cmd := exec.CommandContext(ctx, "nix-collect-garbage", "--dry-run")
 	output, err := cmd.CombinedOutput()
 	return string(output), err
+}
+
+func (p *NixPlugin) printGCRoots(ctx context.Context, cfg config.NixConfig) (string, error) {
+	if _, err := exec.LookPath("nix-store"); err != nil {
+		return "", err
+	}
+
+	timeout := nixCommandTimeout(cfg)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "nix-store", "--gc", "--print-roots")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("nix-store --gc --print-roots failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func (p *NixPlugin) planGCRootAttribution(ctx context.Context, cfg config.NixConfig) ([]CleanupTarget, map[string]string, []string) {
+	limit := nixRootAttributionLimit(cfg)
+	if limit == 0 {
+		return nil, map[string]string{"gc_root_attribution": "disabled"}, nil
+	}
+
+	metadata := map[string]string{
+		"gc_root_attribution_limit": strconv.Itoa(limit),
+	}
+	output, err := p.printGCRoots(ctx, cfg)
+	if err != nil {
+		return nil, metadata, []string{fmt.Sprintf("could not inspect Nix GC roots: %v", err)}
+	}
+
+	roots := parseNixGCRoots(output)
+	metadata["gc_root_attribution_roots"] = strconv.Itoa(len(roots))
+	metadata["gc_root_attribution_classes"] = nixGCRootClassSummary(roots)
+
+	targets := nixGCRootTargets(roots, limit)
+	if len(targets) < len(roots) {
+		metadata["gc_root_attribution_truncated"] = "true"
+		return targets, metadata, []string{fmt.Sprintf("Nix GC root attribution truncated to %d of %d visible roots", len(targets), len(roots))}
+	}
+
+	return targets, metadata, nil
 }
 
 func (p *NixPlugin) collectGarbage(ctx context.Context, level CleanupLevel, args []string, cfg config.NixConfig, logger *slog.Logger) CleanupResult {
@@ -413,6 +472,13 @@ func nixCommandTimeout(cfg config.NixConfig) time.Duration {
 	return parseNixPolicyDuration(cfg.MaxGCDuration, nixDefaultCommandTimeout)
 }
 
+func nixRootAttributionLimit(cfg config.NixConfig) int {
+	if cfg.RootAttributionLimit < 0 {
+		return 0
+	}
+	return cfg.RootAttributionLimit
+}
+
 func parseNixPolicyDuration(raw string, fallback time.Duration) time.Duration {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -479,6 +545,138 @@ func parseNixGenerations(output, scope, profile string) ([]nixGeneration, error)
 	}
 
 	return generations, nil
+}
+
+func parseNixGCRoots(output string) []nixGCRoot {
+	var roots []nixGCRoot
+	seen := map[string]bool{}
+
+	for _, rawLine := range strings.Split(output, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+
+		root := line
+		storePath := ""
+		if before, after, ok := strings.Cut(line, " -> "); ok {
+			root = strings.TrimSpace(before)
+			storePath = strings.TrimSpace(after)
+		} else {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				root = fields[0]
+				storePath = fields[len(fields)-1]
+			}
+		}
+		if root == "" {
+			continue
+		}
+
+		key := root + "\x00" + storePath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		class, active := classifyNixGCRoot(root)
+		roots = append(roots, nixGCRoot{
+			Root:      root,
+			StorePath: storePath,
+			Class:     class,
+			Active:    active,
+		})
+	}
+
+	sort.Slice(roots, func(i, j int) bool {
+		if roots[i].Class == roots[j].Class {
+			return roots[i].Root < roots[j].Root
+		}
+		return roots[i].Class < roots[j].Class
+	})
+	return roots
+}
+
+func classifyNixGCRoot(root string) (string, bool) {
+	lower := strings.ToLower(root)
+
+	switch {
+	case strings.HasPrefix(root, "/proc/"):
+		return "process_root", true
+	case strings.Contains(lower, "/profiles/per-user/") ||
+		strings.Contains(lower, "/nix/var/nix/profiles") ||
+		strings.Contains(lower, "/.local/state/nix/profiles") ||
+		strings.Contains(lower, "/.nix-profile"):
+		return "profile_root", false
+	case strings.Contains(lower, "/gcroots/auto/"):
+		return "auto_gcroot", false
+	case strings.Contains(lower, "/gcroots/"):
+		return "gcroot", false
+	case strings.HasSuffix(root, "/result") ||
+		strings.Contains(root, "/result-"):
+		return "workspace_result", false
+	case strings.Contains(lower, "/var/folders/") ||
+		strings.Contains(lower, "/tmp/"):
+		return "temporary_root", false
+	default:
+		return "unknown_root", false
+	}
+}
+
+func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
+	if limit <= 0 || len(roots) == 0 {
+		return nil
+	}
+
+	if limit > len(roots) {
+		limit = len(roots)
+	}
+
+	targets := make([]CleanupTarget, 0, limit)
+	for _, root := range roots[:limit] {
+		reason := "visible Nix GC root retaining store path"
+		if root.StorePath != "" {
+			reason = fmt.Sprintf("%s %s", reason, filepath.Base(root.StorePath))
+		}
+		name := fmt.Sprintf("%s %s", root.Class, filepath.Base(root.Root))
+		if root.Active {
+			reason = "active process root; review the owning process before any Nix GC action"
+		}
+
+		targets = append(targets, CleanupTarget{
+			Type:      "nix_gc_root",
+			Name:      name,
+			Path:      root.Root,
+			Active:    root.Active,
+			Protected: true,
+			Action:    "review_gc_root",
+			Reason:    reason,
+		})
+	}
+	return targets
+}
+
+func nixGCRootClassSummary(roots []nixGCRoot) string {
+	if len(roots) == 0 {
+		return ""
+	}
+
+	counts := map[string]int{}
+	for _, root := range roots {
+		counts[root.Class]++
+	}
+
+	classes := make([]string, 0, len(counts))
+	for class := range counts {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+
+	parts := make([]string, 0, len(classes))
+	for _, class := range classes {
+		parts = append(parts, fmt.Sprintf("%s=%d", class, counts[class]))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func nixGenerationTargets(generations []nixGeneration, now time.Time, minKeep int, olderThan time.Duration) []CleanupTarget {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -105,6 +105,73 @@ func TestParseNixGenerations(t *testing.T) {
 	}
 }
 
+func TestParseNixGCRoots(t *testing.T) {
+	output := `
+/proc/1234/fd/5 -> /nix/store/111-source
+/nix/var/nix/profiles/per-user/jess/profile-42-link -> /nix/store/222-home-manager-generation
+/nix/var/nix/gcroots/auto/abc -> /nix/store/333-tool
+/Users/jess/git/kernel/result -> /nix/store/444-linux-kernel
+/proc/1234/fd/5 -> /nix/store/111-source
+`
+
+	roots := parseNixGCRoots(output)
+	if len(roots) != 4 {
+		t.Fatalf("got %d roots, want 4: %#v", len(roots), roots)
+	}
+
+	classes := map[string]int{}
+	active := 0
+	for _, root := range roots {
+		classes[root.Class]++
+		if root.Active {
+			active++
+		}
+	}
+
+	if classes["process_root"] != 1 {
+		t.Fatalf("expected one process root, classes=%v", classes)
+	}
+	if classes["profile_root"] != 1 {
+		t.Fatalf("expected one profile root, classes=%v", classes)
+	}
+	if classes["auto_gcroot"] != 1 {
+		t.Fatalf("expected one auto gcroot, classes=%v", classes)
+	}
+	if classes["workspace_result"] != 1 {
+		t.Fatalf("expected one workspace result root, classes=%v", classes)
+	}
+	if active != 1 {
+		t.Fatalf("expected one active root, got %d", active)
+	}
+}
+
+func TestNixGCRootTargetsAreProtectedAndLimited(t *testing.T) {
+	roots := []nixGCRoot{
+		{
+			Root:      "/proc/1234/fd/5",
+			StorePath: "/nix/store/111-source",
+			Class:     "process_root",
+			Active:    true,
+		},
+		{
+			Root:      "/Users/jess/git/kernel/result",
+			StorePath: "/nix/store/444-linux-kernel",
+			Class:     "workspace_result",
+		},
+	}
+
+	targets := nixGCRootTargets(roots, 1)
+	if len(targets) != 1 {
+		t.Fatalf("got %d targets, want 1", len(targets))
+	}
+	if targets[0].Action != "review_gc_root" || !targets[0].Protected {
+		t.Fatalf("GC root target should be protected review-only: %+v", targets[0])
+	}
+	if !targets[0].Active {
+		t.Fatalf("process GC root should be marked active: %+v", targets[0])
+	}
+}
+
 func TestNixGenerationTargetsPreserveCurrentAndMinimum(t *testing.T) {
 	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 	generations := []nixGeneration{


### PR DESCRIPTION

## Summary

Adds non-mutating Nix GC-root attribution when `nix-collect-garbage --dry-run` reports no reclaimable store space.

The dry-run plan now reports protected `nix_gc_root` targets from `nix-store --gc --print-roots`, classifies common root families such as profiles, gcroots, workspace result links, temporary roots, and process roots, and caps the target list with `nix.root_attribution_limit`.

## Operator impact

This gives Darwin and Rocky operators evidence about what is pinning the Nix store before any cleanup action. It is review-only and does not delete roots or run GC beyond the existing dry-run preflight.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./config ./plugins`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `nix build .#default --no-link --print-build-logs`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
