### PR TITLE
Add cleanup target policy metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ All notable changes to this project will be documented in this file.
   cleanup cycles.
 - CLI `--list-plugins` discovery output for plugin names, enabled state, and
   platform support.
+- Dry-run cleanup targets now carry policy tier, logical byte, reclaim kind,
+  and host-space reclaim expectation metadata where planner evidence is
+  available.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ tinyland-cleanup --once --dry-run --level critical --target-used-percent 82
 ```
 
 See [docs/operator-workflow.md](docs/operator-workflow.md) for the current
-dry-run and host free-space accounting workflow.
+dry-run, candidate policy tier, and host free-space accounting workflow.
 
 Podman on macOS needs extra care because `applehv` raw sparse images do not
 shrink from guest `fstrim` alone. See

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -19,8 +19,10 @@ The Bazel plan includes targets for:
 - `disk_cache`: local action cache entries;
 - `bazelisk`: Bazelisk download cache entries.
 
-Targets include bounded physical byte estimates, active-use evidence, protected
-status, the planned action, and a reason. Output bases are protected when:
+Targets include policy tier, bounded physical byte estimates, logical byte
+estimates when different, host-reclaim expectation, active-use evidence,
+protected status, the planned action, and a reason. Output bases are protected
+when:
 
 - a Bazel or Bazelisk process is active;
 - an output-base lock or server PID file is visible;
@@ -68,6 +70,12 @@ Runtime boundary:
   points inside that deleted output base are removed;
 - byte counts use top-level allocation estimates so dry-run remains responsive
   on very large generated trees;
+- Bazel output bases, repository caches, and disk caches are `warm` targets
+  because they are rebuildable but expensive; Bazelisk downloads are `safe`
+  targets;
+- `delete_output_base` and `delete_cache_tier` targets advertise
+  `reclaim=host` and `host_reclaims_space=true`; review and protected targets
+  advertise `reclaim=none`;
 - idle Bazel server stop remains a follow-up guarded by
   `allow_stop_idle_servers`.
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -68,6 +68,20 @@ Dry-run mode does not call plugin cleanup methods. A plugin entry with
 `skip_reason: "dry_run"` means the plugin is enabled and would run at that
 level during a real cleanup cycle.
 
+Structured plugin targets may include policy metadata:
+
+- `tier`: cleanup risk/rebuild-cost class, such as `safe`, `warm`,
+  `disruptive`, `destructive`, or `privileged`;
+- `bytes`: measured physical allocation when available;
+- `logical_bytes`: logical size when it differs from physical allocation;
+- `reclaim`: whether the planned action is expected to reclaim host space
+  directly (`host`), only enable later reclamation (`deferred`), or reclaim no
+  space by itself (`none`);
+- `host_reclaims_space`: boolean form of the direct host-space expectation.
+
+Use this metadata to separate cheap cache cleanup from expensive rebuilds,
+privileged actions, and review-only evidence before applying a real cleanup.
+
 ## Apply
 
 After reviewing the plan, run the same level without `--dry-run`:

--- a/docs/productionization-plan-2026-04-25.md
+++ b/docs/productionization-plan-2026-04-25.md
@@ -58,6 +58,8 @@ Exit criteria:
 ## Phase 2: Runtime Contracts
 
 - Define policy budgets per cleanup domain.
+- Carry candidate policy tier, host-reclaim expectation, and logical versus
+  physical byte evidence in dry-run target output.
 - Add active-use detection for Bazel, Nix, Podman, and IDE caches.
 - Make dry-run output a stable operator contract.
 - Record free-space deltas before and after each plugin decision.

--- a/main_test.go
+++ b/main_test.go
@@ -111,6 +111,7 @@ func TestRunOnceDryRunJSONReportIncludesPluginPlan(t *testing.T) {
 
 func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
 	var output bytes.Buffer
+	hostReclaims := false
 	mock := &planningPlugin{
 		reportingPlugin: reportingPlugin{},
 		plan: plugins.CleanupPlan{
@@ -121,12 +122,15 @@ func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
 			EstimatedBytesFreed: 1024 * 1024,
 			Targets: []plugins.CleanupTarget{
 				{
-					Type:      "cache",
-					Name:      "example-cache",
-					Bytes:     1024,
-					Protected: true,
-					Action:    "review",
-					Reason:    "operator review required",
+					Type:              "cache",
+					Tier:              plugins.CleanupTierWarm,
+					Name:              "example-cache",
+					Bytes:             1024,
+					Reclaim:           plugins.CleanupReclaimNone,
+					HostReclaimsSpace: &hostReclaims,
+					Protected:         true,
+					Action:            "review",
+					Reason:            "operator review required",
 				},
 			},
 			Warnings: []string{"review before cleanup"},
@@ -147,7 +151,7 @@ func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
 		"plan: estimated reclaim 1.0 MiB",
 		"- reporting: would run (dry_run)",
 		"reporting dry-run plan",
-		"example-cache [cache]: review, protected, 1.0 KiB - operator review required",
+		"example-cache [cache]: review, protected, tier=warm, reclaim=none, 1.0 KiB - operator review required",
 		"review before cleanup",
 	} {
 		if !strings.Contains(text, want) {

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -515,7 +515,7 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 		reason = "stale inactive output base outside retention policy"
 	}
 
-	return CleanupTarget{
+	target := CleanupTarget{
 		Type:      candidate.Type,
 		Name:      candidate.Name,
 		Path:      candidate.Path,
@@ -524,6 +524,22 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 		Protected: protected,
 		Action:    action,
 		Reason:    reason,
+	}
+	if candidate.Logical > 0 && candidate.Logical != candidate.Physical {
+		target.LogicalBytes = candidate.Logical
+	}
+	annotateCleanupTargetPolicy(&target, bazelCandidateTier(candidate.Type), hostReclaimForAction(action))
+	return target
+}
+
+func bazelCandidateTier(candidateType string) string {
+	switch candidateType {
+	case "bazelisk":
+		return CleanupTierSafe
+	case "repository_cache", "disk_cache", "output_base":
+		return CleanupTierWarm
+	default:
+		return CleanupTierWarm
 	}
 }
 

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -46,6 +46,7 @@ func TestBazelPlanTargetsProtectsRecentActiveAndWorkspaces(t *testing.T) {
 			Name:     "old",
 			Path:     "/tmp/old",
 			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Logical:  11,
 			Physical: 10,
 		},
 		{
@@ -86,6 +87,15 @@ func TestBazelPlanTargetsProtectsRecentActiveAndWorkspaces(t *testing.T) {
 
 	if actions["old"].Action != "delete_output_base" {
 		t.Fatalf("old action = %q, want delete_output_base", actions["old"].Action)
+	}
+	if actions["old"].Tier != CleanupTierWarm || actions["old"].Reclaim != CleanupReclaimHost {
+		t.Fatalf("old target policy = tier %q reclaim %q, want warm/host", actions["old"].Tier, actions["old"].Reclaim)
+	}
+	if actions["old"].HostReclaimsSpace == nil || !*actions["old"].HostReclaimsSpace {
+		t.Fatalf("old target should be marked as host-space reclaiming: %#v", actions["old"])
+	}
+	if actions["old"].LogicalBytes != 11 {
+		t.Fatalf("old logical bytes = %d, want 11", actions["old"].LogicalBytes)
 	}
 	for _, name := range []string{"new", "active", "protected"} {
 		if actions[name].Action != "keep" || !actions[name].Protected {

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -643,7 +643,8 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 		for _, entry := range listDarwinCacheEntries(jetBrainsRoot) {
 			stale := darwinCacheEntryStale(entry, cfg.JetBrains.StaleAfterDays)
 			eligible := !jetBrainsActive && (level >= LevelCritical || (level >= LevelAggressive && stale))
-			targets = append(targets, CleanupTarget{
+			action := darwinCacheAction(jetBrainsActive, enforce, eligible)
+			target := CleanupTarget{
 				Type:      "jetbrains",
 				Name:      entry.name,
 				Version:   entry.version,
@@ -651,9 +652,11 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 				Bytes:     entry.bytes,
 				Active:    jetBrainsActive,
 				Protected: darwinCacheProtected(jetBrainsActive, enforce, eligible),
-				Action:    darwinCacheAction(jetBrainsActive, enforce, eligible),
+				Action:    action,
 				Reason:    darwinCacheReason(jetBrainsActive, enforce, eligible, "JetBrains cache version", "requires aggressive stale-cache enforcement or critical pressure"),
-			})
+			}
+			annotateCleanupTargetPolicy(&target, CleanupTierWarm, hostReclaimForAction(action))
+			targets = append(targets, target)
 		}
 	}
 
@@ -664,16 +667,19 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 		for _, entry := range entries {
 			isProtected := protected[entry.path]
 			eligible := !isProtected && level >= LevelModerate
-			targets = append(targets, CleanupTarget{
+			action := darwinCacheAction(isProtected, enforce, eligible)
+			target := CleanupTarget{
 				Type:      "playwright",
 				Name:      entry.name,
 				Version:   entry.version,
 				Path:      entry.path,
 				Bytes:     entry.bytes,
 				Protected: isProtected,
-				Action:    darwinCacheAction(isProtected, enforce, eligible),
+				Action:    action,
 				Reason:    darwinCacheReason(isProtected, enforce, eligible, "Playwright browser revision", "older than keep-latest-per-family policy"),
-			})
+			}
+			annotateCleanupTargetPolicy(&target, CleanupTierWarm, hostReclaimForAction(action))
+			targets = append(targets, target)
 		}
 	}
 
@@ -687,16 +693,19 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 		for idx, entry := range entries {
 			isProtected := keepLatest > 0 && idx < keepLatest
 			eligible := !isProtected && level >= LevelModerate
-			targets = append(targets, CleanupTarget{
+			action := darwinCacheAction(isProtected, enforce, eligible)
+			target := CleanupTarget{
 				Type:      "bazelisk",
 				Name:      entry.name,
 				Version:   entry.version,
 				Path:      entry.path,
 				Bytes:     entry.bytes,
 				Protected: isProtected,
-				Action:    darwinCacheAction(isProtected, enforce, eligible),
+				Action:    action,
 				Reason:    darwinCacheReason(isProtected, enforce, eligible, "Bazelisk download cache", "older than keep-latest policy"),
-			})
+			}
+			annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(action))
+			targets = append(targets, target)
 		}
 	}
 
@@ -710,15 +719,18 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 			}
 			stale := dirModTimeStale(pipPath, cfg.Pip.StaleAfterDays)
 			eligible := level >= LevelModerate && stale
-			targets = append(targets, CleanupTarget{
+			action := darwinCacheAction(false, enforce, eligible)
+			target := CleanupTarget{
 				Type:      "pip",
 				Name:      filepath.Base(pipPath),
 				Path:      pipPath,
 				Bytes:     getDirAllocatedBytes(pipPath),
 				Protected: darwinCacheProtected(false, enforce, eligible),
-				Action:    darwinCacheAction(false, enforce, eligible),
+				Action:    action,
 				Reason:    darwinCacheReason(false, enforce, eligible, "pip cache", fmt.Sprintf("stale-after policy is %d days", cfg.Pip.StaleAfterDays)),
-			})
+			}
+			annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(action))
+			targets = append(targets, target)
 		}
 	}
 
@@ -751,18 +763,21 @@ func (p *CachePlugin) darwinEditorCacheTargets(home string, cfg config.DarwinDev
 		stale := dirModTimeStale(path, cfg.StaleAfterDays)
 		eligible := !active && (level >= LevelCritical || (level >= LevelModerate && stale))
 		name := darwinEditorCacheTargetName(home, path)
-		targets = append(targets, CleanupTarget{
+		action := darwinCacheAction(active, enforce, eligible)
+		target := CleanupTarget{
 			Type:      targetType,
 			Name:      name,
 			Path:      path,
 			Bytes:     getDirAllocatedBytes(path),
 			Active:    active,
 			Protected: darwinCacheProtected(active, enforce, eligible),
-			Action:    darwinCacheAction(active, enforce, eligible),
+			Action:    action,
 			Reason: darwinCacheReason(active, enforce, eligible,
 				displayName+" cache directory",
 				fmt.Sprintf("stale-after policy is %d days; critical pressure can delete inactive editor cache directories", cfg.StaleAfterDays)),
-		})
+		}
+		annotateCleanupTargetPolicy(&target, CleanupTierWarm, hostReclaimForAction(action))
+		targets = append(targets, target)
 	}
 
 	return targets

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -281,7 +281,19 @@ func (p *DevArtifactsPlugin) devArtifactTarget(targetType, name, path string, by
 		target.Action = "protect"
 		target.Reason = fmt.Sprintf("project marker %s is newer than %s", marker, formatDevArtifactAge(maxAge))
 	}
+	annotateCleanupTargetPolicy(&target, devArtifactTier(targetType), hostReclaimForAction(target.Action))
 	return target
+}
+
+func devArtifactTier(targetType string) string {
+	switch targetType {
+	case "go-build-cache", "haskell-ghcup-cache":
+		return CleanupTierSafe
+	case "lmstudio-models":
+		return CleanupTierDestructive
+	default:
+		return CleanupTierWarm
+	}
 }
 
 func (p *DevArtifactsPlugin) pythonProjectStale(parentDir string, markers []string, maxAge time.Duration) bool {
@@ -314,6 +326,7 @@ func (p *DevArtifactsPlugin) planGoBuildCache(ctx context.Context, level Cleanup
 		target.Active = true
 		target.Protected = true
 		target.Reason = "active development process detected: " + activeReason
+		annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(target.Action))
 		*targets = append(*targets, target)
 		return
 	}
@@ -330,6 +343,7 @@ func (p *DevArtifactsPlugin) planGoBuildCache(ctx context.Context, level Cleanup
 		target.Protected = true
 		target.Reason = "warning level reports Go build cache without deleting it"
 	}
+	annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(target.Action))
 	*targets = append(*targets, target)
 }
 
@@ -347,17 +361,16 @@ func (p *DevArtifactsPlugin) planHaskellCaches(home string, level CleanupLevel, 
 			target.Active = true
 			target.Protected = true
 			target.Reason = "active development process detected: " + activeReason
-			*targets = append(*targets, target)
 		} else if level >= LevelModerate {
 			target.Action = "delete"
 			target.Reason = ".ghcup/cache contains rebuildable/downloadable artifacts"
-			*targets = append(*targets, target)
 		} else {
 			target.Action = "report"
 			target.Protected = true
 			target.Reason = "warning level reports Haskell caches without deleting them"
-			*targets = append(*targets, target)
 		}
+		annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(target.Action))
+		*targets = append(*targets, target)
 	}
 
 	cabalStore := filepath.Join(home, ".cabal", "store")
@@ -373,6 +386,7 @@ func (p *DevArtifactsPlugin) planHaskellCaches(home string, level CleanupLevel, 
 			target.Active = true
 			target.Protected = true
 			target.Reason = "active development process detected: " + activeReason
+			annotateCleanupTargetPolicy(&target, CleanupTierWarm, hostReclaimForAction(target.Action))
 			*targets = append(*targets, target)
 			return
 		}
@@ -384,6 +398,7 @@ func (p *DevArtifactsPlugin) planHaskellCaches(home string, level CleanupLevel, 
 			target.Protected = true
 			target.Reason = "moderate and warning levels preserve .cabal/store"
 		}
+		annotateCleanupTargetPolicy(&target, CleanupTierWarm, hostReclaimForAction(target.Action))
 		*targets = append(*targets, target)
 	}
 }
@@ -404,6 +419,7 @@ func (p *DevArtifactsPlugin) planLMStudioModels(home string, level CleanupLevel,
 		target.Active = true
 		target.Protected = true
 		target.Reason = "active development process detected: " + activeReason
+		annotateCleanupTargetPolicy(&target, CleanupTierDestructive, hostReclaimForAction(target.Action))
 		*targets = append(*targets, target)
 		return
 	}
@@ -415,6 +431,7 @@ func (p *DevArtifactsPlugin) planLMStudioModels(home string, level CleanupLevel,
 		target.Protected = true
 		target.Reason = "LM Studio model cleanup is opt-in and reports until critical"
 	}
+	annotateCleanupTargetPolicy(&target, CleanupTierDestructive, hostReclaimForAction(target.Action))
 	*targets = append(*targets, target)
 }
 

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -386,6 +386,7 @@ func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLeve
 				systemTargets[i].Protected = true
 				systemTargets[i].Action = "review_privileged_generation"
 				systemTargets[i].Reason = "outside retention policy, but system generation deletion requires explicit privileged workflow"
+				annotateCleanupTargetPolicy(&systemTargets[i], CleanupTierPrivileged, CleanupReclaimDeferred)
 			}
 		}
 		targets = append(targets, systemTargets...)
@@ -643,7 +644,7 @@ func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
 			reason = "active process root; review the owning process before any Nix GC action"
 		}
 
-		targets = append(targets, CleanupTarget{
+		target := CleanupTarget{
 			Type:      "nix_gc_root",
 			Name:      name,
 			Path:      root.Root,
@@ -651,7 +652,9 @@ func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
 			Protected: true,
 			Action:    "review_gc_root",
 			Reason:    reason,
-		})
+		}
+		annotateCleanupTargetPolicy(&target, CleanupTierSafe, CleanupReclaimNone)
+		targets = append(targets, target)
 	}
 	return targets
 }
@@ -722,7 +725,7 @@ func nixGenerationTargets(generations []nixGeneration, now time.Time, minKeep in
 		if nameScope == "" {
 			nameScope = "profile"
 		}
-		targets = append(targets, CleanupTarget{
+		target := CleanupTarget{
 			Type:      "nix_generation",
 			Name:      fmt.Sprintf("%s generation %d", nameScope, generation.Number),
 			Version:   strconv.Itoa(generation.Number),
@@ -730,7 +733,13 @@ func nixGenerationTargets(generations []nixGeneration, now time.Time, minKeep in
 			Protected: protected,
 			Action:    action,
 			Reason:    reason,
-		})
+		}
+		reclaim := CleanupReclaimNone
+		if action == "delete_generation" {
+			reclaim = CleanupReclaimDeferred
+		}
+		annotateCleanupTargetPolicy(&target, CleanupTierWarm, reclaim)
+		targets = append(targets, target)
 	}
 
 	sort.Slice(targets, func(i, j int) bool {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -196,6 +196,16 @@ func TestNixGenerationTargetsPreserveCurrentAndMinimum(t *testing.T) {
 	if actions["2"] != "delete_generation" || protected["2"] {
 		t.Fatalf("expected generation 2 to be a deletion candidate, actions=%v protected=%v", actions, protected)
 	}
+	for _, target := range targets {
+		if target.Version == "1" {
+			if target.Tier != CleanupTierWarm || target.Reclaim != CleanupReclaimDeferred {
+				t.Fatalf("generation 1 policy = tier %q reclaim %q, want warm/deferred", target.Tier, target.Reclaim)
+			}
+			if target.HostReclaimsSpace == nil || *target.HostReclaimsSpace {
+				t.Fatalf("generation deletion should not directly reclaim host space: %+v", target)
+			}
+		}
+	}
 	for _, generation := range []string{"3", "4", "5"} {
 		if actions[generation] != "keep_generation" || !protected[generation] {
 			t.Fatalf("expected generation %s to be protected, actions=%v protected=%v", generation, actions, protected)

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"runtime"
+	"strings"
 
 	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
@@ -23,6 +24,28 @@ const (
 	LevelAggressive
 	// LevelCritical triggers emergency cleanup (everything)
 	LevelCritical
+)
+
+const (
+	// CleanupTierSafe is trivially rebuildable cache with low active-work impact.
+	CleanupTierSafe = "safe"
+	// CleanupTierWarm is rebuildable but expensive enough to slow active work.
+	CleanupTierWarm = "warm"
+	// CleanupTierDisruptive requires stopping services, daemons, VMs, or tools.
+	CleanupTierDisruptive = "disruptive"
+	// CleanupTierDestructive may remove local-only generated artifacts or large user-managed assets.
+	CleanupTierDestructive = "destructive"
+	// CleanupTierPrivileged requires sudo, launchd/systemd, or host package manager authority.
+	CleanupTierPrivileged = "privileged"
+)
+
+const (
+	// CleanupReclaimHost means the planned action is expected to increase host free space.
+	CleanupReclaimHost = "host"
+	// CleanupReclaimDeferred means the action only enables later host free-space reclamation.
+	CleanupReclaimDeferred = "deferred"
+	// CleanupReclaimNone means the plan item is review/protection metadata only.
+	CleanupReclaimNone = "none"
 )
 
 // String returns the string representation of the cleanup level.
@@ -93,14 +116,22 @@ type CleanupPlan struct {
 type CleanupTarget struct {
 	// Type is the cache or resource class.
 	Type string `json:"type"`
+	// Tier classifies the operational risk/rebuild cost of the target.
+	Tier string `json:"tier,omitempty"`
 	// Name is a short target label.
 	Name string `json:"name"`
 	// Version is the tool or cache version when detectable.
 	Version string `json:"version,omitempty"`
 	// Path is the local filesystem path for file-backed targets.
 	Path string `json:"path,omitempty"`
-	// Bytes is the measured target size.
+	// Bytes is the measured physical target size when available.
 	Bytes int64 `json:"bytes"`
+	// LogicalBytes is the logical target size when it differs from physical allocation.
+	LogicalBytes int64 `json:"logical_bytes,omitempty"`
+	// Reclaim describes whether the planned action should reclaim host space.
+	Reclaim string `json:"reclaim,omitempty"`
+	// HostReclaimsSpace reports whether the planned action should increase host free space.
+	HostReclaimsSpace *bool `json:"host_reclaims_space,omitempty"`
 	// Active reports whether active-use evidence was detected.
 	Active bool `json:"active"`
 	// Protected reports whether the plan should preserve the target.
@@ -109,6 +140,38 @@ type CleanupTarget struct {
 	Action string `json:"action"`
 	// Reason explains why the action was selected.
 	Reason string `json:"reason,omitempty"`
+}
+
+func annotateCleanupTargetPolicy(target *CleanupTarget, tier string, reclaim string) {
+	target.Tier = tier
+	target.Reclaim = reclaim
+	target.HostReclaimsSpace = hostReclaimExpectation(reclaim)
+}
+
+func hostReclaimExpectation(reclaim string) *bool {
+	if reclaim == "" {
+		return nil
+	}
+	reclaims := reclaim == CleanupReclaimHost
+	return &reclaims
+}
+
+func hostReclaimForAction(action string) string {
+	switch {
+	case strings.HasPrefix(action, "delete"),
+		action == "clean-cache",
+		action == "clean-stale-files":
+		return CleanupReclaimHost
+	case action == "review",
+		action == "report",
+		action == "protect",
+		action == "keep",
+		strings.HasPrefix(action, "review_"),
+		strings.HasPrefix(action, "keep_"):
+		return CleanupReclaimNone
+	default:
+		return CleanupReclaimNone
+	}
 }
 
 // Plugin is the interface that cleanup plugins must implement.

--- a/report_text.go
+++ b/report_text.go
@@ -255,8 +255,23 @@ func writeTextTarget(w io.Writer, target plugins.CleanupTarget) error {
 	if _, err := fmt.Fprintf(w, "  - %s [%s]: %s", name, target.Type, status); err != nil {
 		return err
 	}
+	if target.Tier != "" {
+		if _, err := fmt.Fprintf(w, ", tier=%s", target.Tier); err != nil {
+			return err
+		}
+	}
+	if target.Reclaim != "" {
+		if _, err := fmt.Fprintf(w, ", reclaim=%s", target.Reclaim); err != nil {
+			return err
+		}
+	}
 	if target.Bytes > 0 {
 		if _, err := fmt.Fprintf(w, ", %s", formatByteCount(target.Bytes)); err != nil {
+			return err
+		}
+	}
+	if target.LogicalBytes > 0 && target.LogicalBytes != target.Bytes {
+		if _, err := fmt.Fprintf(w, ", logical %s", formatByteCount(target.LogicalBytes)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- add cleanup target tier, reclaim, host-space, and logical-size metadata to the shared dry-run target model
- annotate Bazel, Nix, Darwin developer-cache, and dev-artifact planners without changing deletion eligibility
- document the operator-facing policy fields

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- git diff --check

No cleanup dry-run against live cache surfaces was run.