### PR TITLE
Add Darwin editor cache targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ All notable changes to this project will be documented in this file.
   configured budget.
 - Active-process protection for development artifact cleanup families such as
   Node.js, Python, Rust, Go, Haskell, and LM Studio.
+- Typed Darwin developer-cache targets for VS Code and Cursor cache-only
+  directories, with active-editor protection.
 
 ### Changed
 

--- a/config/config.go
+++ b/config/config.go
@@ -273,6 +273,10 @@ type DarwinDevCachesConfig struct {
 	Bazelisk DarwinDevCacheToolConfig `yaml:"bazelisk"`
 	// Pip controls pip cache planning.
 	Pip DarwinDevCacheToolConfig `yaml:"pip"`
+	// VSCode controls Visual Studio Code cache planning.
+	VSCode DarwinDevCacheToolConfig `yaml:"vscode"`
+	// Cursor controls Cursor cache planning.
+	Cursor DarwinDevCacheToolConfig `yaml:"cursor"`
 }
 
 // DarwinDevCacheToolConfig holds per-tool cache budget settings.
@@ -435,6 +439,18 @@ func DefaultConfig() *Config {
 			Pip: DarwinDevCacheToolConfig{
 				Enabled:        true,
 				StaleAfterDays: 14,
+			},
+			VSCode: DarwinDevCacheToolConfig{
+				Enabled:            true,
+				MaxGB:              4,
+				StaleAfterDays:     14,
+				KeepActiveVersions: true,
+			},
+			Cursor: DarwinDevCacheToolConfig{
+				Enabled:            true,
+				MaxGB:              4,
+				StaleAfterDays:     14,
+				KeepActiveVersions: true,
 			},
 		},
 		APFS: APFSConfig{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -335,6 +335,24 @@ func TestDarwinDevCacheDefaults(t *testing.T) {
 	if cfg.DarwinDevCaches.Bazelisk.KeepLatest != 2 {
 		t.Errorf("DarwinDevCaches.Bazelisk.KeepLatest should default to 2, got %d", cfg.DarwinDevCaches.Bazelisk.KeepLatest)
 	}
+	if !cfg.DarwinDevCaches.VSCode.Enabled {
+		t.Error("DarwinDevCaches.VSCode.Enabled should default to true")
+	}
+	if cfg.DarwinDevCaches.VSCode.StaleAfterDays != 14 {
+		t.Errorf("DarwinDevCaches.VSCode.StaleAfterDays should default to 14, got %d", cfg.DarwinDevCaches.VSCode.StaleAfterDays)
+	}
+	if !cfg.DarwinDevCaches.VSCode.KeepActiveVersions {
+		t.Error("DarwinDevCaches.VSCode.KeepActiveVersions should default to true")
+	}
+	if !cfg.DarwinDevCaches.Cursor.Enabled {
+		t.Error("DarwinDevCaches.Cursor.Enabled should default to true")
+	}
+	if cfg.DarwinDevCaches.Cursor.StaleAfterDays != 14 {
+		t.Errorf("DarwinDevCaches.Cursor.StaleAfterDays should default to 14, got %d", cfg.DarwinDevCaches.Cursor.StaleAfterDays)
+	}
+	if !cfg.DarwinDevCaches.Cursor.KeepActiveVersions {
+		t.Error("DarwinDevCaches.Cursor.KeepActiveVersions should default to true")
+	}
 }
 
 func TestLoadConfigWithNewFields(t *testing.T) {
@@ -411,6 +429,13 @@ darwin_dev_caches:
   pip:
     enabled: true
     stale_after_days: 7
+  vscode:
+    enabled: true
+    stale_after_days: 10
+    keep_active_versions: false
+  cursor:
+    enabled: false
+    stale_after_days: 5
 `
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -546,5 +571,17 @@ darwin_dev_caches:
 	}
 	if cfg.DarwinDevCaches.Pip.StaleAfterDays != 7 {
 		t.Errorf("DarwinDevCaches.Pip.StaleAfterDays should be 7 per config, got %d", cfg.DarwinDevCaches.Pip.StaleAfterDays)
+	}
+	if cfg.DarwinDevCaches.VSCode.StaleAfterDays != 10 {
+		t.Errorf("DarwinDevCaches.VSCode.StaleAfterDays should be 10 per config, got %d", cfg.DarwinDevCaches.VSCode.StaleAfterDays)
+	}
+	if cfg.DarwinDevCaches.VSCode.KeepActiveVersions {
+		t.Error("DarwinDevCaches.VSCode.KeepActiveVersions should be false per config")
+	}
+	if cfg.DarwinDevCaches.Cursor.Enabled {
+		t.Error("DarwinDevCaches.Cursor.Enabled should be false per config")
+	}
+	if cfg.DarwinDevCaches.Cursor.StaleAfterDays != 5 {
+		t.Errorf("DarwinDevCaches.Cursor.StaleAfterDays should be 5 per config, got %d", cfg.DarwinDevCaches.Cursor.StaleAfterDays)
 	}
 }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -127,6 +127,16 @@ darwin_dev_caches:
   pip:
     enabled: true
     stale_after_days: 14
+  vscode:
+    enabled: true
+    max_gb: 4
+    stale_after_days: 14
+    keep_active_versions: true
+  cursor:
+    enabled: true
+    max_gb: 4
+    stale_after_days: 14
+    keep_active_versions: true
 
 # Lima VM settings (macOS)
 lima:

--- a/docs/darwin-dev-caches.md
+++ b/docs/darwin-dev-caches.md
@@ -15,7 +15,11 @@ The cache plugin plan includes `targets` for known cache families:
 - `jetbrains`: versioned directories under `~/Library/Caches/JetBrains`;
 - `playwright`: browser revisions under `~/Library/Caches/ms-playwright`;
 - `bazelisk`: downloads under `~/Library/Caches/bazelisk`;
-- `pip`: caches under `~/Library/Caches/pip` and `~/.cache/pip`.
+- `pip`: caches under `~/Library/Caches/pip` and `~/.cache/pip`;
+- `vscode-cache`: selected VS Code cache directories such as `Cache`,
+  `CachedData`, `Code Cache`, `GPUCache`, and service worker cache storage;
+- `cursor-cache`: selected Cursor cache directories with the same cache-only
+  boundary.
 
 Targets include the cache type, name, detected version, path, physical bytes,
 active-use evidence, protected status, review action, and reason.
@@ -24,8 +28,11 @@ Safety boundaries:
 
 - never remove `~/Library/Application Support/JetBrains`;
 - never remove project workspaces;
-- never remove keychains, auth databases, editor settings, or extension config;
+- never remove keychains, auth databases, editor settings, extension config, or
+  `User` settings directories;
 - protect active JetBrains IDE versions when matching processes are running;
+- protect VS Code and Cursor cache targets when matching editor processes are
+  running;
 - protect newest Playwright browser revisions per browser family;
 - protect the newest Bazelisk cache entries.
 
@@ -39,7 +46,8 @@ darwin_dev_caches:
 ```
 
 When `enforce: true`, moderate cleanup can delete unprotected Playwright and
-Bazelisk entries outside the keep-latest policy and stale pip caches. Aggressive
-cleanup can delete inactive stale JetBrains cache versions. Critical cleanup can
-delete inactive unprotected JetBrains cache versions regardless of age. The same
-protected target rules from dry-run planning are used for real cleanup.
+Bazelisk entries outside the keep-latest policy, stale pip caches, and stale
+inactive editor cache directories. Aggressive cleanup can delete inactive stale
+JetBrains cache versions. Critical cleanup can delete inactive unprotected
+JetBrains and editor cache targets regardless of age. The same protected target
+rules from dry-run planning are used for real cleanup.

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -94,6 +94,9 @@ space.
 For Darwin IDE and tool caches, review
 [darwin-dev-caches.md](darwin-dev-caches.md). These targets are reported for
 operator review, and real deletion requires `darwin_dev_caches.enforce: true`.
+The typed surface covers cache-only JetBrains, Playwright, Bazelisk, pip, VS
+Code, and Cursor targets while preserving settings, extension data, credentials,
+and active editor or IDE processes.
 
 For workspace build artifacts, the `dev-artifacts` plan reports rebuildable
 targets such as `node_modules`, Python virtualenvs, Rust `target/` directories,

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -448,7 +448,7 @@ func (p *CachePlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *
 		Steps: []string{
 			"Measure known Darwin developer caches by physical allocation",
 			"Classify versioned tool caches by cache family and active-use evidence",
-			"Protect settings, application support data, project workspaces, credentials, and active IDE versions",
+			"Protect settings, extension data, application support data, project workspaces, credentials, and active editor or IDE versions",
 		},
 		Metadata: map[string]string{
 			"darwin_dev_caches_enabled": strconv.FormatBool(cfg.DarwinDevCaches.Enabled),
@@ -722,7 +722,85 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 		}
 	}
 
+	if cfg.VSCode.Enabled {
+		targets = append(targets, p.darwinEditorCacheTargets(home, cfg.VSCode, activeProcesses, level, enforce, "vscode-cache", "VS Code", "Code", []string{
+			"visual studio code",
+			"code helper",
+		})...)
+	}
+
+	if cfg.Cursor.Enabled {
+		targets = append(targets, p.darwinEditorCacheTargets(home, cfg.Cursor, activeProcesses, level, enforce, "cursor-cache", "Cursor", "Cursor", []string{
+			"cursor",
+			"cursor helper",
+		})...)
+	}
+
 	return targets
+}
+
+func (p *CachePlugin) darwinEditorCacheTargets(home string, cfg config.DarwinDevCacheToolConfig, activeProcesses map[string]bool, level CleanupLevel, enforce bool, targetType, displayName, appSupportName string, processNames []string) []CleanupTarget {
+	active := cfg.KeepActiveVersions && darwinAnyProcessActive(activeProcesses, processNames...)
+	targetPaths := darwinEditorCachePaths(home, appSupportName)
+	targets := make([]CleanupTarget, 0, len(targetPaths))
+
+	for _, path := range targetPaths {
+		if !pathExistsAndIsDir(path) {
+			continue
+		}
+		stale := dirModTimeStale(path, cfg.StaleAfterDays)
+		eligible := !active && (level >= LevelCritical || (level >= LevelModerate && stale))
+		name := darwinEditorCacheTargetName(home, path)
+		targets = append(targets, CleanupTarget{
+			Type:      targetType,
+			Name:      name,
+			Path:      path,
+			Bytes:     getDirAllocatedBytes(path),
+			Active:    active,
+			Protected: darwinCacheProtected(active, enforce, eligible),
+			Action:    darwinCacheAction(active, enforce, eligible),
+			Reason: darwinCacheReason(active, enforce, eligible,
+				displayName+" cache directory",
+				fmt.Sprintf("stale-after policy is %d days; critical pressure can delete inactive editor cache directories", cfg.StaleAfterDays)),
+		})
+	}
+
+	return targets
+}
+
+func darwinEditorCachePaths(home string, appSupportName string) []string {
+	appSupportRoot := filepath.Join(home, "Library", "Application Support", appSupportName)
+	paths := []string{
+		filepath.Join(appSupportRoot, "Cache"),
+		filepath.Join(appSupportRoot, "CachedData"),
+		filepath.Join(appSupportRoot, "Code Cache"),
+		filepath.Join(appSupportRoot, "DawnCache"),
+		filepath.Join(appSupportRoot, "GPUCache"),
+		filepath.Join(appSupportRoot, "ShaderCache"),
+		filepath.Join(appSupportRoot, "Service Worker", "CacheStorage"),
+		filepath.Join(home, "Library", "Caches", appSupportName),
+	}
+
+	switch appSupportName {
+	case "Code":
+		paths = append(paths, filepath.Join(home, "Library", "Caches", "com.microsoft.VSCode"))
+	case "Cursor":
+		paths = append(paths, filepath.Join(home, "Library", "Caches", "com.cursor.Cursor"))
+	}
+
+	return paths
+}
+
+func darwinEditorCacheTargetName(home string, path string) string {
+	for _, root := range []string{
+		filepath.Join(home, "Library", "Application Support"),
+		filepath.Join(home, "Library", "Caches"),
+	} {
+		if rel, err := filepath.Rel(root, path); err == nil && !strings.HasPrefix(rel, "..") {
+			return rel
+		}
+	}
+	return filepath.Base(path)
 }
 
 func (p *CachePlugin) cleanupDarwinDeveloperCacheTargets(ctx context.Context, level CleanupLevel, home string, cfg config.DarwinDevCachesConfig, logger *slog.Logger) CleanupResult {

--- a/plugins/darwin_dev_cache_test.go
+++ b/plugins/darwin_dev_cache_test.go
@@ -106,6 +106,41 @@ func TestDarwinDeveloperCacheTargetsOptInEnforcement(t *testing.T) {
 	}
 }
 
+func TestDarwinDeveloperCacheTargetsEditorCaches(t *testing.T) {
+	home := t.TempDir()
+	cfg := config.DefaultConfig().DarwinDevCaches
+	cfg.Enforce = true
+
+	vscodeCache := filepath.Join(home, "Library/Application Support/Code/Cache")
+	vscodeSettings := filepath.Join(home, "Library/Application Support/Code/User/settings.json")
+	cursorCache := filepath.Join(home, "Library/Application Support/Cursor/Cache")
+	writeCacheFile(t, home, "Library/Application Support/Code/Cache/cache.bin", "vscode")
+	writeCacheFile(t, home, "Library/Application Support/Code/User/settings.json", "{}")
+	writeCacheFile(t, home, "Library/Application Support/Cursor/Cache/cache.bin", "cursor")
+
+	oldTime := time.Now().Add(-30 * 24 * time.Hour)
+	mustChtimes(t, vscodeCache, oldTime)
+	mustChtimes(t, cursorCache, oldTime)
+
+	plugin := &CachePlugin{}
+	targets := plugin.darwinDeveloperCacheTargets(home, cfg, map[string]bool{"code helper": true}, LevelModerate)
+
+	vscode := findCleanupTarget(t, targets, "vscode-cache", "Code/Cache")
+	if !vscode.Active || !vscode.Protected || vscode.Action != "protect" {
+		t.Fatalf("expected active VS Code cache to be protected: %#v", vscode)
+	}
+	cursor := findCleanupTarget(t, targets, "cursor-cache", "Cursor/Cache")
+	if cursor.Active || cursor.Protected || cursor.Action != "delete" {
+		t.Fatalf("expected inactive stale Cursor cache to be an opt-in delete target: %#v", cursor)
+	}
+	if _, ok := findCleanupTargetMaybe(targets, "vscode-cache", "Code/User"); ok {
+		t.Fatalf("editor settings directory should not be emitted as a cache target")
+	}
+	if _, err := os.Stat(vscodeSettings); err != nil {
+		t.Fatalf("test settings fixture should exist: %v", err)
+	}
+}
+
 func TestCleanupDarwinDeveloperCacheTargetsDeletesOnlyEligibleTargets(t *testing.T) {
 	home := t.TempDir()
 	cfg := config.DefaultConfig().DarwinDevCaches
@@ -164,11 +199,19 @@ func nilLogger() *slog.Logger {
 
 func findCleanupTarget(t *testing.T, targets []CleanupTarget, targetType, name string) CleanupTarget {
 	t.Helper()
-	for _, target := range targets {
-		if target.Type == targetType && target.Name == name {
-			return target
-		}
+	target, ok := findCleanupTargetMaybe(targets, targetType, name)
+	if ok {
+		return target
 	}
 	t.Fatalf("target %s/%s not found in %#v", targetType, name, targets)
 	return CleanupTarget{}
+}
+
+func findCleanupTargetMaybe(targets []CleanupTarget, targetType, name string) (CleanupTarget, bool) {
+	for _, target := range targets {
+		if target.Type == targetType && target.Name == name {
+			return target, true
+		}
+	}
+	return CleanupTarget{}, false
 }


### PR DESCRIPTION
## Summary

- add typed Darwin developer-cache targets for VS Code and Cursor cache-only directories
- protect matching editor cache targets when editor processes are active
- keep settings, extension data, credentials, and User directories outside the target surface
- document the expanded Darwin cache boundary and config defaults

## Validation

- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test -count=1 ./config ./plugins
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test -count=1 ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...

Refs #5
Refs #2