### PR TITLE
Add APFS snapshot dry-run planner

### DIFF
--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -153,6 +153,12 @@ enabled. Reported reclaimable bytes may describe Docker daemon or VM storage
 and may not immediately equal host free-space delta on macOS or VM-backed
 Docker installations.
 
+For APFS snapshots on macOS, the plan reports local snapshot count, newest and
+oldest snapshot dates, requested thinning size, sudo capability, and Time
+Machine backup state. Snapshot sizes are estimates because `tmutil` does not
+report per-snapshot allocation; real cleanup requires passwordless sudo and is
+deferred while a Time Machine backup is active.
+
 ## Current Boundary
 
 This is the first stable reporting surface. It now exposes typed targets for

--- a/plugins/apfs_darwin.go
+++ b/plugins/apfs_darwin.go
@@ -19,6 +19,8 @@ import (
 	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
+const apfsGiB = int64(1024 * 1024 * 1024)
+
 // APFSPlugin handles APFS snapshot thinning and Time Machine cleanup.
 type APFSPlugin struct {
 	sudoCap *SudoCapability
@@ -49,6 +51,95 @@ func (p *APFSPlugin) Enabled(cfg *config.Config) bool {
 	return cfg.Enable.APFSSnapshots
 }
 
+// PlanCleanup returns a non-mutating APFS snapshot cleanup plan.
+func (p *APFSPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupPlan {
+	apfsCfg := cfg.APFS
+	requestGB, urgency := apfsThinRequest(level, apfsCfg)
+	plan := CleanupPlan{
+		Plugin:   p.Name(),
+		Level:    level.String(),
+		Summary:  "APFS snapshot review plan",
+		WouldRun: true,
+		Steps:    apfsPlanSteps(level, apfsCfg, requestGB, urgency),
+		Metadata: map[string]string{
+			"cleanup_level":     level.String(),
+			"thin_enabled":      strconv.FormatBool(apfsCfg.ThinEnabled),
+			"max_thin_gb":       strconv.Itoa(apfsCfg.MaxThinGB),
+			"keep_recent_days":  strconv.Itoa(apfsCfg.KeepRecentDays),
+			"delete_os_updates": strconv.FormatBool(apfsCfg.DeleteOSUpdates),
+			"request_thin_gb":   strconv.Itoa(requestGB),
+			"urgency":           strconv.Itoa(urgency),
+		},
+	}
+
+	if _, err := exec.LookPath("tmutil"); err != nil {
+		plan.Summary = "APFS snapshot tooling is not available"
+		plan.WouldRun = false
+		plan.SkipReason = "tmutil_unavailable"
+		return plan
+	}
+
+	if p.sudoCap == nil {
+		cap := DetectSudo(ctx)
+		p.sudoCap = &cap
+	}
+	plan.Metadata["sudo_available"] = strconv.FormatBool(p.sudoCap.Available)
+	plan.Metadata["sudo_passwordless"] = strconv.FormatBool(p.sudoCap.Passwordless)
+
+	snapshots, err := p.listSnapshots(ctx)
+	if err != nil {
+		plan.Summary = "APFS snapshots could not be inspected"
+		plan.WouldRun = false
+		plan.SkipReason = "apfs_snapshot_list_failed"
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("could not list APFS local snapshots: %v", err))
+		return plan
+	}
+
+	plan.Metadata["snapshot_count"] = strconv.Itoa(len(snapshots))
+	if len(snapshots) == 0 {
+		plan.Summary = "No APFS local snapshots found"
+		plan.WouldRun = false
+		plan.SkipReason = "no_apfs_snapshots"
+		return plan
+	}
+	plan.Metadata["newest_snapshot"] = snapshots[0].Date
+	plan.Metadata["oldest_snapshot"] = snapshots[len(snapshots)-1].Date
+
+	low, high := apfsSnapshotEstimateBytes(snapshots)
+	plan.Metadata["estimated_snapshot_low_bytes"] = strconv.FormatInt(low, 10)
+	plan.Metadata["estimated_snapshot_high_bytes"] = strconv.FormatInt(high, 10)
+
+	backupActive := p.isBackupActive(ctx)
+	plan.Metadata["backup_active"] = strconv.FormatBool(backupActive)
+
+	plan.Targets = apfsPlanTargets(snapshots, level, apfsCfg, requestGB, backupActive, p.sudoCap.Passwordless, time.Now())
+	plan.EstimatedBytesFreed = apfsEstimatedCandidateBytes(plan.Targets)
+	plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
+
+	switch {
+	case level == LevelWarning:
+		plan.Summary = "APFS snapshots are report-only at warning level"
+		plan.WouldRun = false
+		plan.SkipReason = "report_only"
+	case level >= LevelModerate && !apfsCfg.ThinEnabled:
+		plan.Summary = "APFS snapshot thinning is disabled"
+		plan.WouldRun = false
+		plan.SkipReason = "apfs_thinning_disabled"
+	case level >= LevelModerate && !p.sudoCap.Passwordless:
+		plan.Summary = "APFS snapshot cleanup is deferred because passwordless sudo is unavailable"
+		plan.WouldRun = false
+		plan.SkipReason = "sudo_required"
+	case backupActive:
+		plan.Summary = "APFS snapshot cleanup is deferred because Time Machine backup is active"
+		plan.WouldRun = false
+		plan.SkipReason = "time_machine_backup_active"
+	}
+
+	plan.Warnings = append(plan.Warnings, "APFS snapshot size is not reported by tmutil; estimates use a conservative 5-15 GiB per local snapshot")
+	plan.Warnings = append(plan.Warnings, "APFS snapshot thinning requires passwordless sudo and may reclaim less than requested")
+	return plan
+}
+
 // Cleanup performs APFS snapshot thinning at the specified level.
 func (p *APFSPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *config.Config, logger *slog.Logger) CleanupResult {
 	result := CleanupResult{
@@ -77,6 +168,11 @@ func (p *APFSPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *confi
 
 	if len(snapshots) == 0 {
 		logger.Debug("no local APFS snapshots found")
+		return result
+	}
+
+	if p.isBackupActive(ctx) {
+		logger.Warn("Time Machine backup in progress, skipping snapshot cleanup")
 		return result
 	}
 
@@ -116,12 +212,6 @@ func (p *APFSPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *confi
 			return result
 		}
 
-		// Check if Time Machine backup is active - NEVER delete during backup
-		if p.isBackupActive(ctx) {
-			logger.Warn("Time Machine backup in progress, skipping snapshot deletion")
-			return result
-		}
-
 		// Request max thinning at urgency 4
 		maxThinGB := apfsCfg.MaxThinGB
 		if maxThinGB <= 0 {
@@ -154,7 +244,10 @@ type snapshotInfo struct {
 
 // listSnapshots lists all local APFS snapshots.
 func (p *APFSPlugin) listSnapshots(ctx context.Context) ([]snapshotInfo, error) {
-	cmd := exec.CommandContext(ctx, "tmutil", "listlocalsnapshots", "/")
+	listCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(listCtx, "tmutil", "listlocalsnapshots", "/")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("tmutil listlocalsnapshots failed: %w", err)
@@ -216,6 +309,128 @@ func (p *APFSPlugin) reportSnapshots(snapshots []snapshotInfo, logger *slog.Logg
 		"newest", newest.Date,
 		"estimated_size_gb", fmt.Sprintf("~%d-%d", len(snapshots)*5, len(snapshots)*15),
 	)
+}
+
+func apfsPlanSteps(level CleanupLevel, cfg config.APFSConfig, requestGB int, urgency int) []string {
+	switch level {
+	case LevelWarning:
+		return []string{"List APFS local snapshots for operator review"}
+	case LevelModerate, LevelAggressive:
+		return []string{
+			"List APFS local snapshots",
+			"Confirm passwordless sudo is available",
+			fmt.Sprintf("Request tmutil thinlocalsnapshots for %d GiB at urgency %d", requestGB, urgency),
+			"Skip snapshot thinning while a Time Machine backup is active",
+		}
+	case LevelCritical:
+		steps := []string{
+			"List APFS local snapshots",
+			"Confirm passwordless sudo is available",
+			"Confirm Time Machine backup is not active",
+			fmt.Sprintf("Request tmutil thinlocalsnapshots for %d GiB at urgency %d", requestGB, urgency),
+		}
+		if cfg.DeleteOSUpdates {
+			keepDays := cfg.KeepRecentDays
+			if keepDays <= 0 {
+				keepDays = 1
+			}
+			steps = append(steps, fmt.Sprintf("Delete old local snapshots older than %d day(s), preserving the newest snapshot", keepDays))
+		}
+		return steps
+	default:
+		return []string{"Report APFS snapshot state"}
+	}
+}
+
+func apfsThinRequest(level CleanupLevel, cfg config.APFSConfig) (int, int) {
+	switch level {
+	case LevelModerate:
+		return 5, 1
+	case LevelAggressive:
+		return 20, 3
+	case LevelCritical:
+		maxThinGB := cfg.MaxThinGB
+		if maxThinGB <= 0 {
+			maxThinGB = 50
+		}
+		return maxThinGB, 4
+	default:
+		return 0, 0
+	}
+}
+
+func apfsSnapshotEstimateBytes(snapshots []snapshotInfo) (int64, int64) {
+	count := int64(len(snapshots))
+	return count * 5 * apfsGiB, count * 15 * apfsGiB
+}
+
+func apfsPlanTargets(snapshots []snapshotInfo, level CleanupLevel, cfg config.APFSConfig, requestGB int, backupActive bool, sudoPasswordless bool, now time.Time) []CleanupTarget {
+	var targets []CleanupTarget
+	low, _ := apfsSnapshotEstimateBytes(snapshots)
+	requestBytes := int64(requestGB) * apfsGiB
+	thinEstimate := low
+	if requestBytes > 0 && requestBytes < thinEstimate {
+		thinEstimate = requestBytes
+	}
+
+	thinTarget := CleanupTarget{
+		Type:      "apfs-local-snapshots",
+		Tier:      CleanupTierPrivileged,
+		Name:      "local snapshot thinning",
+		Bytes:     thinEstimate,
+		Protected: level < LevelModerate || !cfg.ThinEnabled || !sudoPasswordless || backupActive,
+		Action:    "thin_local_snapshots",
+		Reason:    "request APFS local snapshot thinning through tmutil",
+	}
+	if thinTarget.Protected {
+		thinTarget.Action = "protect"
+		thinTarget.Reason = "snapshot thinning is not currently eligible"
+	}
+	annotateCleanupTargetPolicy(&thinTarget, thinTarget.Tier, hostReclaimForAction(thinTarget.Action))
+	targets = append(targets, thinTarget)
+
+	keepDays := cfg.KeepRecentDays
+	if keepDays <= 0 {
+		keepDays = 1
+	}
+	cutoff := now.Add(-time.Duration(keepDays) * 24 * time.Hour)
+	for i, snapshot := range snapshots {
+		target := CleanupTarget{
+			Type:      "apfs-snapshot",
+			Tier:      CleanupTierPrivileged,
+			Name:      snapshot.Date,
+			Bytes:     5 * apfsGiB,
+			Protected: true,
+			Action:    "keep",
+			Reason:    "local snapshot is preserved by default",
+		}
+		switch {
+		case i == 0:
+			target.Reason = "newest local snapshot is always preserved"
+		case level == LevelCritical && cfg.DeleteOSUpdates && sudoPasswordless && !backupActive && snapshot.Time.Before(cutoff):
+			target.Protected = false
+			target.Action = "delete_old_snapshot"
+			target.Reason = "critical level may delete old local snapshots after thinning"
+		case snapshot.Time.After(cutoff):
+			target.Reason = "snapshot is newer than keep_recent_days"
+		case !cfg.DeleteOSUpdates:
+			target.Reason = "delete_os_updates is disabled"
+		}
+		annotateCleanupTargetPolicy(&target, target.Tier, hostReclaimForAction(target.Action))
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+func apfsEstimatedCandidateBytes(targets []CleanupTarget) int64 {
+	var total int64
+	for _, target := range targets {
+		if target.Protected {
+			continue
+		}
+		total += target.Bytes
+	}
+	return total
 }
 
 // thinSnapshots requests macOS to thin local snapshots.
@@ -302,7 +517,10 @@ func (p *APFSPlugin) deleteOldSnapshots(ctx context.Context, snapshots []snapsho
 
 // isBackupActive checks if a Time Machine backup is currently running.
 func (p *APFSPlugin) isBackupActive(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "tmutil", "status")
+	statusCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(statusCtx, "tmutil", "status")
 	output, err := cmd.Output()
 	if err != nil {
 		return false // Assume not active if we can't check

--- a/plugins/apfs_darwin_test.go
+++ b/plugins/apfs_darwin_test.go
@@ -167,6 +167,66 @@ func TestDeleteOldSnapshotsNeverDeleteNewest(t *testing.T) {
 	}
 }
 
+func TestAPFSPlanTargetsCriticalDeletesOnlyEligibleOldSnapshots(t *testing.T) {
+	now := time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC)
+	snapshots := []snapshotInfo{
+		{Date: "2026-01-16-100000", Time: time.Date(2026, 1, 16, 10, 0, 0, 0, time.UTC)},
+		{Date: "2026-01-15-180000", Time: time.Date(2026, 1, 15, 18, 0, 0, 0, time.UTC)},
+		{Date: "2026-01-10-080000", Time: time.Date(2026, 1, 10, 8, 0, 0, 0, time.UTC)},
+	}
+	cfg := config.APFSConfig{
+		ThinEnabled:     true,
+		MaxThinGB:       50,
+		KeepRecentDays:  1,
+		DeleteOSUpdates: true,
+	}
+
+	targets := apfsPlanTargets(snapshots, LevelCritical, cfg, 50, false, true, now)
+	if len(targets) != 4 {
+		t.Fatalf("expected aggregate target plus 3 snapshots, got %d", len(targets))
+	}
+
+	if targets[0].Action != "thin_local_snapshots" || targets[0].Protected {
+		t.Fatalf("expected eligible thinning target, got %#v", targets[0])
+	}
+	if targets[1].Action != "keep" || !targets[1].Protected {
+		t.Fatalf("newest snapshot must be kept, got %#v", targets[1])
+	}
+	if targets[2].Action != "keep" || !targets[2].Protected {
+		t.Fatalf("recent snapshot must be kept, got %#v", targets[2])
+	}
+	if targets[3].Action != "delete_old_snapshot" || targets[3].Protected {
+		t.Fatalf("old snapshot should be eligible for deletion, got %#v", targets[3])
+	}
+	if got := apfsEstimatedCandidateBytes(targets); got != 20*apfsGiB {
+		t.Fatalf("estimated candidate bytes = %d, want %d", got, 20*apfsGiB)
+	}
+}
+
+func TestAPFSPlanTargetsProtectsWhenBackupActive(t *testing.T) {
+	now := time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC)
+	snapshots := []snapshotInfo{
+		{Date: "2026-01-16-100000", Time: time.Date(2026, 1, 16, 10, 0, 0, 0, time.UTC)},
+		{Date: "2026-01-10-080000", Time: time.Date(2026, 1, 10, 8, 0, 0, 0, time.UTC)},
+	}
+	cfg := config.APFSConfig{
+		ThinEnabled:     true,
+		MaxThinGB:       50,
+		KeepRecentDays:  1,
+		DeleteOSUpdates: true,
+	}
+
+	targets := apfsPlanTargets(snapshots, LevelCritical, cfg, 50, true, true, now)
+	if got := apfsEstimatedCandidateBytes(targets); got != 0 {
+		t.Fatalf("backup-active plan should estimate 0 bytes, got %d", got)
+	}
+	for _, target := range targets {
+		if !target.Protected {
+			t.Fatalf("backup-active target should be protected: %#v", target)
+		}
+	}
+}
+
 func TestAPFSConfigDefaults(t *testing.T) {
 	cfg := config.DefaultConfig()
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -160,7 +160,8 @@ func hostReclaimForAction(action string) string {
 	switch {
 	case strings.HasPrefix(action, "delete"),
 		action == "clean-cache",
-		action == "clean-stale-files":
+		action == "clean-stale-files",
+		action == "thin_local_snapshots":
 		return CleanupReclaimHost
 	case action == "review",
 		action == "report",


### PR DESCRIPTION
## Summary

- add a structured APFS snapshot dry-run planner for Darwin
- report snapshot count, thinning request size, sudo capability, backup-active gate, and per-snapshot keep/delete intent
- skip real APFS cleanup while Time Machine backup is active at every cleanup level
- document APFS planner evidence in the operator workflow

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `git diff --check`
- `/tmp/tinyland-cleanup-lab/tinyland-cleanup --config /tmp/tinyland-cleanup-lab/config.yaml --once --dry-run --level critical --plugins apfs-snapshots --output json`

## Lab note

The attended Darwin dry-run reported `no_apfs_snapshots`, with `tmutil` available, passwordless sudo unavailable, and no mutation performed.
