### PR TITLE
Add plugin discovery output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ All notable changes to this project will be documented in this file.
   directories, with active-editor protection.
 - CLI `--plugins` filter for bounded dry-run evidence collection and targeted
   cleanup cycles.
+- CLI `--list-plugins` discovery output for plugin names, enabled state, and
+  platform support.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Use JSON when another tool needs the stable report schema:
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
 
+List available plugin names before constraining an evidence run:
+
+```sh
+tinyland-cleanup --list-plugins
+```
+
 Constrain review to specific plugins before scanning broad cache surfaces:
 
 ```sh

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -20,6 +20,14 @@ Use JSON when another tool needs the stable report schema:
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
 
+List registered plugin names and whether they are enabled for the current
+config before choosing a bounded evidence run:
+
+```sh
+tinyland-cleanup --list-plugins
+tinyland-cleanup --list-plugins --output json
+```
+
 When gathering evidence on an active workstation, constrain the run to the
 plugin family under review instead of scanning every enabled cache surface:
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@
 //	-level string     Force cleanup level: none, warning, moderate, aggressive, critical
 //	-dry-run          Show what would be cleaned without actually cleaning
 //	-output string    Output format: text, json (default: text)
+//	-list-plugins     List registered plugin names and exit
 //	-plugins string   Comma-separated plugin names to run or plan
 //	-target-used-percent int
 //	                 Override target maximum used-space percentage after cleanup
@@ -33,6 +34,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"syscall"
@@ -58,6 +60,7 @@ func main() {
 		level       = flag.String("level", "", "Force cleanup level")
 		dryRun      = flag.Bool("dry-run", false, "Show what would be cleaned")
 		output      = flag.String("output", "text", "Output format: text, json")
+		listPlugins = flag.Bool("list-plugins", false, "List registered plugin names and exit")
 		pluginNames = flag.String("plugins", "", "Comma-separated plugin names to run or plan")
 		targetUsed  = flag.Int("target-used-percent", 0, "Override target maximum used-space percentage after cleanup")
 		verbose     = flag.Bool("verbose", false, "Enable verbose logging")
@@ -97,6 +100,21 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Create plugin registry and register all plugins.
+	registry := plugins.NewRegistry()
+	registerPlugins(registry)
+	if err := validatePluginFilter(pluginFilter, registry); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
+	if *listPlugins {
+		if err := writePluginList(os.Stdout, *output, listPluginEntries(registry, cfg)); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write plugin list: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// Setup log file directory
 	if err := ensureLogDir(cfg.LogFile); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
@@ -122,14 +140,6 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(multiWriter, &slog.HandlerOptions{
 		Level: logLevel,
 	}))
-
-	// Create plugin registry and register all plugins
-	registry := plugins.NewRegistry()
-	registerPlugins(registry)
-	if err := validatePluginFilter(pluginFilter, registry); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(2)
-	}
 
 	// Create disk monitor
 	diskMon := monitor.NewDiskMonitor(
@@ -463,6 +473,18 @@ type pluginCycleReport struct {
 	Error                    string               `json:"error,omitempty"`
 }
 
+type pluginListReport struct {
+	Plugins []pluginListEntry `json:"plugins"`
+}
+
+type pluginListEntry struct {
+	Name               string   `json:"name"`
+	Description        string   `json:"description"`
+	Enabled            bool     `json:"enabled"`
+	Supported          bool     `json:"supported"`
+	SupportedPlatforms []string `json:"supported_platforms,omitempty"`
+}
+
 type mountAssessment struct {
 	Level  monitor.CleanupLevel
 	Mounts []mountReport
@@ -767,6 +789,63 @@ func filterEnabledPlugins(enabled []plugins.Plugin, filter []string) []plugins.P
 		}
 	}
 	return filtered
+}
+
+func listPluginEntries(registry *plugins.Registry, cfg *config.Config) []pluginListEntry {
+	registered := registry.GetAll()
+	entries := make([]pluginListEntry, 0, len(registered))
+	for _, plugin := range registered {
+		supportedPlatforms := plugin.SupportedPlatforms()
+		entries = append(entries, pluginListEntry{
+			Name:               plugin.Name(),
+			Description:        plugin.Description(),
+			Enabled:            plugin.Enabled(cfg),
+			Supported:          pluginSupportedOnCurrentPlatform(supportedPlatforms),
+			SupportedPlatforms: supportedPlatforms,
+		})
+	}
+	return entries
+}
+
+func pluginSupportedOnCurrentPlatform(supportedPlatforms []string) bool {
+	if len(supportedPlatforms) == 0 {
+		return true
+	}
+	for _, platform := range supportedPlatforms {
+		if platform == runtime.GOOS {
+			return true
+		}
+	}
+	return false
+}
+
+func writePluginList(w io.Writer, output string, entries []pluginListEntry) error {
+	if output == "json" {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(pluginListReport{Plugins: entries})
+	}
+
+	if _, err := fmt.Fprintln(w, "tinyland-cleanup plugins"); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		enabled := "disabled"
+		if entry.Enabled {
+			enabled = "enabled"
+		}
+		supported := "unsupported"
+		if entry.Supported {
+			supported = "supported"
+		}
+		if len(entry.SupportedPlatforms) > 0 {
+			supported += " on " + strings.Join(entry.SupportedPlatforms, ",")
+		}
+		if _, err := fmt.Fprintf(w, "- %s: %s, %s - %s\n", entry.Name, enabled, supported, entry.Description); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func expandPathHome(path string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -371,6 +371,81 @@ func TestValidatePluginFilterRejectsUnknownPlugin(t *testing.T) {
 	}
 }
 
+func TestListPluginEntriesReportsEnabledAndPlatformSupport(t *testing.T) {
+	cfg := config.DefaultConfig()
+	registry := plugins.NewRegistry()
+	registry.Register(&reportingPlugin{name: "all"})
+	registry.Register(&reportingPlugin{name: "unsupported", supported: []string{"not-this-platform"}})
+	registry.Register(&reportingPlugin{name: "disabled", disabled: true})
+
+	entries := listPluginEntries(registry, cfg)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 plugin entries, got %d", len(entries))
+	}
+
+	if entries[0].Name != "all" || !entries[0].Enabled || !entries[0].Supported {
+		t.Fatalf("unexpected all entry: %#v", entries[0])
+	}
+	if entries[1].Name != "unsupported" || !entries[1].Enabled || entries[1].Supported {
+		t.Fatalf("unexpected unsupported entry: %#v", entries[1])
+	}
+	if entries[2].Name != "disabled" || entries[2].Enabled || !entries[2].Supported {
+		t.Fatalf("unexpected disabled entry: %#v", entries[2])
+	}
+}
+
+func TestWritePluginListText(t *testing.T) {
+	var output bytes.Buffer
+	err := writePluginList(&output, "text", []pluginListEntry{
+		{
+			Name:               "bazel",
+			Description:        "Bazel cleanup",
+			Enabled:            true,
+			Supported:          true,
+			SupportedPlatforms: nil,
+		},
+		{
+			Name:               "homebrew",
+			Description:        "Homebrew cleanup",
+			Enabled:            false,
+			Supported:          false,
+			SupportedPlatforms: []string{"darwin"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("writePluginList failed: %v", err)
+	}
+
+	text := output.String()
+	for _, want := range []string{
+		"tinyland-cleanup plugins",
+		"- bazel: enabled, supported - Bazel cleanup",
+		"- homebrew: disabled, unsupported on darwin - Homebrew cleanup",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("plugin list text missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestWritePluginListJSON(t *testing.T) {
+	var output bytes.Buffer
+	err := writePluginList(&output, "json", []pluginListEntry{
+		{Name: "nix", Description: "Nix cleanup", Enabled: true, Supported: true},
+	})
+	if err != nil {
+		t.Fatalf("writePluginList failed: %v", err)
+	}
+
+	var report pluginListReport
+	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+		t.Fatalf("failed to decode plugin list JSON: %v\n%s", err, output.String())
+	}
+	if len(report.Plugins) != 1 || report.Plugins[0].Name != "nix" {
+		t.Fatalf("unexpected plugin list report: %#v", report)
+	}
+}
+
 func TestRunOnceSkipsPluginDuringCooldown(t *testing.T) {
 	var output bytes.Buffer
 	mock := &reportingPlugin{}
@@ -519,9 +594,11 @@ func decodeCycleReport(t *testing.T, data []byte) cycleReport {
 }
 
 type reportingPlugin struct {
-	called bool
-	name   string
-	result plugins.CleanupResult
+	called    bool
+	name      string
+	disabled  bool
+	supported []string
+	result    plugins.CleanupResult
 }
 
 func (p *reportingPlugin) Name() string {
@@ -536,11 +613,11 @@ func (p *reportingPlugin) Description() string {
 }
 
 func (p *reportingPlugin) SupportedPlatforms() []string {
-	return nil
+	return p.supported
 }
 
 func (p *reportingPlugin) Enabled(*config.Config) bool {
-	return true
+	return !p.disabled
 }
 
 func (p *reportingPlugin) Cleanup(context.Context, plugins.CleanupLevel, *config.Config, *slog.Logger) plugins.CleanupResult {


### PR DESCRIPTION
## Summary
- add --list-plugins for side-effect-light plugin discovery
- support text and JSON output with enabled and platform support fields
- document discovery before bounded --plugins evidence runs

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go run . --list-plugins --output json
- git diff --check

No cleanup plan or real cleanup was run.