### PR TITLE
Apply JetBrains cache budget targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ All notable changes to this project will be documented in this file.
 - Dry-run cleanup targets now carry policy tier, logical byte, reclaim kind,
   and host-space reclaim expectation metadata where planner evidence is
   available.
+- Darwin JetBrains cache planning now uses the configured `max_gb` budget to
+  mark oldest inactive cache versions as opt-in aggressive cleanup candidates.
 
 ### Changed
 

--- a/docs/darwin-dev-caches.md
+++ b/docs/darwin-dev-caches.md
@@ -21,8 +21,9 @@ The cache plugin plan includes `targets` for known cache families:
 - `cursor-cache`: selected Cursor cache directories with the same cache-only
   boundary.
 
-Targets include the cache type, name, detected version, path, physical bytes,
-active-use evidence, protected status, review action, and reason.
+Targets include the cache type, policy tier, name, detected version, path,
+physical bytes, active-use evidence, protected status, reclaim expectation,
+review action, and reason.
 
 Safety boundaries:
 
@@ -48,6 +49,7 @@ darwin_dev_caches:
 When `enforce: true`, moderate cleanup can delete unprotected Playwright and
 Bazelisk entries outside the keep-latest policy, stale pip caches, and stale
 inactive editor cache directories. Aggressive cleanup can delete inactive stale
-JetBrains cache versions. Critical cleanup can delete inactive unprotected
-JetBrains and editor cache targets regardless of age. The same protected target
-rules from dry-run planning are used for real cleanup.
+JetBrains cache versions and the oldest inactive JetBrains versions needed to
+bring `jetbrains.max_gb` back under budget. Critical cleanup can delete inactive
+unprotected JetBrains and editor cache targets regardless of age. The same
+protected target rules from dry-run planning are used for real cleanup.

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -18,6 +18,8 @@ import (
 	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
+const darwinDevCacheGiB = int64(1024 * 1024 * 1024)
+
 // HomebrewPlugin handles Homebrew cleanup operations.
 type HomebrewPlugin struct{}
 
@@ -632,6 +634,50 @@ type darwinCacheEntry struct {
 	bytes   int64
 }
 
+func darwinCacheEntriesOverBudget(entries []darwinCacheEntry, maxGB int, keepNewest int) map[string]bool {
+	overBudget := map[string]bool{}
+	if maxGB <= 0 || len(entries) == 0 {
+		return overBudget
+	}
+
+	budget := int64(maxGB) * darwinDevCacheGiB
+	var total int64
+	for _, entry := range entries {
+		total += entry.bytes
+	}
+	if total <= budget {
+		return overBudget
+	}
+
+	sorted := append([]darwinCacheEntry(nil), entries...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].modTime.After(sorted[j].modTime)
+	})
+
+	protectedNewest := map[string]bool{}
+	for idx, entry := range sorted {
+		if idx >= keepNewest {
+			break
+		}
+		protectedNewest[entry.path] = true
+	}
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].modTime.Before(sorted[j].modTime)
+	})
+	for _, entry := range sorted {
+		if total <= budget {
+			break
+		}
+		if protectedNewest[entry.path] {
+			continue
+		}
+		overBudget[entry.path] = true
+		total -= entry.bytes
+	}
+	return overBudget
+}
+
 func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.DarwinDevCachesConfig, activeProcesses map[string]bool, level CleanupLevel) []CleanupTarget {
 	var targets []CleanupTarget
 	enforce := cfg.Enforce && level >= LevelModerate
@@ -640,9 +686,19 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 		jetBrainsRoot := filepath.Join(home, "Library", "Caches", "JetBrains")
 		jetBrainsActive := cfg.JetBrains.KeepActiveVersions && darwinAnyProcessActive(activeProcesses,
 			"appcode", "clion", "datagrip", "goland", "idea", "intellij", "phpstorm", "pycharm", "rider", "rubymine", "webstorm")
-		for _, entry := range listDarwinCacheEntries(jetBrainsRoot) {
+		entries := listDarwinCacheEntries(jetBrainsRoot)
+		overBudget := darwinCacheEntriesOverBudget(entries, cfg.JetBrains.MaxGB, 0)
+		for _, entry := range entries {
 			stale := darwinCacheEntryStale(entry, cfg.JetBrains.StaleAfterDays)
-			eligible := !jetBrainsActive && (level >= LevelCritical || (level >= LevelAggressive && stale))
+			budgetCandidate := overBudget[entry.path]
+			eligible := !jetBrainsActive && (level >= LevelCritical || (level >= LevelAggressive && (stale || budgetCandidate)))
+			eligibility := "requires aggressive stale-cache enforcement or critical pressure"
+			if cfg.JetBrains.MaxGB > 0 {
+				eligibility = fmt.Sprintf("requires aggressive stale-cache enforcement, max_gb budget pressure, or critical pressure; max_gb=%d", cfg.JetBrains.MaxGB)
+			}
+			if budgetCandidate {
+				eligibility = fmt.Sprintf("outside JetBrains max_gb=%d budget", cfg.JetBrains.MaxGB)
+			}
 			action := darwinCacheAction(jetBrainsActive, enforce, eligible)
 			target := CleanupTarget{
 				Type:      "jetbrains",
@@ -653,7 +709,7 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 				Active:    jetBrainsActive,
 				Protected: darwinCacheProtected(jetBrainsActive, enforce, eligible),
 				Action:    action,
-				Reason:    darwinCacheReason(jetBrainsActive, enforce, eligible, "JetBrains cache version", "requires aggressive stale-cache enforcement or critical pressure"),
+				Reason:    darwinCacheReason(jetBrainsActive, enforce, eligible, "JetBrains cache version", eligibility),
 			}
 			annotateCleanupTargetPolicy(&target, CleanupTierWarm, hostReclaimForAction(action))
 			targets = append(targets, target)

--- a/plugins/darwin_dev_cache_test.go
+++ b/plugins/darwin_dev_cache_test.go
@@ -106,6 +106,23 @@ func TestDarwinDeveloperCacheTargetsOptInEnforcement(t *testing.T) {
 	}
 }
 
+func TestDarwinCacheEntriesOverBudgetSelectsOldestEntries(t *testing.T) {
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	entries := []darwinCacheEntry{
+		{path: "/cache/new", modTime: now, bytes: 600 * 1024 * 1024},
+		{path: "/cache/mid", modTime: now.Add(-1 * time.Hour), bytes: 600 * 1024 * 1024},
+		{path: "/cache/old", modTime: now.Add(-2 * time.Hour), bytes: 600 * 1024 * 1024},
+	}
+
+	overBudget := darwinCacheEntriesOverBudget(entries, 1, 1)
+	if !overBudget["/cache/old"] || overBudget["/cache/new"] {
+		t.Fatalf("expected oldest entry over budget while newest is protected: %#v", overBudget)
+	}
+	if len(overBudget) != 2 {
+		t.Fatalf("expected two entries to bring cache under budget, got %#v", overBudget)
+	}
+}
+
 func TestDarwinDeveloperCacheTargetsEditorCaches(t *testing.T) {
 	home := t.TempDir()
 	cfg := config.DefaultConfig().DarwinDevCaches


### PR DESCRIPTION
## Summary
- use darwin_dev_caches.jetbrains.max_gb when classifying JetBrains cache targets
- mark oldest inactive over-budget JetBrains cache versions as opt-in aggressive cleanup candidates
- document the budget behavior and cover oldest-first selection with tests

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- git diff --check

No cleanup dry-run against live cache surfaces was run.