### PR TITLE
Skip Nix cleanup on store contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ All notable changes to this project will be documented in this file.
   mark oldest inactive cache versions as opt-in aggressive cleanup candidates.
 - Nix dry-run GC lock and SQLite contention now surfaces as
   `nix_daemon_contention` deferral when daemon-busy skipping is enabled.
+- Nix generation deletion and GC commands now treat the same contention
+  signatures as skipped cleanup rather than hard failures when daemon-busy
+  skipping is enabled.
 
 ### Changed
 

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -47,6 +47,9 @@ Runtime behavior:
 - dry-run GC lock or SQLite contention is treated like active Nix work when
   `skip_when_daemon_busy` is enabled, so the plan is deferred instead of
   continuing into generation inspection;
+- real generation deletion and GC commands also treat those contention
+  signatures as deferred no-op cleanup steps when `skip_when_daemon_busy` is
+  enabled;
 - system or nix-darwin generations are reported for operator review but are not
   deleted by the unprivileged plugin path;
 - low-reclaim dry-runs run `nix-store --gc --print-roots` and emit protected

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -270,6 +270,10 @@ func (p *NixPlugin) collectGarbage(ctx context.Context, level CleanupLevel, args
 	cmd := exec.CommandContext(ctx, "nix-collect-garbage", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if reason, ok := nixContentionReason(string(output)); ok && cfg.SkipWhenDaemonBusy {
+			logger.Warn("skipping Nix garbage collection because store contention was reported", "reason", reason)
+			return result
+		}
 		result.Error = err
 		return result
 	}
@@ -354,6 +358,10 @@ func (p *NixPlugin) deleteUserGenerationsByPolicy(ctx context.Context, level Cle
 	cmd := exec.CommandContext(deleteCtx, "nix-env", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if reason, ok := nixContentionReason(string(output)); ok && cfg.SkipWhenDaemonBusy {
+			logger.Warn("skipping Nix generation deletion because store contention was reported", "reason", reason)
+			return result
+		}
 		result.Error = fmt.Errorf("nix-env %s failed: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
 		return result
 	}


### PR DESCRIPTION
## Summary
- treat Nix generation deletion and GC store-lock contention as deferred no-op cleanup when skip_when_daemon_busy is enabled
- keep non-contention command failures as hard errors
- document the real-cleanup behavior alongside the dry-run preflight deferral

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- git diff --check

No cleanup dry-run or real cleanup against live Nix store/cache surfaces was run.