### PR TITLE
Clean repo-local Bazel symlinks after output-base deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - Bazel cache-tier budget enforcement for stale repository cache, disk cache,
   and Bazelisk download targets when total Bazel footprint exceeds the
   configured budget.
+- Repo-local Bazel symlink cleanup after successful stale output-base deletion.
 - Active-process protection for development artifact cleanup families such as
   Node.js, Python, Rust, Go, Haskell, and LM Studio.
 - Typed Darwin developer-cache targets for VS Code and Cursor cache-only

--- a/config/config.go
+++ b/config/config.go
@@ -186,6 +186,8 @@ type PodmanConfig struct {
 type BazelConfig struct {
 	// Roots are directories that may contain Bazel output-user-root trees or caches.
 	Roots []string `yaml:"roots"`
+	// WorkspaceRoots are developer workspace roots scanned for repo-local bazel-* symlinks after output-base deletion.
+	WorkspaceRoots []string `yaml:"workspace_roots"`
 	// BazeliskCache is the Bazelisk download cache path.
 	BazeliskCache string `yaml:"bazelisk_cache"`
 	// MaxTotalGB is the review budget across detected Bazel caches.
@@ -377,6 +379,7 @@ func DefaultConfig() *Config {
 		},
 		Bazel: BazelConfig{
 			Roots:                 defaultBazelRoots(home),
+			WorkspaceRoots:        defaultScanPaths,
 			BazeliskCache:         bazeliskCache,
 			MaxTotalGB:            20,
 			KeepRecentOutputBases: 5,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -280,6 +280,9 @@ func TestBazelPolicyDefaults(t *testing.T) {
 	if len(cfg.Bazel.Roots) == 0 {
 		t.Fatal("Bazel.Roots should have defaults")
 	}
+	if len(cfg.Bazel.WorkspaceRoots) != 3 {
+		t.Fatalf("Bazel.WorkspaceRoots should have 3 defaults, got %#v", cfg.Bazel.WorkspaceRoots)
+	}
 	if cfg.Bazel.BazeliskCache == "" {
 		t.Fatal("Bazel.BazeliskCache should have a default")
 	}
@@ -402,6 +405,8 @@ nix:
 bazel:
   roots:
     - ~/custom-bazel
+  workspace_roots:
+    - ~/custom-workspaces
   bazelisk_cache: ~/custom-bazelisk
   max_total_gb: 30
   keep_recent_output_bases: 2
@@ -523,6 +528,9 @@ darwin_dev_caches:
 	}
 	if len(cfg.Bazel.Roots) != 1 || cfg.Bazel.Roots[0] != "~/custom-bazel" {
 		t.Errorf("unexpected Bazel.Roots: %#v", cfg.Bazel.Roots)
+	}
+	if len(cfg.Bazel.WorkspaceRoots) != 1 || cfg.Bazel.WorkspaceRoots[0] != "~/custom-workspaces" {
+		t.Errorf("unexpected Bazel.WorkspaceRoots: %#v", cfg.Bazel.WorkspaceRoots)
 	}
 	if cfg.Bazel.BazeliskCache != "~/custom-bazelisk" {
 		t.Errorf("Bazel.BazeliskCache should be custom path, got %q", cfg.Bazel.BazeliskCache)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -95,6 +95,10 @@ nix:
 bazel:
   roots:
     - ~/.cache/bazel
+  workspace_roots:
+    - ~/git
+    - ~/src
+    - ~/projects
   # Darwin default; Linux operators commonly use ~/.cache/bazelisk
   bazelisk_cache: ~/Library/Caches/bazelisk
   max_total_gb: 20

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -34,6 +34,10 @@ Default policy:
 bazel:
   roots:
     - ~/.cache/bazel
+  workspace_roots:
+    - ~/git
+    - ~/src
+    - ~/projects
   bazelisk_cache: ~/Library/Caches/bazelisk
   max_total_gb: 20
   keep_recent_output_bases: 5
@@ -59,10 +63,13 @@ Runtime boundary:
 - cache-tier cleanup is skipped while active Bazel or Bazelisk work is visible;
 - deletion normalizes writable permissions first, and on Darwin attempts to
   clear `uchg` file flags with `chflags -R nouchg`;
+- after an output base is deleted, workspace roots are scanned shallowly for
+  canonical repo-local `bazel-*` symlinks, and only symlinks whose raw target
+  points inside that deleted output base are removed;
 - byte counts use top-level allocation estimates so dry-run remains responsive
   on very large generated trees;
-- repo-local `bazel-*` symlink cleanup remains a follow-up after output-base
-  deletion evidence is proven on real hosts.
+- idle Bazel server stop remains a follow-up guarded by
+  `allow_stop_idle_servers`.
 
 Do not disable active-output-base protection on developer machines or shared
 runners unless an operator has already drained the relevant jobs and accepted

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -80,10 +80,12 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 			"Measure logical and physical bytes without following repo-local bazel-* symlinks",
 			"Protect active output bases, protected workspace output bases, and newest output bases",
 			"Delete only stale inactive output bases and budget-excess cache tiers in real cleanup mode at moderate or higher levels",
+			"Remove repo-local bazel-* symlinks only after their target output base was deleted",
 		},
 		Metadata: map[string]string{
 			"cleanup_level":                    level.String(),
 			"max_total_gb":                     strconv.Itoa(cfg.Bazel.MaxTotalGB),
+			"workspace_root_count":             strconv.Itoa(len(cfg.Bazel.WorkspaceRoots)),
 			"keep_recent_output_bases":         strconv.Itoa(cfg.Bazel.KeepRecentOutputBases),
 			"stale_after":                      cfg.Bazel.StaleAfter,
 			"critical_stale_after":             cfg.Bazel.CriticalStaleAfter,
@@ -131,7 +133,8 @@ func (p *BazelPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *conf
 		return result
 	}
 
-	result = applyBazelCleanupTargets(ctx, p.Name(), level, plan.Targets, logger)
+	home, _ := os.UserHomeDir()
+	result = applyBazelCleanupTargets(ctx, p.Name(), level, plan.Targets, cfg.Bazel.WorkspaceRoots, home, logger)
 	if result.ItemsCleaned == 0 {
 		logger.Info("Bazel cleanup found no eligible stale inactive output bases", "level", level.String())
 	}
@@ -534,7 +537,7 @@ func bazelEstimatedCandidateBytes(targets []CleanupTarget) int64 {
 	return total
 }
 
-func applyBazelCleanupTargets(ctx context.Context, plugin string, level CleanupLevel, targets []CleanupTarget, logger *slog.Logger) CleanupResult {
+func applyBazelCleanupTargets(ctx context.Context, plugin string, level CleanupLevel, targets []CleanupTarget, workspaceRoots []string, home string, logger *slog.Logger) CleanupResult {
 	result := CleanupResult{Plugin: plugin, Level: level}
 	for _, target := range targets {
 		if !bazelTargetEligibleForDeletion(target) {
@@ -547,6 +550,12 @@ func applyBazelCleanupTargets(ctx context.Context, plugin string, level CleanupL
 		if err := deleteBazelTarget(target, logger); err != nil {
 			logger.Warn("failed to delete Bazel target", "type", target.Type, "path", target.Path, "error", err)
 			continue
+		}
+		if target.Type == "output_base" {
+			removedLinks := cleanupRepoLocalBazelSymlinksForDeletedOutputBase(workspaceRoots, home, target.Path, logger)
+			if removedLinks > 0 {
+				logger.Info("removed repo-local Bazel symlinks for deleted output base", "output_base", target.Path, "links_removed", removedLinks)
+			}
 		}
 		result.BytesFreed += target.Bytes
 		result.EstimatedBytesFreed += target.Bytes
@@ -589,6 +598,84 @@ func deleteBazelOutputBase(path string, logger *slog.Logger) error {
 		return err
 	}
 	return os.RemoveAll(path)
+}
+
+func cleanupRepoLocalBazelSymlinksForDeletedOutputBase(workspaceRoots []string, home string, outputBase string, logger *slog.Logger) int {
+	if len(workspaceRoots) == 0 || outputBase == "" {
+		return 0
+	}
+
+	outputBase = filepath.Clean(outputBase)
+	removed := 0
+	for _, root := range workspaceRoots {
+		expanded := expandHome(root, home)
+		_ = filepath.WalkDir(expanded, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			if !entry.IsDir() {
+				return nil
+			}
+			if path != expanded && bazelWorkspaceScanDepth(expanded, path) > 2 {
+				return filepath.SkipDir
+			}
+			for _, linkName := range repoLocalBazelSymlinkNames(path) {
+				linkPath := filepath.Join(path, linkName)
+				if !bazelSymlinkTargetInsideOutputBase(linkPath, outputBase) {
+					continue
+				}
+				if err := os.Remove(linkPath); err != nil {
+					logger.Warn("failed to remove repo-local Bazel symlink", "path", linkPath, "output_base", outputBase, "error", err)
+					continue
+				}
+				removed++
+				logger.Debug("removed repo-local Bazel symlink", "path", linkPath, "output_base", outputBase)
+			}
+			return nil
+		})
+	}
+	return removed
+}
+
+func bazelWorkspaceScanDepth(root string, path string) int {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." {
+		return 0
+	}
+	return len(strings.Split(rel, string(os.PathSeparator)))
+}
+
+func repoLocalBazelSymlinkNames(workspace string) []string {
+	return []string{
+		"bazel-bin",
+		"bazel-out",
+		"bazel-testlogs",
+		"bazel-" + filepath.Base(workspace),
+	}
+}
+
+func bazelSymlinkTargetInsideOutputBase(linkPath string, outputBase string) bool {
+	info, err := os.Lstat(linkPath)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	rawTarget, err := os.Readlink(linkPath)
+	if err != nil || rawTarget == "" {
+		return false
+	}
+	target := rawTarget
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(linkPath), target)
+	}
+	return pathInsideRoot(filepath.Clean(target), outputBase)
+}
+
+func pathInsideRoot(path string, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
 func deleteBazelCacheTier(targetType, path string, logger *slog.Logger) error {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -268,6 +268,12 @@ func TestApplyBazelCleanupTargetsDeletesEligibleOutputBase(t *testing.T) {
 	if err := os.Chmod(filepath.Dir(generated), 0500); err != nil {
 		t.Fatal(err)
 	}
+	workspaceRoot := filepath.Join(root, "workspaces")
+	workspace := filepath.Join(workspaceRoot, "project")
+	mustMkdir(t, workspace)
+	if err := os.Symlink(filepath.Dir(generated), filepath.Join(workspace, "bazel-bin")); err != nil {
+		t.Fatal(err)
+	}
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	result := applyBazelCleanupTargets(context.Background(), "bazel", LevelModerate, []CleanupTarget{
@@ -278,7 +284,7 @@ func TestApplyBazelCleanupTargetsDeletesEligibleOutputBase(t *testing.T) {
 			Bytes:  123,
 			Action: "delete_output_base",
 		},
-	}, logger)
+	}, []string{workspaceRoot}, root, logger)
 
 	if result.Error != nil {
 		t.Fatalf("unexpected error: %v", result.Error)
@@ -291,6 +297,42 @@ func TestApplyBazelCleanupTargetsDeletesEligibleOutputBase(t *testing.T) {
 	}
 	if _, err := os.Stat(outputBase); !os.IsNotExist(err) {
 		t.Fatalf("expected output base to be deleted, stat err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(workspace, "bazel-bin")); !os.IsNotExist(err) {
+		t.Fatalf("expected repo-local bazel-bin symlink to be removed, stat err=%v", err)
+	}
+}
+
+func TestCleanupRepoLocalBazelSymlinksOnlyRemovesLinksIntoDeletedOutputBase(t *testing.T) {
+	root := t.TempDir()
+	deletedOutputBase := filepath.Join(root, "_bazel_jess", "deleted")
+	keptOutputBase := filepath.Join(root, "_bazel_jess", "kept")
+	makeBazelOutputBase(t, deletedOutputBase)
+	makeBazelOutputBase(t, keptOutputBase)
+
+	workspaceRoot := filepath.Join(root, "workspaces")
+	deletedWorkspace := filepath.Join(workspaceRoot, "deleted-workspace")
+	keptWorkspace := filepath.Join(workspaceRoot, "kept-workspace")
+	mustMkdir(t, deletedWorkspace)
+	mustMkdir(t, keptWorkspace)
+	deletedTarget := filepath.Join(deletedOutputBase, "execroot", "_main", "bazel-out")
+	keptTarget := filepath.Join(keptOutputBase, "execroot", "_main", "bazel-out")
+	if err := os.Symlink(deletedTarget, filepath.Join(deletedWorkspace, "bazel-out")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(keptTarget, filepath.Join(keptWorkspace, "bazel-out")); err != nil {
+		t.Fatal(err)
+	}
+
+	removed := cleanupRepoLocalBazelSymlinksForDeletedOutputBase([]string{workspaceRoot}, root, deletedOutputBase, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if removed != 1 {
+		t.Fatalf("removed links = %d, want 1", removed)
+	}
+	if _, err := os.Lstat(filepath.Join(deletedWorkspace, "bazel-out")); !os.IsNotExist(err) {
+		t.Fatalf("expected deleted output-base symlink to be removed, stat err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(keptWorkspace, "bazel-out")); err != nil {
+		t.Fatalf("expected unrelated Bazel symlink to remain, stat err=%v", err)
 	}
 }
 
@@ -333,7 +375,7 @@ func TestApplyBazelCleanupTargetsDeletesEligibleCacheTier(t *testing.T) {
 			Bytes:  17,
 			Action: "delete_cache_tier",
 		},
-	}, logger)
+	}, nil, root, logger)
 
 	if result.Error != nil {
 		t.Fatalf("unexpected error: %v", result.Error)
@@ -365,7 +407,7 @@ func TestApplyBazelCleanupTargetsRejectsUnsafeCacheTierPath(t *testing.T) {
 			Bytes:  10,
 			Action: "delete_cache_tier",
 		},
-	}, logger)
+	}, nil, root, logger)
 
 	if result.ItemsCleaned != 0 {
 		t.Fatalf("items cleaned = %d, want 0", result.ItemsCleaned)
@@ -400,7 +442,7 @@ func TestApplyBazelCleanupTargetsSkipsProtectedAndActiveTargets(t *testing.T) {
 			Protected: true,
 			Action:    "delete_output_base",
 		},
-	}, logger)
+	}, nil, root, logger)
 
 	if result.ItemsCleaned != 0 {
 		t.Fatalf("items cleaned = %d, want 0", result.ItemsCleaned)


### PR DESCRIPTION
## Summary

- add `bazel.workspace_roots` for shallow repo-local symlink scans after output-base cleanup
- remove canonical repo-local `bazel-*` symlinks only after their target output base was successfully deleted
- require each symlink raw target to point inside the deleted output base before unlinking
- document the boundary and keep idle server stop as a follow-up

## Validation

- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test -count=1 ./config ./plugins
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test -count=1 ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix build .#default --no-link --print-build-logs
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...

Refs #3
Refs #2