### PR TITLE
Defer Nix plans on store contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ All notable changes to this project will be documented in this file.
   available.
 - Darwin JetBrains cache planning now uses the configured `max_gb` budget to
   mark oldest inactive cache versions as opt-in aggressive cleanup candidates.
+- Nix dry-run GC lock and SQLite contention now surfaces as
+  `nix_daemon_contention` deferral when daemon-busy skipping is enabled.
 
 ### Changed
 

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -15,6 +15,8 @@ The Nix plan includes:
 - `estimated_bytes_freed` from `nix-collect-garbage --dry-run`;
 - detected active Nix work such as `nix build`, `home-manager switch`,
   `darwin-rebuild`, `nixos-rebuild`, and worker-style `nix-daemon` activity;
+- `nix_daemon_contention` deferral when dry-run GC itself reports SQLite or
+  store lock contention and `skip_when_daemon_busy` is enabled;
 - visible GC roots when dry-run GC reports no reclaimable store space;
 - generation targets with `keep_generation`, `delete_generation`, or
   `review_privileged_generation` actions;
@@ -42,6 +44,9 @@ Runtime behavior:
 - moderate and aggressive may delete old user profile generations selected by
   the age policy, while preserving the current generation and the minimum count;
 - critical uses the stricter age policy, then runs plain Nix garbage collection;
+- dry-run GC lock or SQLite contention is treated like active Nix work when
+  `skip_when_daemon_busy` is enabled, so the plan is deferred instead of
+  continuing into generation inspection;
 - system or nix-darwin generations are reported for operator review but are not
   deleted by the unprivileged plugin path;
 - low-reclaim dry-runs run `nix-store --gc --print-roots` and emit protected

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -109,6 +109,16 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 	}
 
 	if output, err := p.collectGarbageDryRun(ctx, cfg.Nix); err != nil {
+		if reason, ok := nixContentionReason(output); ok {
+			plan.Metadata["nix_contention"] = reason
+			plan.Warnings = append(plan.Warnings, fmt.Sprintf("nix-collect-garbage dry-run reported store contention: %s", reason))
+			if cfg.Nix.SkipWhenDaemonBusy {
+				plan.WouldRun = false
+				plan.SkipReason = "nix_daemon_contention"
+				plan.Summary = "Nix cleanup is deferred because dry-run reported store contention"
+				return plan
+			}
+		}
 		plan.Warnings = append(plan.Warnings, fmt.Sprintf("nix-collect-garbage dry-run failed: %v", err))
 	} else {
 		estimated := p.parseDryRunFreedSpace(output)
@@ -790,6 +800,30 @@ func nixBusyProcessReasons(output string) []string {
 
 	sort.Strings(reasons)
 	return reasons
+}
+
+func nixContentionReason(output string) (string, bool) {
+	normalized := strings.ToLower(strings.Join(strings.Fields(output), " "))
+	if normalized == "" {
+		return "", false
+	}
+
+	switch {
+	case strings.Contains(normalized, "sqlite") && strings.Contains(normalized, "busy"):
+		return "sqlite database busy", true
+	case strings.Contains(normalized, "database is locked"):
+		return "sqlite database locked", true
+	case strings.Contains(normalized, "big-lock") &&
+		(strings.Contains(normalized, "resource temporarily unavailable") ||
+			strings.Contains(normalized, "temporarily unavailable") ||
+			strings.Contains(normalized, "locked") ||
+			strings.Contains(normalized, "busy")):
+		return "nix store big-lock busy", true
+	case strings.Contains(normalized, "waiting for the big nix store lock"):
+		return "nix store big-lock busy", true
+	default:
+		return "", false
+	}
 }
 
 func (p *NixPlugin) parseDryRunFreedSpace(output string) int64 {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -88,6 +88,48 @@ func TestNixBusyProcessReasons(t *testing.T) {
 	}
 }
 
+func TestNixContentionReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected string
+		ok       bool
+	}{
+		{
+			name:     "sqlite busy",
+			output:   "error: SQLite database '/nix/var/nix/db/db.sqlite' is busy",
+			expected: "sqlite database busy",
+			ok:       true,
+		},
+		{
+			name:     "database locked",
+			output:   "error: cannot open SQLite database: database is locked",
+			expected: "sqlite database locked",
+			ok:       true,
+		},
+		{
+			name:     "big lock unavailable",
+			output:   "error: opening lock file '/nix/var/nix/db/big-lock': Resource temporarily unavailable",
+			expected: "nix store big-lock busy",
+			ok:       true,
+		},
+		{
+			name:   "unrelated error",
+			output: "error: path '/nix/store/missing' does not exist",
+			ok:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := nixContentionReason(tt.output)
+			if ok != tt.ok || got != tt.expected {
+				t.Fatalf("nixContentionReason(%q) = %q, %t; want %q, %t", tt.output, got, ok, tt.expected, tt.ok)
+			}
+		})
+	}
+}
+
 func TestParseNixGenerations(t *testing.T) {
 	output := `
    1   2026-04-01 10:00:00


### PR DESCRIPTION
## Summary
- detect Nix dry-run GC SQLite and store-lock contention from command output
- defer the Nix cleanup plan with skip_reason nix_daemon_contention when skip_when_daemon_busy is enabled
- document the deferral behavior and cover parser cases with unit tests

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- git diff --check

No cleanup dry-run against live Nix store/cache surfaces was run.