### PR TITLE
Add targeted plugin evidence filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ All notable changes to this project will be documented in this file.
   Node.js, Python, Rust, Go, Haskell, and LM Studio.
 - Typed Darwin developer-cache targets for VS Code and Cursor cache-only
   directories, with active-editor protection.
+- CLI `--plugins` filter for bounded dry-run evidence collection and targeted
+  cleanup cycles.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Use JSON when another tool needs the stable report schema:
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
 
+Constrain review to specific plugins before scanning broad cache surfaces:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --plugins bazel,nix --output text
+```
+
 For a one-off run, override the configured maximum used-space target without
 editing the config file:
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -20,6 +20,21 @@ Use JSON when another tool needs the stable report schema:
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
 
+When gathering evidence on an active workstation, constrain the run to the
+plugin family under review instead of scanning every enabled cache surface:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --plugins bazel --output text
+tinyland-cleanup --once --dry-run --level critical --plugins nix --output json
+tinyland-cleanup --once --dry-run --level critical --plugins cache --output text
+```
+
+The plugin filter is comma-separated and preserves the normal registry order:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --plugins bazel,nix --output json
+```
+
 For a one-off operator run, override the configured maximum used-space target
 without editing config:
 
@@ -37,6 +52,7 @@ The JSON report includes:
 - daemon state file and configured cleanup cooldown;
 - top-level dry-run totals for planned estimated reclaim, required free space,
   and cleanup target count;
+- optional `plugin_filter` when `--plugins` constrains the cycle;
 - enabled plugins that would run;
 - plugin descriptions and dry-run skip reasons.
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@
 //	-level string     Force cleanup level: none, warning, moderate, aggressive, critical
 //	-dry-run          Show what would be cleaned without actually cleaning
 //	-output string    Output format: text, json (default: text)
+//	-plugins string   Comma-separated plugin names to run or plan
 //	-target-used-percent int
 //	                 Override target maximum used-space percentage after cleanup
 //	-verbose          Enable verbose logging
@@ -32,6 +33,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -56,6 +58,7 @@ func main() {
 		level       = flag.String("level", "", "Force cleanup level")
 		dryRun      = flag.Bool("dry-run", false, "Show what would be cleaned")
 		output      = flag.String("output", "text", "Output format: text, json")
+		pluginNames = flag.String("plugins", "", "Comma-separated plugin names to run or plan")
 		targetUsed  = flag.Int("target-used-percent", 0, "Override target maximum used-space percentage after cleanup")
 		verbose     = flag.Bool("verbose", false, "Enable verbose logging")
 		showVersion = flag.Bool("version", false, "Print version and exit")
@@ -69,6 +72,11 @@ func main() {
 
 	if *output != "text" && *output != "json" {
 		fmt.Fprintf(os.Stderr, "invalid output format %q: expected text or json\n", *output)
+		os.Exit(2)
+	}
+	pluginFilter, err := parsePluginFilter(*pluginNames)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(2)
 	}
 
@@ -118,6 +126,10 @@ func main() {
 	// Create plugin registry and register all plugins
 	registry := plugins.NewRegistry()
 	registerPlugins(registry)
+	if err := validatePluginFilter(pluginFilter, registry); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
 
 	// Create disk monitor
 	diskMon := monitor.NewDiskMonitor(
@@ -129,15 +141,16 @@ func main() {
 
 	// Create cleanup daemon
 	d := &daemon{
-		config:    cfg,
-		registry:  registry,
-		monitor:   diskMon,
-		logger:    logger,
-		dryRun:    *dryRun,
-		output:    *output,
-		report:    os.Stdout,
-		diskStats: monitor.GetDiskStats,
-		now:       time.Now,
+		config:       cfg,
+		registry:     registry,
+		monitor:      diskMon,
+		logger:       logger,
+		dryRun:       *dryRun,
+		output:       *output,
+		pluginFilter: pluginFilter,
+		report:       os.Stdout,
+		diskStats:    monitor.GetDiskStats,
+		now:          time.Now,
 	}
 
 	// Determine operation mode
@@ -188,15 +201,16 @@ func main() {
 }
 
 type daemon struct {
-	config    *config.Config
-	registry  *plugins.Registry
-	monitor   *monitor.DiskMonitor
-	logger    *slog.Logger
-	dryRun    bool
-	output    string
-	report    io.Writer
-	diskStats func(path string) (*monitor.DiskStats, error)
-	now       func() time.Time
+	config       *config.Config
+	registry     *plugins.Registry
+	monitor      *monitor.DiskMonitor
+	logger       *slog.Logger
+	dryRun       bool
+	output       string
+	pluginFilter []string
+	report       io.Writer
+	diskStats    func(path string) (*monitor.DiskStats, error)
+	now          func() time.Time
 }
 
 func (d *daemon) run(ctx context.Context) error {
@@ -230,12 +244,13 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 
 	now := d.currentTime()
 	report := cycleReport{
-		Timestamp:   now.UTC().Format(time.RFC3339),
-		DryRun:      d.dryRun,
-		ForcedLevel: forcedLevel != monitor.LevelNone,
-		Level:       level.String(),
-		MonitorPath: d.primaryMonitorPath(assessment),
-		Mounts:      assessment.Mounts,
+		Timestamp:    now.UTC().Format(time.RFC3339),
+		DryRun:       d.dryRun,
+		ForcedLevel:  forcedLevel != monitor.LevelNone,
+		Level:        level.String(),
+		MonitorPath:  d.primaryMonitorPath(assessment),
+		Mounts:       assessment.Mounts,
+		PluginFilter: d.pluginFilter,
 	}
 
 	cooldown := d.cleanupCooldown()
@@ -267,7 +282,7 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 	pluginLevel := plugins.CleanupLevel(level)
 
 	// Run cleanup plugins
-	enabledPlugins := d.registry.GetEnabled(d.config)
+	enabledPlugins := filterEnabledPlugins(d.registry.GetEnabled(d.config), d.pluginFilter)
 	d.logger.Debug("running plugins", "count", len(enabledPlugins))
 
 	var totalFreed int64
@@ -417,6 +432,7 @@ type cycleReport struct {
 	TotalBytesFreed   int64               `json:"total_bytes_freed"`
 	TotalItemsCleaned int                 `json:"total_items_cleaned"`
 	Mounts            []mountReport       `json:"mounts"`
+	PluginFilter      []string            `json:"plugin_filter,omitempty"`
 	Plugins           []pluginCycleReport `json:"plugins"`
 }
 
@@ -681,6 +697,76 @@ func applyTargetUsedPercentOverride(cfg *config.Config, targetUsedPercent int) e
 	}
 	cfg.TargetFree = targetUsedPercent
 	return nil
+}
+
+func parsePluginFilter(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	var filter []string
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, fmt.Errorf("invalid plugins filter %q: empty plugin name", raw)
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		filter = append(filter, name)
+	}
+	return filter, nil
+}
+
+func validatePluginFilter(filter []string, registry *plugins.Registry) error {
+	if len(filter) == 0 {
+		return nil
+	}
+
+	available := make(map[string]struct{})
+	for _, name := range availablePluginNames(registry) {
+		available[name] = struct{}{}
+	}
+	for _, name := range filter {
+		if _, ok := available[name]; !ok {
+			return fmt.Errorf("unknown plugin %q; available plugins: %s", name, strings.Join(availablePluginNames(registry), ", "))
+		}
+	}
+	return nil
+}
+
+func availablePluginNames(registry *plugins.Registry) []string {
+	seen := make(map[string]struct{})
+	for _, plugin := range registry.GetAll() {
+		seen[plugin.Name()] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func filterEnabledPlugins(enabled []plugins.Plugin, filter []string) []plugins.Plugin {
+	if len(filter) == 0 {
+		return enabled
+	}
+
+	allowed := make(map[string]struct{}, len(filter))
+	for _, name := range filter {
+		allowed[name] = struct{}{}
+	}
+	filtered := make([]plugins.Plugin, 0, len(enabled))
+	for _, plugin := range enabled {
+		if _, ok := allowed[plugin.Name()]; ok {
+			filtered = append(filtered, plugin)
+		}
+	}
+	return filtered
 }
 
 func expandPathHome(path string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -156,6 +156,49 @@ func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
 	}
 }
 
+func TestRunOnceDryRunHonorsPluginFilter(t *testing.T) {
+	var output bytes.Buffer
+	first := &planningPlugin{
+		reportingPlugin: reportingPlugin{name: "first"},
+		plan: plugins.CleanupPlan{
+			Plugin:   "first",
+			Level:    "critical",
+			Summary:  "first plan",
+			WouldRun: true,
+		},
+	}
+	second := &planningPlugin{
+		reportingPlugin: reportingPlugin{name: "second"},
+		plan: plugins.CleanupPlan{
+			Plugin:   "second",
+			Level:    "critical",
+			Summary:  "second plan",
+			WouldRun: true,
+		},
+	}
+	daemon := newTestDaemonWithPlugins(t, &output, first, second)
+	daemon.dryRun = true
+	daemon.pluginFilter = []string{"second"}
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelCritical); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	report := decodeCycleReport(t, output.Bytes())
+	if len(report.PluginFilter) != 1 || report.PluginFilter[0] != "second" {
+		t.Fatalf("expected plugin filter [second], got %#v", report.PluginFilter)
+	}
+	if len(report.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin report, got %d", len(report.Plugins))
+	}
+	if report.Plugins[0].Name != "second" {
+		t.Fatalf("expected second plugin, got %q", report.Plugins[0].Name)
+	}
+	if report.Plugins[0].Plan == nil || report.Plugins[0].Plan.Summary != "second plan" {
+		t.Fatalf("expected second plan, got %#v", report.Plugins[0].Plan)
+	}
+}
+
 func TestRunOnceCleanupJSONReport(t *testing.T) {
 	var output bytes.Buffer
 	mock := &reportingPlugin{
@@ -291,6 +334,40 @@ func TestApplyTargetUsedPercentOverride(t *testing.T) {
 		if err := applyTargetUsedPercentOverride(cfg, value); err == nil {
 			t.Fatalf("expected error for target override %d", value)
 		}
+	}
+}
+
+func TestParsePluginFilter(t *testing.T) {
+	filter, err := parsePluginFilter(" bazel, nix,bazel ")
+	if err != nil {
+		t.Fatalf("parsePluginFilter failed: %v", err)
+	}
+	if len(filter) != 2 || filter[0] != "bazel" || filter[1] != "nix" {
+		t.Fatalf("unexpected filter %#v", filter)
+	}
+
+	empty, err := parsePluginFilter("")
+	if err != nil {
+		t.Fatalf("empty filter failed: %v", err)
+	}
+	if empty != nil {
+		t.Fatalf("expected nil empty filter, got %#v", empty)
+	}
+
+	if _, err := parsePluginFilter("bazel,,nix"); err == nil {
+		t.Fatal("expected empty plugin name error")
+	}
+}
+
+func TestValidatePluginFilterRejectsUnknownPlugin(t *testing.T) {
+	registry := plugins.NewRegistry()
+	registry.Register(&reportingPlugin{name: "known"})
+
+	if err := validatePluginFilter([]string{"known"}, registry); err != nil {
+		t.Fatalf("known plugin should validate: %v", err)
+	}
+	if err := validatePluginFilter([]string{"missing"}, registry); err == nil {
+		t.Fatal("expected unknown plugin error")
 	}
 }
 

--- a/report_text.go
+++ b/report_text.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/Jesssullivan/tinyland-cleanup/monitor"
 	"github.com/Jesssullivan/tinyland-cleanup/plugins"
@@ -36,6 +37,11 @@ func writeTextReport(w io.Writer, report cycleReport) error {
 
 	if report.MonitorPath != "" {
 		if _, err := fmt.Fprintf(w, "monitor: %s\n", report.MonitorPath); err != nil {
+			return err
+		}
+	}
+	if len(report.PluginFilter) > 0 {
+		if _, err := fmt.Fprintf(w, "plugin filter: %s\n", strings.Join(report.PluginFilter, ", ")); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- add a --plugins comma-separated filter for bounded dry-run planning and targeted cleanup cycles
- include plugin_filter in JSON reports and render it in text reports
- document targeted evidence collection for active workstations

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- git diff --check

No real cache cleanup or broad local cache sweep was performed.