### PR TITLE
Refresh productionization status docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ Bazel cache and output-base review is documented in
 ## Distribution Status
 
 Current package authority is the Nix flake package `.#tinyland-cleanup`.
-Release archives are produced from GitHub tags. Linux RPM packaging is
-documented in [docs/rpm-packaging.md](docs/rpm-packaging.md); the RPM installs a
-systemd unit but leaves enable/start as an explicit operator action.
+Release archives are produced from GitHub tags. No public tag has been cut yet.
+Linux RPM packaging is documented in
+[docs/rpm-packaging.md](docs/rpm-packaging.md); the RPM installs a systemd unit
+but leaves enable/start as an explicit operator action.
 
 ## Roadmap
 
@@ -101,10 +102,14 @@ Open productionization work is tracked in GitHub issues:
 - `#4`: Nix cleanup policy for generations, roots, and daemon contention
 - `#5`: Darwin IDE and developer-tool cache budgets
 - `#6`: Podman offline compaction for Darwin `applehv`
+- `#9`: GloriousFlywheel shared-cache runner proof
+
+Recently completed productionization work:
+
 - `#7`: dry-run, telemetry, and host free-space accounting
 
 See [docs/productionization-plan-2026-04-25.md](docs/productionization-plan-2026-04-25.md)
 for the current productionization plan.
 
 Current validation notes are tracked in
-[docs/validation-status-2026-04-25.md](docs/validation-status-2026-04-25.md).
+[docs/validation-status-2026-04-26.md](docs/validation-status-2026-04-26.md).

--- a/docs/productionization-plan-2026-04-25.md
+++ b/docs/productionization-plan-2026-04-25.md
@@ -1,6 +1,7 @@
 # Productionization Plan: tinyland-cleanup
 
 Date: 2026-04-25
+Last reviewed: 2026-04-26
 
 ## Current Authority
 
@@ -17,7 +18,8 @@ Date: 2026-04-25
 - GitHub `#4`: Nix cleanup policy for generations, roots, and daemon contention
 - GitHub `#5`: Darwin IDE and developer-tool cache budgets
 - GitHub `#6`: Podman offline compaction for Darwin `applehv`
-- GitHub `#7`: dry-run, telemetry, and host free-space accounting
+- GitHub `#7`: dry-run, telemetry, and host free-space accounting (closed)
+- GitHub `#9`: GloriousFlywheel shared-cache runner proof
 - Linear `TIN-117`: canonical repo decision for `tinyland-cleanup`
 - Linear `TIN-139`: Nix/Bazel audit and cleanup
 - Linear `TIN-127`: Linux builder and publication contracts
@@ -40,10 +42,11 @@ Follow the scheduling package pattern where artifact authority is explicit:
 - Add hosted GitHub CI for Go and Bazel validation.
 - Add manual GloriousFlywheel proof workflow for shared-cache validation.
 
-Validation note: Go, Nix, and hosted Bazel CI are green as of 2026-04-25.
-Bazel now gets past the previous missing-module failure, but local Darwin
-validation still has a rules_go cold-start blocker before tests execute. See
-[validation-status-2026-04-25.md](validation-status-2026-04-25.md).
+Validation note: Go and hosted Bazel CI are green on `main` as of 2026-04-26.
+Local Go test, vet, and build validation also passed on 2026-04-26. The
+GloriousFlywheel proof workflow is present but blocked because this repository
+currently has zero visible self-hosted runners. See
+[validation-status-2026-04-26.md](validation-status-2026-04-26.md).
 
 Exit criteria:
 
@@ -62,7 +65,8 @@ Exit criteria:
 
 Exit criteria:
 
-- GitHub `#2` and `#7` acceptance criteria are testable.
+- GitHub `#2` residual acceptance criteria are testable, and the closed `#7`
+  reporting surface stays covered by tests.
 - Operator output can explain every removal candidate.
 - Mission-critical machines can run in audit mode without mutation.
 

--- a/docs/validation-status-2026-04-26.md
+++ b/docs/validation-status-2026-04-26.md
@@ -1,0 +1,79 @@
+# Validation Status: 2026-04-26
+
+Branch: `main`
+Commit: `1ac4953`
+
+## Repo State
+
+- Canonical upstream: `github.com/Jesssullivan/tinyland-cleanup`
+- Local checkout: clean `main`, aligned with `github/main`
+- Historical fork: `tinyland-inc/tinyland-cleanup`, public and archived
+- Open PRs: none
+- Open GitHub issues: `#2`, `#3`, `#4`, `#5`, `#6`, `#9`
+- Tags/releases: none yet
+
+## Local Validation
+
+Passed locally on 2026-04-26 with repo-managed caches under `/tmp`:
+
+```sh
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
+```
+
+No cache pruning or destructive cleanup was performed during this validation.
+
+## Hosted CI
+
+Latest `main` CI after PR `#28` passed:
+
+```text
+GitHub Actions run 24960795043
+Go: passed
+Bazel: passed
+```
+
+The Bazel hosted job runs through Nix and Bazelisk:
+
+```sh
+nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+```
+
+## GloriousFlywheel Proof
+
+The manual GloriousFlywheel proof workflow is present and configured for
+shared-cache-backed Bazel validation, not remote execution/offload. It currently
+targets the shared `tinyland-nix` runner class and passes
+`BAZEL_REMOTE_CACHE` directly into `scripts/bazel-cache-backed.sh`.
+
+Current blocker:
+
+```text
+gh api repos/Jesssullivan/tinyland-cleanup/actions/runners
+total_count=0
+```
+
+Two workflow-dispatch attempts on 2026-04-25 were cancelled after queueing
+without a matching self-hosted runner:
+
+```text
+24943163465 cancelled
+24943258387 cancelled
+```
+
+Next step for `#9`: grant this repository access to an appropriate
+GloriousFlywheel `tinyland-nix` runner, confirm the Bazel remote cache endpoint
+from that runner, rerun the proof, and record the result here.
+
+## Local Host Snapshot
+
+Read-only disk snapshot during the status check:
+
+```text
+/System/Volumes/Data: 31GiB available
+/nix:                 31GiB available
+```
+
+Nix package and local Bazel validation were not rerun during this status pass to
+avoid adding unnecessary store/cache pressure while the machine remains tight.


### PR DESCRIPTION
## Summary
- mark #7 as completed and add #9 to the current roadmap
- add a 2026-04-26 validation/status note for local Go validation, hosted CI, release/tag state, and the GloriousFlywheel runner blocker
- update the productionization plan to point at the current validation note

## Validation
- git diff --check
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...

No cache pruning or destructive cleanup was performed.