### PR TITLE
Add Docker dry-run planner

### DIFF
--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -35,6 +35,7 @@ plugin family under review instead of scanning every enabled cache surface:
 tinyland-cleanup --once --dry-run --level critical --plugins bazel --output text
 tinyland-cleanup --once --dry-run --level critical --plugins nix --output json
 tinyland-cleanup --once --dry-run --level critical --plugins cache --output text
+tinyland-cleanup --once --dry-run --level critical --plugins docker --output json
 ```
 
 The plugin filter is comma-separated and preserves the normal registry order:
@@ -143,6 +144,14 @@ level reports only; moderate and above mark eligible stale artifacts as
 deletion or cache-clean targets while preserving configured protected paths.
 The plan also protects matching artifact families when active package manager,
 compiler, language server, runtime, or LM Studio processes are visible.
+
+For Docker, the plan reports Docker daemon disk-usage rows from `docker system
+df`, including images, stopped containers, local volumes, and build cache when
+available. Docker cleanup is deferred when active Docker build, buildx, compose,
+pull, push, or run work is visible and `docker.protect_running_containers` is
+enabled. Reported reclaimable bytes may describe Docker daemon or VM storage
+and may not immediately equal host free-space delta on macOS or VM-backed
+Docker installations.
 
 ## Current Boundary
 

--- a/plugins/docker.go
+++ b/plugins/docker.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +20,15 @@ import (
 // DockerPlugin handles Docker cleanup operations.
 type DockerPlugin struct {
 	socketPath string
+}
+
+type dockerDFSummaryRow struct {
+	Type             string
+	Total            string
+	Active           string
+	SizeBytes        int64
+	ReclaimableBytes int64
+	Raw              string
 }
 
 // NewDockerPlugin creates a new Docker cleanup plugin.
@@ -45,6 +56,68 @@ func (p *DockerPlugin) Enabled(cfg *config.Config) bool {
 	return cfg.Enable.Docker
 }
 
+// PlanCleanup returns a non-mutating Docker cleanup plan.
+func (p *DockerPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupPlan {
+	if cfg.Docker.Socket != "" {
+		p.socketPath = cfg.Docker.Socket
+	}
+
+	plan := CleanupPlan{
+		Plugin:   p.Name(),
+		Level:    level.String(),
+		Summary:  "Docker cleanup plan",
+		WouldRun: true,
+		Steps:    dockerPlanSteps(level, cfg.Docker),
+		Metadata: map[string]string{
+			"cleanup_level":              level.String(),
+			"prune_images_age":           cfg.Docker.PruneImagesAge,
+			"protect_running_containers": strconv.FormatBool(cfg.Docker.ProtectRunningContainers),
+			"socket_configured":          strconv.FormatBool(p.socketPath != ""),
+		},
+	}
+
+	if !p.isDockerAvailableContext(ctx) {
+		plan.Summary = "Docker is not available"
+		plan.WouldRun = false
+		plan.SkipReason = "docker_unavailable"
+		return plan
+	}
+
+	activeReasons, activeErr := p.activeDockerProcesses(ctx)
+	if activeErr != nil {
+		plan.Summary = "Docker cleanup is deferred because active process inspection failed"
+		plan.WouldRun = false
+		plan.SkipReason = "docker_process_inspection_failed"
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("could not inspect active Docker processes: %v", activeErr))
+	} else if len(activeReasons) > 0 {
+		plan.Metadata["active_docker_processes"] = strings.Join(activeReasons, ", ")
+		if cfg.Docker.ProtectRunningContainers {
+			plan.Summary = "Docker cleanup is deferred because active Docker work was detected"
+			plan.WouldRun = false
+			plan.SkipReason = "docker_active_work"
+		}
+	}
+
+	dfOutput, err := p.runDockerCommandWithTimeout(ctx, 30*time.Second, "system", "df")
+	if err != nil {
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("could not inspect Docker disk usage: %v", err))
+		plan.Metadata["system_df_available"] = "false"
+	} else {
+		rows := parseDockerDFSummaryRows(dfOutput)
+		reclaim := dockerPlanReclaimExpectation()
+		plan.Targets = dockerPlanTargets(rows, level, reclaim, len(activeReasons) > 0 && cfg.Docker.ProtectRunningContainers)
+		plan.EstimatedBytesFreed = dockerEstimatedCandidateBytes(plan.Targets)
+		plan.Metadata["system_df_available"] = "true"
+		plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
+		plan.Metadata["total_physical_bytes"] = strconv.FormatInt(dockerTotalSizeBytes(rows), 10)
+		plan.Metadata["total_reclaimable_bytes"] = strconv.FormatInt(dockerTotalReclaimableBytes(rows), 10)
+	}
+
+	plan.Warnings = append(plan.Warnings, "Docker reported reclaimable bytes may describe daemon or VM storage and may not immediately equal host free-space delta")
+	plan.Warnings = append(plan.Warnings, "Docker cleanup should not run while active build, pull, push, or compose work is detected")
+	return plan
+}
+
 // Cleanup performs Docker cleanup at the specified level.
 func (p *DockerPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupResult {
 	result := CleanupResult{
@@ -61,6 +134,18 @@ func (p *DockerPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *con
 	if !p.isDockerAvailable() {
 		logger.Debug("docker not available, skipping")
 		return result
+	}
+
+	if cfg.Docker.ProtectRunningContainers {
+		activeReasons, err := p.activeDockerProcesses(ctx)
+		if err != nil {
+			logger.Warn("skipping Docker cleanup because active process inspection failed", "error", err)
+			return result
+		}
+		if len(activeReasons) > 0 {
+			logger.Warn("skipping Docker cleanup because active Docker work was detected", "active", strings.Join(activeReasons, ", "))
+			return result
+		}
 	}
 
 	switch level {
@@ -82,7 +167,14 @@ func (p *DockerPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *con
 }
 
 func (p *DockerPlugin) isDockerAvailable() bool {
-	cmd := exec.Command("docker", "info")
+	return p.isDockerAvailableContext(context.Background())
+}
+
+func (p *DockerPlugin) isDockerAvailableContext(ctx context.Context) bool {
+	availableCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(availableCtx, "docker", "info")
 	if p.socketPath != "" {
 		cmd.Env = append(os.Environ(), "DOCKER_HOST=unix://"+p.socketPath)
 	}
@@ -189,7 +281,11 @@ func (p *DockerPlugin) cleanCritical(ctx context.Context, logger *slog.Logger) C
 }
 
 func (p *DockerPlugin) runDockerCommand(ctx context.Context, args ...string) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	return p.runDockerCommandWithTimeout(ctx, 5*time.Minute, args...)
+}
+
+func (p *DockerPlugin) runDockerCommandWithTimeout(ctx context.Context, timeout time.Duration, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
@@ -198,6 +294,53 @@ func (p *DockerPlugin) runDockerCommand(ctx context.Context, args ...string) (st
 	}
 	output, err := cmd.CombinedOutput()
 	return string(output), err
+}
+
+func (p *DockerPlugin) activeDockerProcesses(ctx context.Context) ([]string, error) {
+	psCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(psCtx, "ps", "-axo", "comm=,args=")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return dockerBusyProcessReasons(string(output)), nil
+}
+
+func dockerBusyProcessReasons(output string) []string {
+	reasons := map[string]bool{}
+	for _, line := range strings.Split(output, "\n") {
+		lower := strings.ToLower(line)
+		switch {
+		case strings.Contains(lower, "docker-buildx") && strings.Contains(lower, " build"):
+			reasons["docker buildx"] = true
+		case strings.Contains(lower, "docker buildx build"):
+			reasons["docker buildx"] = true
+		case strings.Contains(lower, "docker compose build"):
+			reasons["docker compose build"] = true
+		case strings.Contains(lower, "docker compose up"):
+			reasons["docker compose up"] = true
+		case strings.Contains(lower, "docker build "):
+			reasons["docker build"] = true
+		case strings.Contains(lower, "docker pull "):
+			reasons["docker pull"] = true
+		case strings.Contains(lower, "docker push "):
+			reasons["docker push"] = true
+		case strings.Contains(lower, "docker run "):
+			reasons["docker run"] = true
+		}
+	}
+
+	if len(reasons) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(reasons))
+	for reason := range reasons {
+		out = append(out, reason)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (p *DockerPlugin) parseReclaimedSpace(output string) int64 {
@@ -238,6 +381,225 @@ func (p *DockerPlugin) parseReclaimedSpace(output string) int64 {
 	}
 
 	return 0
+}
+
+func dockerPlanSteps(level CleanupLevel, cfg config.DockerConfig) []string {
+	switch level {
+	case LevelWarning:
+		return []string{"Prune dangling Docker images"}
+	case LevelModerate:
+		return []string{
+			"Prune dangling Docker images",
+			fmt.Sprintf("Prune Docker images older than %s", cfg.PruneImagesAge),
+			"Prune stopped Docker containers older than 1h",
+			"Prune Docker buildx cache older than 24h",
+		}
+	case LevelAggressive:
+		return []string{
+			"Run moderate Docker cleanup",
+			"Prune unused Docker volumes",
+			"Prune unused Docker networks",
+			"Prune all Docker builder cache",
+		}
+	case LevelCritical:
+		return []string{"Run full Docker system prune with volumes"}
+	default:
+		return []string{"Report Docker cleanup state"}
+	}
+}
+
+func parseDockerDFSummaryRows(output string) []dockerDFSummaryRow {
+	var rows []dockerDFSummaryRow
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "TYPE") || strings.HasPrefix(line, "Docker") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+
+		var row dockerDFSummaryRow
+		switch {
+		case len(fields) >= 6 && fields[0] == "Local" && fields[1] == "Volumes":
+			row = dockerDFSummaryRow{
+				Type:             "Local Volumes",
+				Total:            fields[2],
+				Active:           fields[3],
+				SizeBytes:        parseDockerSizeBytes(fields[4]),
+				ReclaimableBytes: parseDockerSizeBytes(fields[5]),
+				Raw:              line,
+			}
+		case len(fields) >= 6 && fields[0] == "Build" && fields[1] == "Cache":
+			row = dockerDFSummaryRow{
+				Type:             "Build Cache",
+				Total:            fields[2],
+				Active:           fields[3],
+				SizeBytes:        parseDockerSizeBytes(fields[4]),
+				ReclaimableBytes: parseDockerSizeBytes(fields[5]),
+				Raw:              line,
+			}
+		default:
+			row = dockerDFSummaryRow{
+				Type:             fields[0],
+				Total:            fields[1],
+				Active:           fields[2],
+				SizeBytes:        parseDockerSizeBytes(fields[3]),
+				ReclaimableBytes: parseDockerSizeBytes(fields[4]),
+				Raw:              line,
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func parseDockerSizeBytes(value string) int64 {
+	value = strings.TrimSpace(strings.Trim(value, ","))
+	re := regexp.MustCompile(`(?i)^([\d.]+)\s*([kmgt]?i?b|b)$`)
+	matches := re.FindStringSubmatch(value)
+	if len(matches) != 3 {
+		return 0
+	}
+
+	number, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return 0
+	}
+
+	switch strings.ToUpper(matches[2]) {
+	case "B":
+		return int64(number)
+	case "KB", "KIB":
+		return int64(number * 1024)
+	case "MB", "MIB":
+		return int64(number * 1024 * 1024)
+	case "GB", "GIB":
+		return int64(number * 1024 * 1024 * 1024)
+	case "TB", "TIB":
+		return int64(number * 1024 * 1024 * 1024 * 1024)
+	default:
+		return 0
+	}
+}
+
+func dockerPlanTargets(rows []dockerDFSummaryRow, level CleanupLevel, reclaim string, activeProtected bool) []CleanupTarget {
+	var targets []CleanupTarget
+	for _, row := range rows {
+		target, ok := dockerPlanTarget(row, level, activeProtected)
+		if !ok {
+			continue
+		}
+		annotateCleanupTargetPolicy(&target, target.Tier, reclaim)
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+func dockerPlanTarget(row dockerDFSummaryRow, level CleanupLevel, activeProtected bool) (CleanupTarget, bool) {
+	target := CleanupTarget{
+		Name:      row.Type,
+		Bytes:     row.ReclaimableBytes,
+		Active:    activeProtected,
+		Protected: activeProtected,
+	}
+	if activeProtected {
+		target.Action = "protect"
+		target.Reason = "active Docker build, pull, push, run, or compose process detected"
+	}
+
+	switch row.Type {
+	case "Images":
+		target.Type = "docker-images"
+		target.Tier = CleanupTierWarm
+		if !activeProtected {
+			target.Action = "prune_images"
+			if level == LevelWarning {
+				target.Action = "prune_dangling_images"
+				target.Reason = "warning level prunes dangling images only; Docker df reclaimable is an upper bound"
+			} else {
+				target.Reason = "Docker images are eligible for age-filtered or dangling-image prune"
+			}
+		}
+	case "Containers":
+		if level < LevelModerate {
+			return CleanupTarget{}, false
+		}
+		target.Type = "docker-containers"
+		target.Tier = CleanupTierSafe
+		if !activeProtected {
+			target.Action = "prune_stopped_containers"
+			target.Reason = "stopped containers older than the configured threshold are eligible"
+		}
+	case "Local Volumes":
+		if level < LevelAggressive {
+			return CleanupTarget{}, false
+		}
+		target.Type = "docker-volumes"
+		target.Tier = CleanupTierDestructive
+		if !activeProtected {
+			target.Action = "prune_unused_volumes"
+			target.Reason = "unused volumes are eligible only at aggressive or critical levels"
+		}
+	case "Build Cache":
+		if level < LevelModerate {
+			return CleanupTarget{}, false
+		}
+		target.Type = "docker-build-cache"
+		target.Tier = CleanupTierWarm
+		if !activeProtected {
+			if level == LevelModerate {
+				target.Action = "prune_old_build_cache"
+				target.Reason = "moderate level prunes buildx cache older than 24h"
+			} else {
+				target.Action = "prune_builder_cache"
+				target.Reason = "builder cache is eligible at aggressive and critical levels"
+			}
+		}
+	default:
+		return CleanupTarget{}, false
+	}
+
+	if level == LevelCritical && !activeProtected {
+		target.Action = "system_prune_with_volumes"
+		target.Reason = "critical level runs full Docker system prune with volumes"
+	}
+	return target, true
+}
+
+func dockerPlanReclaimExpectation() string {
+	if runtime.GOOS == "linux" {
+		return CleanupReclaimHost
+	}
+	return CleanupReclaimDeferred
+}
+
+func dockerEstimatedCandidateBytes(targets []CleanupTarget) int64 {
+	var total int64
+	for _, target := range targets {
+		if target.Protected {
+			continue
+		}
+		total += target.Bytes
+	}
+	return total
+}
+
+func dockerTotalSizeBytes(rows []dockerDFSummaryRow) int64 {
+	var total int64
+	for _, row := range rows {
+		total += row.SizeBytes
+	}
+	return total
+}
+
+func dockerTotalReclaimableBytes(rows []dockerDFSummaryRow) int64 {
+	var total int64
+	for _, row := range rows {
+		total += row.ReclaimableBytes
+	}
+	return total
 }
 
 // ProactiveCleanup checks Docker reclaimable space and cleans if needed.

--- a/plugins/plugin_test.go
+++ b/plugins/plugin_test.go
@@ -219,6 +219,89 @@ func TestDockerPluginParseReclaimedSpace(t *testing.T) {
 	}
 }
 
+func TestDockerBusyProcessReasons(t *testing.T) {
+	output := `
+/nix/store/abc-docker-27.5.1/bin/docker buildx build --platform linux/amd64 --push .
+/usr/bin/docker system df
+/usr/local/bin/docker compose up web
+/usr/local/bin/docker pull alpine:latest
+`
+	reasons := dockerBusyProcessReasons(output)
+	expected := []string{"docker buildx", "docker compose up", "docker pull"}
+	if len(reasons) != len(expected) {
+		t.Fatalf("expected %d reasons, got %d: %v", len(expected), len(reasons), reasons)
+	}
+	for i := range expected {
+		if reasons[i] != expected[i] {
+			t.Fatalf("reason %d = %q, want %q; all reasons: %v", i, reasons[i], expected[i], reasons)
+		}
+	}
+}
+
+func TestParseDockerDFSummaryRows(t *testing.T) {
+	output := `TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
+Images          12        3         8.5GB     4.25GB (50%)
+Containers      2         0         1.5kB     1.5kB (100%)
+Local Volumes   4         1         10GB      6GB (60%)
+Build Cache     20        0         2GiB      512MiB
+`
+	rows := parseDockerDFSummaryRows(output)
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 rows, got %d: %#v", len(rows), rows)
+	}
+	if rows[0].Type != "Images" || rows[0].ReclaimableBytes != 4563402752 {
+		t.Fatalf("unexpected images row: %#v", rows[0])
+	}
+	if rows[2].Type != "Local Volumes" || rows[2].SizeBytes != 10737418240 {
+		t.Fatalf("unexpected volume row: %#v", rows[2])
+	}
+	if rows[3].Type != "Build Cache" || rows[3].ReclaimableBytes != 536870912 {
+		t.Fatalf("unexpected build cache row: %#v", rows[3])
+	}
+}
+
+func TestDockerPlanTargetsCriticalProtectsActiveWork(t *testing.T) {
+	rows := []dockerDFSummaryRow{
+		{Type: "Images", ReclaimableBytes: 10},
+		{Type: "Containers", ReclaimableBytes: 20},
+		{Type: "Local Volumes", ReclaimableBytes: 30},
+		{Type: "Build Cache", ReclaimableBytes: 40},
+	}
+	targets := dockerPlanTargets(rows, LevelCritical, CleanupReclaimDeferred, true)
+	if len(targets) != 4 {
+		t.Fatalf("expected 4 targets, got %d", len(targets))
+	}
+	if got := dockerEstimatedCandidateBytes(targets); got != 0 {
+		t.Fatalf("expected protected active work to estimate 0 bytes, got %d", got)
+	}
+	for _, target := range targets {
+		if !target.Protected || !target.Active || target.Action != "protect" {
+			t.Fatalf("expected protected active target, got %#v", target)
+		}
+	}
+}
+
+func TestDockerPlanTargetsCriticalEstimatesEligibleBytes(t *testing.T) {
+	rows := []dockerDFSummaryRow{
+		{Type: "Images", ReclaimableBytes: 10},
+		{Type: "Containers", ReclaimableBytes: 20},
+		{Type: "Local Volumes", ReclaimableBytes: 30},
+		{Type: "Build Cache", ReclaimableBytes: 40},
+	}
+	targets := dockerPlanTargets(rows, LevelCritical, CleanupReclaimHost, false)
+	if got := dockerEstimatedCandidateBytes(targets); got != 100 {
+		t.Fatalf("estimated bytes = %d, want 100", got)
+	}
+	for _, target := range targets {
+		if target.Action != "system_prune_with_volumes" {
+			t.Fatalf("expected critical action, got %#v", target)
+		}
+		if target.HostReclaimsSpace == nil || !*target.HostReclaimsSpace {
+			t.Fatalf("expected host reclaim annotation, got %#v", target)
+		}
+	}
+}
+
 func TestNixPluginName(t *testing.T) {
 	p := NewNixPlugin()
 	if p.Name() != "nix" {


### PR DESCRIPTION
## Summary

- add a structured Docker dry-run planner with `docker system df` target rows
- defer Docker cleanup when active Docker/buildx/compose/pull/push/run work is detected
- document the bounded Docker evidence route in the operator workflow

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `git diff --check`

## Lab note

The outside-sandbox Docker dry-run could not be rerun because approval was blocked. The sandboxed dry-run safely emitted `docker_unavailable` through the new planner instead of the old blank dry-run wrapper.
