### PR TITLE
Enforce Bazel cache tier budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to this project will be documented in this file.
   representative targets.
 - CLI `--target-used-percent` override for one-off cleanup runs without editing
   config.
+- Bazel cache-tier budget enforcement for stale repository cache, disk cache,
+  and Bazelisk download targets when total Bazel footprint exceeds the
+  configured budget.
 
 ### Changed
 

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -2,7 +2,8 @@
 
 Bazel cleanup reports output bases, repository caches, disk caches, and
 Bazelisk downloads. Real cleanup mode deletes only stale inactive output bases
-after active-process inspection succeeds.
+and budget-excess rebuildable cache tiers after active-process inspection
+succeeds.
 
 Review with:
 
@@ -51,13 +52,15 @@ Runtime boundary:
 - moderate, aggressive, and critical classify stale inactive output bases as
   `delete_output_base` candidates in dry-run output and delete those output
   bases in real cleanup mode;
+- moderate, aggressive, and critical classify stale repository cache, disk
+  cache, and Bazelisk download entries as `delete_cache_tier` only when the
+  total Bazel footprint exceeds `max_total_gb`;
 - real cleanup skips Bazel mutation if active Bazel process inspection fails;
+- cache-tier cleanup is skipped while active Bazel or Bazelisk work is visible;
 - deletion normalizes writable permissions first, and on Darwin attempts to
   clear `uchg` file flags with `chflags -R nouchg`;
 - byte counts use top-level allocation estimates so dry-run remains responsive
   on very large generated trees;
-- repository cache, disk cache, and Bazelisk entries are reported for budget
-  review but not deleted yet;
 - repo-local `bazel-*` symlink cleanup remains a follow-up after output-base
   deletion evidence is proven on real hosts.
 

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -79,7 +79,7 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 			"Discover Bazel output bases, repository caches, disk caches, and Bazelisk downloads",
 			"Measure logical and physical bytes without following repo-local bazel-* symlinks",
 			"Protect active output bases, protected workspace output bases, and newest output bases",
-			"Delete only stale inactive output bases in real cleanup mode at moderate or higher levels",
+			"Delete only stale inactive output bases and budget-excess cache tiers in real cleanup mode at moderate or higher levels",
 		},
 		Metadata: map[string]string{
 			"cleanup_level":                    level.String(),
@@ -106,11 +106,12 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 	plan.EstimatedBytesFreed = bazelEstimatedCandidateBytes(targets)
 	plan.Metadata["target_count"] = strconv.Itoa(len(targets))
 	plan.Metadata["total_physical_bytes"] = strconv.FormatInt(totalPhysical, 10)
+	plan.Metadata["budget_exceeded"] = strconv.FormatBool(bazelBudgetExceeded(totalPhysical, cfg.Bazel))
 
 	if cfg.Bazel.MaxTotalGB > 0 && totalPhysical > int64(cfg.Bazel.MaxTotalGB)*bazelGiB {
 		plan.Warnings = append(plan.Warnings, "detected Bazel cache footprint exceeds configured review budget")
 	}
-	plan.Warnings = append(plan.Warnings, "Bazel cleanup deletes only stale inactive output bases; repository, disk, and Bazelisk cache budget enforcement remains follow-up work")
+	plan.Warnings = append(plan.Warnings, "Bazel cleanup deletes rebuildable cache tiers only when the total footprint exceeds the configured budget and active-use inspection succeeds")
 	plan.Warnings = append(plan.Warnings, "Bazel byte counts use bounded top-level allocation estimates so dry-run stays responsive on very large output bases")
 
 	return plan, activeErr
@@ -262,8 +263,29 @@ func discoverBazeliskCandidates(root string) []bazelCandidate {
 	}
 
 	var candidates []bazelCandidate
+	shaDownloads := filepath.Join(root, "downloads", "sha256")
+	if entries, err := os.ReadDir(shaDownloads); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			path := filepath.Join(shaDownloads, entry.Name())
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			candidates = append(candidates, newBazelCandidate("bazelisk", filepath.Join("sha256", entry.Name()), path, info.ModTime()))
+		}
+	}
+
 	for _, entry := range entries {
 		if !entry.IsDir() {
+			continue
+		}
+		if len(candidates) > 0 && entry.Name() == "downloads" {
+			continue
+		}
+		if entry.Name() == "metadata" {
 			continue
 		}
 		path := filepath.Join(root, entry.Name())
@@ -401,10 +423,14 @@ func bazelPlanTargets(candidates []bazelCandidate, cfg config.BazelConfig, level
 
 	recentOutputBases := newestBazelOutputBases(candidates, cfg.KeepRecentOutputBases)
 	var totalPhysical int64
-	targets := make([]CleanupTarget, 0, len(candidates))
 	for _, candidate := range candidates {
 		totalPhysical += candidate.Physical
-		target := bazelTargetForCandidate(candidate, staleAfter, now, recentOutputBases[candidate.Path], globalActive, level, cfg)
+	}
+
+	budgetExceeded := bazelBudgetExceeded(totalPhysical, cfg)
+	targets := make([]CleanupTarget, 0, len(candidates))
+	for _, candidate := range candidates {
+		target := bazelTargetForCandidate(candidate, staleAfter, now, recentOutputBases[candidate.Path], globalActive, budgetExceeded, level, cfg)
 		targets = append(targets, target)
 	}
 
@@ -415,6 +441,10 @@ func bazelPlanTargets(candidates []bazelCandidate, cfg config.BazelConfig, level
 		return targets[i].Bytes > targets[j].Bytes
 	})
 	return targets, totalPhysical
+}
+
+func bazelBudgetExceeded(totalPhysical int64, cfg config.BazelConfig) bool {
+	return cfg.MaxTotalGB > 0 && totalPhysical > int64(cfg.MaxTotalGB)*bazelGiB
 }
 
 func newestBazelOutputBases(candidates []bazelCandidate, keep int) map[string]bool {
@@ -442,7 +472,7 @@ func newestBazelOutputBases(candidates []bazelCandidate, keep int) map[string]bo
 	return protected
 }
 
-func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration, now time.Time, protectedByRecent bool, globalActive bool, level CleanupLevel, cfg config.BazelConfig) CleanupTarget {
+func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration, now time.Time, protectedByRecent bool, globalActive bool, budgetExceeded bool, level CleanupLevel, cfg config.BazelConfig) CleanupTarget {
 	active := candidate.Active || globalActive
 	protected := candidate.Protected || protectedByRecent || (active && !cfg.AllowDeleteActiveOutputBases)
 	action := "review"
@@ -462,8 +492,17 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 		action = "review"
 		reason = "warning level reports Bazel cache footprint only"
 	case candidate.Type != "output_base":
-		action = "review_cache_budget"
-		reason = "cache tier budget enforcement is not enabled yet"
+		if !budgetExceeded {
+			action = "review_cache_budget"
+			reason = "within configured Bazel cache budget"
+		} else if candidate.ModTime.After(now.Add(-staleAfter)) {
+			action = "keep"
+			protected = true
+			reason = "newer than configured Bazel cache stale threshold"
+		} else {
+			action = "delete_cache_tier"
+			reason = "cache tier exceeds budget and is older than configured Bazel stale threshold"
+		}
 	case candidate.ModTime.After(now.Add(-staleAfter)):
 		action = "keep"
 		protected = true
@@ -505,24 +544,41 @@ func applyBazelCleanupTargets(ctx context.Context, plugin string, level CleanupL
 			result.Error = err
 			return result
 		}
-		if err := deleteBazelOutputBase(target.Path, logger); err != nil {
-			logger.Warn("failed to delete Bazel output base", "path", target.Path, "error", err)
+		if err := deleteBazelTarget(target, logger); err != nil {
+			logger.Warn("failed to delete Bazel target", "type", target.Type, "path", target.Path, "error", err)
 			continue
 		}
 		result.BytesFreed += target.Bytes
 		result.EstimatedBytesFreed += target.Bytes
 		result.ItemsCleaned++
-		logger.Info("deleted stale Bazel output base", "path", target.Path, "estimated_bytes", target.Bytes)
+		logger.Info("deleted Bazel cleanup target", "type", target.Type, "path", target.Path, "estimated_bytes", target.Bytes)
 	}
 	return result
 }
 
 func bazelTargetEligibleForDeletion(target CleanupTarget) bool {
-	return target.Type == "output_base" &&
-		target.Action == "delete_output_base" &&
-		target.Path != "" &&
-		!target.Active &&
-		!target.Protected
+	if target.Path == "" || target.Active || target.Protected {
+		return false
+	}
+	switch target.Action {
+	case "delete_output_base":
+		return target.Type == "output_base"
+	case "delete_cache_tier":
+		return target.Type == "repository_cache" || target.Type == "disk_cache" || target.Type == "bazelisk"
+	default:
+		return false
+	}
+}
+
+func deleteBazelTarget(target CleanupTarget, logger *slog.Logger) error {
+	switch target.Type {
+	case "output_base":
+		return deleteBazelOutputBase(target.Path, logger)
+	case "repository_cache", "disk_cache", "bazelisk":
+		return deleteBazelCacheTier(target.Type, target.Path, logger)
+	default:
+		return fmt.Errorf("refusing to delete unsupported Bazel target type %q", target.Type)
+	}
 }
 
 func deleteBazelOutputBase(path string, logger *slog.Logger) error {
@@ -533,6 +589,45 @@ func deleteBazelOutputBase(path string, logger *slog.Logger) error {
 		return err
 	}
 	return os.RemoveAll(path)
+}
+
+func deleteBazelCacheTier(targetType, path string, logger *slog.Logger) error {
+	if !bazelCacheTierPathAllowed(targetType, path) {
+		return fmt.Errorf("refusing to delete unsafe Bazel cache tier path: %s", path)
+	}
+	if err := normalizeBazelDeletionPermissions(path, logger); err != nil {
+		return err
+	}
+	return os.RemoveAll(path)
+}
+
+func bazelCacheTierPathAllowed(targetType, path string) bool {
+	path = filepath.Clean(path)
+	if path == "." || path == string(os.PathSeparator) {
+		return false
+	}
+
+	switch targetType {
+	case "repository_cache":
+		return filepath.Base(path) == "repository_cache"
+	case "disk_cache":
+		return filepath.Base(path) == "disk_cache"
+	case "bazelisk":
+		parts := strings.Split(path, string(os.PathSeparator))
+		for idx := 0; idx < len(parts)-1; idx++ {
+			if parts[idx] == "downloads" && parts[idx+1] == "sha256" && idx+2 < len(parts) {
+				return true
+			}
+		}
+		for idx, part := range parts {
+			if part == "bazelisk" && idx < len(parts)-1 {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
 }
 
 func normalizeBazelDeletionPermissions(root string, logger *slog.Logger) error {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -94,6 +94,125 @@ func TestBazelPlanTargetsProtectsRecentActiveAndWorkspaces(t *testing.T) {
 	}
 }
 
+func TestBazelPlanTargetsDeletesCacheTiersOnlyWhenBudgetExceeded(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cfg := config.BazelConfig{
+		MaxTotalGB:           1,
+		StaleAfter:           "14d",
+		CriticalStaleAfter:   "3d",
+		AllowStopIdleServers: true,
+	}
+	candidates := []bazelCandidate{
+		{
+			Type:     "repository_cache",
+			Name:     "repository_cache",
+			Path:     "/tmp/repository_cache",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+		},
+		{
+			Type:     "disk_cache",
+			Name:     "disk_cache",
+			Path:     "/tmp/disk_cache",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+		},
+		{
+			Type:     "bazelisk",
+			Name:     "sha256/hash",
+			Path:     "/tmp/bazelisk/downloads/sha256/hash",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+		},
+		{
+			Type:     "repository_cache",
+			Name:     "fresh_repository_cache",
+			Path:     "/tmp/fresh_repository_cache",
+			ModTime:  now.Add(-1 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+		},
+	}
+
+	targets, total := bazelPlanTargets(candidates, cfg, LevelModerate, now, false)
+	if total != 8*bazelGiB {
+		t.Fatalf("total physical = %d, want %d", total, 8*bazelGiB)
+	}
+
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Name] = target
+	}
+
+	for _, name := range []string{"repository_cache", "disk_cache", "sha256/hash"} {
+		if actions[name].Action != "delete_cache_tier" || actions[name].Protected {
+			t.Fatalf("%s target should be a cache-tier deletion candidate: %#v", name, actions[name])
+		}
+	}
+	if actions["fresh_repository_cache"].Action != "keep" || !actions["fresh_repository_cache"].Protected {
+		t.Fatalf("fresh cache tier should be kept: %#v", actions["fresh_repository_cache"])
+	}
+
+	cfg.MaxTotalGB = 20
+	targets, _ = bazelPlanTargets(candidates[:1], cfg, LevelModerate, now, false)
+	if len(targets) != 1 {
+		t.Fatalf("expected one target, got %d", len(targets))
+	}
+	if targets[0].Action != "review_cache_budget" {
+		t.Fatalf("within-budget cache tier action = %q, want review_cache_budget", targets[0].Action)
+	}
+}
+
+func TestBazelPlanTargetsProtectsCacheTiersWhenBazelActive(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cfg := config.BazelConfig{
+		MaxTotalGB:                   1,
+		StaleAfter:                   "14d",
+		AllowDeleteActiveOutputBases: false,
+		KeepRecentOutputBases:        0,
+		CriticalStaleAfter:           "3d",
+	}
+	candidates := []bazelCandidate{
+		{
+			Type:     "disk_cache",
+			Name:     "disk_cache",
+			Path:     "/tmp/disk_cache",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+		},
+	}
+
+	targets, _ := bazelPlanTargets(candidates, cfg, LevelModerate, now, true)
+	if len(targets) != 1 {
+		t.Fatalf("expected one target, got %d", len(targets))
+	}
+	if targets[0].Action != "keep" || !targets[0].Protected || !targets[0].Active {
+		t.Fatalf("active cache tier should be protected: %#v", targets[0])
+	}
+}
+
+func TestDiscoverBazeliskCandidatesPrefersSha256Downloads(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "bazelisk")
+	sha := filepath.Join(root, "downloads", "sha256", "abc123")
+	metadata := filepath.Join(root, "downloads", "metadata", "bazelbuild")
+	mustMkdir(t, sha)
+	mustMkdir(t, metadata)
+
+	candidates := discoverBazeliskCandidates(root)
+	if len(candidates) != 1 {
+		t.Fatalf("got %d candidates, want 1: %#v", len(candidates), candidates)
+	}
+	if candidates[0].Type != "bazelisk" || candidates[0].Name != filepath.Join("sha256", "abc123") {
+		t.Fatalf("unexpected Bazelisk candidate: %#v", candidates[0])
+	}
+	resolvedSha, err := filepath.EvalSymlinks(sha)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidates[0].Path != resolvedSha {
+		t.Fatalf("candidate path = %q, want %q", candidates[0].Path, resolvedSha)
+	}
+}
+
 func TestOutputBasesProtectedByWorkspaces(t *testing.T) {
 	root := t.TempDir()
 	outputBase := filepath.Join(root, "_bazel_jess", "abc123")
@@ -172,6 +291,87 @@ func TestApplyBazelCleanupTargetsDeletesEligibleOutputBase(t *testing.T) {
 	}
 	if _, err := os.Stat(outputBase); !os.IsNotExist(err) {
 		t.Fatalf("expected output base to be deleted, stat err=%v", err)
+	}
+}
+
+func TestApplyBazelCleanupTargetsDeletesEligibleCacheTier(t *testing.T) {
+	root := t.TempDir()
+	repositoryCache := filepath.Join(root, "repository_cache")
+	mustMkdir(t, repositoryCache)
+	if err := os.WriteFile(filepath.Join(repositoryCache, "artifact"), []byte("artifact"), 0400); err != nil {
+		t.Fatal(err)
+	}
+
+	bazeliskEntry := filepath.Join(root, "bazelisk", "downloads", "sha256", "abc123")
+	mustMkdir(t, bazeliskEntry)
+	if err := os.WriteFile(filepath.Join(bazeliskEntry, "bazel"), []byte("binary"), 0400); err != nil {
+		t.Fatal(err)
+	}
+	customBazeliskEntry := filepath.Join(root, "custom-bazelisk-home", "downloads", "sha256", "def456")
+	mustMkdir(t, customBazeliskEntry)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := applyBazelCleanupTargets(context.Background(), "bazel", LevelModerate, []CleanupTarget{
+		{
+			Type:   "repository_cache",
+			Name:   "repository_cache",
+			Path:   repositoryCache,
+			Bytes:  11,
+			Action: "delete_cache_tier",
+		},
+		{
+			Type:   "bazelisk",
+			Name:   "sha256/abc123",
+			Path:   bazeliskEntry,
+			Bytes:  13,
+			Action: "delete_cache_tier",
+		},
+		{
+			Type:   "bazelisk",
+			Name:   "sha256/def456",
+			Path:   customBazeliskEntry,
+			Bytes:  17,
+			Action: "delete_cache_tier",
+		},
+	}, logger)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.ItemsCleaned != 3 {
+		t.Fatalf("items cleaned = %d, want 3", result.ItemsCleaned)
+	}
+	if result.EstimatedBytesFreed != 41 || result.BytesFreed != 41 {
+		t.Fatalf("unexpected bytes: estimated=%d legacy=%d", result.EstimatedBytesFreed, result.BytesFreed)
+	}
+	for _, path := range []string{repositoryCache, bazeliskEntry, customBazeliskEntry} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be deleted, stat err=%v", path, err)
+		}
+	}
+}
+
+func TestApplyBazelCleanupTargetsRejectsUnsafeCacheTierPath(t *testing.T) {
+	root := t.TempDir()
+	unsafe := filepath.Join(root, "not_repository_cache")
+	mustMkdir(t, unsafe)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := applyBazelCleanupTargets(context.Background(), "bazel", LevelModerate, []CleanupTarget{
+		{
+			Type:   "repository_cache",
+			Name:   "unsafe",
+			Path:   unsafe,
+			Bytes:  10,
+			Action: "delete_cache_tier",
+		},
+	}, logger)
+
+	if result.ItemsCleaned != 0 {
+		t.Fatalf("items cleaned = %d, want 0", result.ItemsCleaned)
+	}
+	if _, err := os.Stat(unsafe); err != nil {
+		t.Fatalf("unsafe path should remain, err=%v", err)
 	}
 }
 


### PR DESCRIPTION

## Summary

Adds budget-gated real cleanup for rebuildable Bazel cache tiers.

The Bazel planner now marks stale repository cache, disk cache, and Bazelisk download targets as `delete_cache_tier` only when the total Bazel footprint exceeds `bazel.max_total_gb`. Active Bazel or Bazelisk work still protects all targets, warning level remains report-only, and output-base deletion keeps its existing safety checks.

## Safety details

- Real cleanup still skips Bazel mutation if active-process inspection fails.
- Cache-tier deletion is gated by budget pressure, stale age, active-use protection, and path-shape guards.
- Bazelisk discovery prefers individual `downloads/sha256/*` entries instead of deleting the broader downloads directory when that layout is visible.
- Repository and disk cache deletion require expected cache directory basenames.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `nix build .#default --no-link --print-build-logs`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
