### PR TITLE
Add text cleanup reports

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     name = "tinyland-cleanup_lib",
     srcs = [
         "main.go",
+        "report_text.go",
         "state.go",
     ] + select({
         "@platforms//os:macos": ["plugins_darwin.go"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to this project will be documented in this file.
   Bazelisk, and pip cache targets.
 - Nix low-reclaim dry-runs now emit protected GC-root attribution targets so
   operators can see what is pinning the store before taking action.
+- Human-readable `--output text` reports now explain dry-run and cleanup cycles
+  with mount status, host free-space accounting, plugin plans, warnings, and
+  representative targets.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ BAZEL_REMOTE_CACHE=grpc://bazel-cache.nix-cache.svc.cluster.local:9092 \
 Review the cleanup plan before mutating a high-pressure machine:
 
 ```sh
+tinyland-cleanup --once --dry-run --level critical --output text
+```
+
+Use JSON when another tool needs the stable report schema:
+
+```sh
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -7,6 +7,16 @@ Use this workflow when a developer machine or runner is under disk pressure.
 Start with a dry-run at the pressure level you are considering:
 
 ```sh
+tinyland-cleanup --once --dry-run --level critical --output text
+```
+
+The text report is the operator explain view. It summarizes the selected level,
+monitored mounts, host free-space accounting, target free-space deficit, plugin
+plans, warnings, and the first few cleanup targets for review.
+
+Use JSON when another tool needs the stable report schema:
+
+```sh
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
 
@@ -32,10 +42,10 @@ level during a real cleanup cycle.
 After reviewing the plan, run the same level without `--dry-run`:
 
 ```sh
-tinyland-cleanup --once --level critical --output json
+tinyland-cleanup --once --level critical --output text
 ```
 
-The report distinguishes:
+Use `--output json` for automation. The report distinguishes:
 
 - `bytes_freed`: the legacy aggregate byte count reported by the plugin;
 - `estimated_bytes_freed`: bytes based on local size estimates, when a plugin

--- a/main.go
+++ b/main.go
@@ -573,12 +573,15 @@ func (d *daemon) primaryMonitorPath(assessment mountAssessment) string {
 }
 
 func (d *daemon) writeReport(report cycleReport) error {
-	if d.output != "json" {
-		return nil
+	if d.output == "json" {
+		encoder := json.NewEncoder(d.report)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
 	}
-	encoder := json.NewEncoder(d.report)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(report)
+	if d.output == "text" {
+		return writeTextReport(d.report, report)
+	}
+	return nil
 }
 
 func (d *daemon) getDiskStats(path string) (*monitor.DiskStats, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,6 +106,53 @@ func TestRunOnceDryRunJSONReportIncludesPluginPlan(t *testing.T) {
 	}
 	if report.PlannedTargets != 2 {
 		t.Fatalf("expected 2 planned targets, got %d", report.PlannedTargets)
+	}
+}
+
+func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
+	var output bytes.Buffer
+	mock := &planningPlugin{
+		reportingPlugin: reportingPlugin{},
+		plan: plugins.CleanupPlan{
+			Plugin:              "reporting",
+			Level:               "critical",
+			Summary:             "reporting dry-run plan",
+			WouldRun:            true,
+			EstimatedBytesFreed: 1024 * 1024,
+			Targets: []plugins.CleanupTarget{
+				{
+					Type:      "cache",
+					Name:      "example-cache",
+					Bytes:     1024,
+					Protected: true,
+					Action:    "review",
+					Reason:    "operator review required",
+				},
+			},
+			Warnings: []string{"review before cleanup"},
+		},
+	}
+	daemon := newTestDaemon(t, mock, &output)
+	daemon.dryRun = true
+	daemon.output = "text"
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelCritical); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	text := output.String()
+	for _, want := range []string{
+		"tinyland-cleanup dry-run report",
+		"level: critical (forced)",
+		"plan: estimated reclaim 1.0 MiB",
+		"- reporting: would run (dry_run)",
+		"reporting dry-run plan",
+		"example-cache [cache]: review, protected, 1.0 KiB - operator review required",
+		"review before cleanup",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("text report missing %q:\n%s", want, text)
+		}
 	}
 }
 

--- a/report_text.go
+++ b/report_text.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Jesssullivan/tinyland-cleanup/monitor"
+	"github.com/Jesssullivan/tinyland-cleanup/plugins"
+)
+
+func writeTextReport(w io.Writer, report cycleReport) error {
+	mode := "cleanup"
+	if report.DryRun {
+		mode = "dry-run"
+	}
+	if report.Level == monitor.LevelNone.String() {
+		mode = "monitor"
+	}
+
+	if _, err := fmt.Fprintf(w, "tinyland-cleanup %s report\n", mode); err != nil {
+		return err
+	}
+	if report.Timestamp != "" {
+		if _, err := fmt.Fprintf(w, "time: %s\n", report.Timestamp); err != nil {
+			return err
+		}
+	}
+
+	levelLine := fmt.Sprintf("level: %s", report.Level)
+	if report.ForcedLevel {
+		levelLine += " (forced)"
+	}
+	if _, err := fmt.Fprintln(w, levelLine); err != nil {
+		return err
+	}
+
+	if report.MonitorPath != "" {
+		if _, err := fmt.Fprintf(w, "monitor: %s\n", report.MonitorPath); err != nil {
+			return err
+		}
+	}
+	if report.HostFreeError != "" {
+		if _, err := fmt.Fprintf(w, "host free: unavailable (%s)\n", report.HostFreeError); err != nil {
+			return err
+		}
+	} else if report.HostFreeBeforeBytes > 0 || report.HostFreeAfterBytes > 0 {
+		after := "not measured"
+		if report.HostFreeAfterBytes > 0 {
+			after = formatByteCount(int64(report.HostFreeAfterBytes))
+		}
+		if _, err := fmt.Fprintf(w, "host free: %s before, %s after, delta %s\n",
+			formatByteCount(int64(report.HostFreeBeforeBytes)),
+			after,
+			formatSignedByteCount(report.HostFreeDeltaBytes),
+		); err != nil {
+			return err
+		}
+	}
+
+	if report.TargetUsedPercent > 0 {
+		if _, err := fmt.Fprintf(w, "target: <=%d%% used, need %s free, deficit %s\n",
+			report.TargetUsedPercent,
+			formatByteCount(int64(report.TargetFreeBytes)),
+			formatByteCount(report.TargetFreeDeficitBytes),
+		); err != nil {
+			return err
+		}
+	}
+	if report.StopReason != "" {
+		if _, err := fmt.Fprintf(w, "stop: %s\n", report.StopReason); err != nil {
+			return err
+		}
+	}
+
+	if len(report.Mounts) > 0 {
+		if _, err := fmt.Fprintln(w, "mounts:"); err != nil {
+			return err
+		}
+		for _, mount := range report.Mounts {
+			label := mount.Label
+			if label == "" {
+				label = mount.Path
+			}
+			if mount.Error != "" {
+				if _, err := fmt.Fprintf(w, "- %s (%s): unavailable (%s)\n", label, mount.Path, mount.Error); err != nil {
+					return err
+				}
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "- %s (%s): %.1f%% used, %s free, level %s\n",
+				label,
+				mount.Path,
+				mount.UsedPercent,
+				formatByteCount(int64(mount.FreeBytes)),
+				mount.Level,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	if report.PlannedEstimatedBytesFreed > 0 || report.PlannedRequiredFreeBytes > 0 || report.PlannedTargets > 0 {
+		if _, err := fmt.Fprintf(w, "plan: estimated reclaim %s, required free %s, targets %d\n",
+			formatByteCount(report.PlannedEstimatedBytesFreed),
+			formatByteCount(report.PlannedRequiredFreeBytes),
+			report.PlannedTargets,
+		); err != nil {
+			return err
+		}
+	}
+	if !report.DryRun && (report.TotalBytesFreed > 0 || report.TotalItemsCleaned > 0) {
+		if _, err := fmt.Fprintf(w, "cleaned: %s across %d items\n",
+			formatByteCount(report.TotalBytesFreed),
+			report.TotalItemsCleaned,
+		); err != nil {
+			return err
+		}
+	}
+
+	if len(report.Plugins) == 0 {
+		return nil
+	}
+
+	if _, err := fmt.Fprintln(w, "plugins:"); err != nil {
+		return err
+	}
+	for _, plugin := range report.Plugins {
+		if err := writeTextPluginReport(w, plugin); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTextPluginReport(w io.Writer, plugin pluginCycleReport) error {
+	status := "would run"
+	if !plugin.WouldRun {
+		status = "skipped"
+	}
+	if plugin.SkipReason != "" {
+		status += " (" + plugin.SkipReason + ")"
+	}
+
+	if _, err := fmt.Fprintf(w, "- %s: %s\n", plugin.Name, status); err != nil {
+		return err
+	}
+
+	if plugin.Plan != nil {
+		plan := plugin.Plan
+		if plan.Summary != "" {
+			if _, err := fmt.Fprintf(w, "  plan: %s\n", plan.Summary); err != nil {
+				return err
+			}
+		}
+		if !plan.WouldRun && plan.SkipReason != "" {
+			if _, err := fmt.Fprintf(w, "  plan skip: %s\n", plan.SkipReason); err != nil {
+				return err
+			}
+		}
+		if plan.EstimatedBytesFreed > 0 || plan.RequiredFreeBytes > 0 || len(plan.Targets) > 0 {
+			if _, err := fmt.Fprintf(w, "  estimate: %s reclaim, %s required free, %d targets\n",
+				formatByteCount(plan.EstimatedBytesFreed),
+				formatByteCount(plan.RequiredFreeBytes),
+				len(plan.Targets),
+			); err != nil {
+				return err
+			}
+		}
+		if len(plan.Warnings) > 0 {
+			if err := writeTextList(w, "  warnings:", plan.Warnings, 3); err != nil {
+				return err
+			}
+		}
+		if len(plan.Targets) > 0 {
+			if _, err := fmt.Fprintln(w, "  targets:"); err != nil {
+				return err
+			}
+			for idx, target := range plan.Targets {
+				if idx >= 5 {
+					if _, err := fmt.Fprintf(w, "  - ... %d more targets\n", len(plan.Targets)-idx); err != nil {
+						return err
+					}
+					break
+				}
+				if err := writeTextTarget(w, target); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	if plugin.Error != "" {
+		if _, err := fmt.Fprintf(w, "  error: %s\n", plugin.Error); err != nil {
+			return err
+		}
+	}
+	if plugin.CooldownRemainingSeconds > 0 {
+		if _, err := fmt.Fprintf(w, "  cooldown remaining: %ds\n", plugin.CooldownRemainingSeconds); err != nil {
+			return err
+		}
+	}
+	if plugin.BytesFreed > 0 || plugin.ItemsCleaned > 0 {
+		if _, err := fmt.Fprintf(w, "  cleaned: %s across %d items\n",
+			formatByteCount(plugin.BytesFreed),
+			plugin.ItemsCleaned,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTextList(w io.Writer, header string, items []string, limit int) error {
+	if _, err := fmt.Fprintln(w, header); err != nil {
+		return err
+	}
+	for idx, item := range items {
+		if idx >= limit {
+			if _, err := fmt.Fprintf(w, "  - ... %d more\n", len(items)-idx); err != nil {
+				return err
+			}
+			break
+		}
+		if _, err := fmt.Fprintf(w, "  - %s\n", item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTextTarget(w io.Writer, target plugins.CleanupTarget) error {
+	status := target.Action
+	if target.Protected {
+		status += ", protected"
+	}
+	if target.Active {
+		status += ", active"
+	}
+
+	name := target.Name
+	if name == "" {
+		name = target.Path
+	}
+	if name == "" {
+		name = target.Type
+	}
+
+	if _, err := fmt.Fprintf(w, "  - %s [%s]: %s", name, target.Type, status); err != nil {
+		return err
+	}
+	if target.Bytes > 0 {
+		if _, err := fmt.Fprintf(w, ", %s", formatByteCount(target.Bytes)); err != nil {
+			return err
+		}
+	}
+	if target.Reason != "" {
+		if _, err := fmt.Fprintf(w, " - %s", target.Reason); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(w)
+	return err
+}
+
+func formatSignedByteCount(bytes int64) string {
+	if bytes < 0 {
+		return "-" + formatByteCount(-bytes)
+	}
+	if bytes > 0 {
+		return "+" + formatByteCount(bytes)
+	}
+	return "0 B"
+}
+
+func formatByteCount(bytes int64) string {
+	if bytes <= 0 {
+		return "0 B"
+	}
+
+	value := float64(bytes)
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB"}
+	unit := 0
+	for value >= 1024 && unit < len(units)-1 {
+		value /= 1024
+		unit++
+	}
+	if unit == 0 {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	return fmt.Sprintf("%.1f %s", value, units[unit])
+}


### PR DESCRIPTION

## Summary

Adds a human-readable `--output text` report for dry-run and cleanup cycles.

The text report summarizes the selected level, monitor path, mount status, host free-space accounting, target free-space deficit, aggregate dry-run plan totals, plugin status, warnings, and representative cleanup targets. JSON remains the stable automation interface.

## Operator impact

Operators can review a high-pressure machine with:

```sh
tinyland-cleanup --once --dry-run --level critical --output text
```

Automation can keep using `--output json` with the existing schema.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test .`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `nix build .#default --no-link --print-build-logs`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
