### PR TITLE
Add target used CLI override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this project will be documented in this file.
 - Human-readable `--output text` reports now explain dry-run and cleanup cycles
   with mount status, host free-space accounting, plugin plans, warnings, and
   representative targets.
+- CLI `--target-used-percent` override for one-off cleanup runs without editing
+  config.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Use JSON when another tool needs the stable report schema:
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
 
+For a one-off run, override the configured maximum used-space target without
+editing the config file:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --target-used-percent 82
+```
+
 See [docs/operator-workflow.md](docs/operator-workflow.md) for the current
 dry-run and host free-space accounting workflow.
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -20,6 +20,13 @@ Use JSON when another tool needs the stable report schema:
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
 
+For a one-off operator run, override the configured maximum used-space target
+without editing config:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --target-used-percent 82
+```
+
 The JSON report includes:
 
 - the selected cleanup level;

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@
 //	-level string     Force cleanup level: none, warning, moderate, aggressive, critical
 //	-dry-run          Show what would be cleaned without actually cleaning
 //	-output string    Output format: text, json (default: text)
+//	-target-used-percent int
+//	                 Override target maximum used-space percentage after cleanup
 //	-verbose          Enable verbose logging
 //	-version          Print version and exit
 package main
@@ -54,6 +56,7 @@ func main() {
 		level       = flag.String("level", "", "Force cleanup level")
 		dryRun      = flag.Bool("dry-run", false, "Show what would be cleaned")
 		output      = flag.String("output", "text", "Output format: text, json")
+		targetUsed  = flag.Int("target-used-percent", 0, "Override target maximum used-space percentage after cleanup")
 		verbose     = flag.Bool("verbose", false, "Enable verbose logging")
 		showVersion = flag.Bool("version", false, "Print version and exit")
 	)
@@ -80,6 +83,10 @@ func main() {
 		// Fall back to stderr logging if config fails
 		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
 		os.Exit(1)
+	}
+	if err := applyTargetUsedPercentOverride(cfg, *targetUsed); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
 	}
 
 	// Setup log file directory
@@ -663,6 +670,17 @@ func targetFreeBytes(totalBytes uint64, targetUsedPercent int) (uint64, bool) {
 
 	freePercent := 100 - targetUsedPercent
 	return totalBytes * uint64(freePercent) / 100, true
+}
+
+func applyTargetUsedPercentOverride(cfg *config.Config, targetUsedPercent int) error {
+	if targetUsedPercent == 0 {
+		return nil
+	}
+	if targetUsedPercent <= 0 || targetUsedPercent >= 100 {
+		return fmt.Errorf("invalid target-used-percent %d: expected 1-99", targetUsedPercent)
+	}
+	cfg.TargetFree = targetUsedPercent
+	return nil
 }
 
 func expandPathHome(path string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -269,6 +269,31 @@ func TestRunOnceStopsAfterTargetFreeMet(t *testing.T) {
 	}
 }
 
+func TestApplyTargetUsedPercentOverride(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.TargetFree = 70
+
+	if err := applyTargetUsedPercentOverride(cfg, 82); err != nil {
+		t.Fatalf("override failed: %v", err)
+	}
+	if cfg.TargetFree != 82 {
+		t.Fatalf("expected target used percent 82, got %d", cfg.TargetFree)
+	}
+
+	if err := applyTargetUsedPercentOverride(cfg, 0); err != nil {
+		t.Fatalf("zero override should be ignored: %v", err)
+	}
+	if cfg.TargetFree != 82 {
+		t.Fatalf("zero override should preserve existing target, got %d", cfg.TargetFree)
+	}
+
+	for _, value := range []int{-1, 100} {
+		if err := applyTargetUsedPercentOverride(cfg, value); err == nil {
+			t.Fatalf("expected error for target override %d", value)
+		}
+	}
+}
+
 func TestRunOnceSkipsPluginDuringCooldown(t *testing.T) {
 	var output bytes.Buffer
 	mock := &reportingPlugin{}


### PR DESCRIPTION

## Summary

Adds a `--target-used-percent` CLI override for one-off cleanup and dry-run cycles.

The override updates the existing `target_free` policy value in memory for the current run only, with validation that the percentage is between 1 and 99. The config file remains unchanged.

## Operator impact

Operators can temporarily tighten or relax the target free-space policy without editing config:

```sh
tinyland-cleanup --once --dry-run --level critical --target-used-percent 82
```

The text and JSON reports continue to expose the resulting `target_used_percent`, target free bytes, and deficit.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test .`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `nix build .#default --no-link --print-build-logs`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
