### PR TITLE
[codex] Add Nix cleanup deferral targets

### DIFF
--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -15,6 +15,10 @@ The Nix plan includes:
 - `estimated_bytes_freed` from `nix-collect-garbage --dry-run`;
 - detected active Nix work such as `nix build`, `home-manager switch`,
   `darwin-rebuild`, `nixos-rebuild`, and worker-style `nix-daemon` activity;
+- protected `nix_active_work`, `nix_process_inspection`, or
+  `nix_store_contention` targets when cleanup is deferred before mutation;
+- `retry_after` metadata derived from `daemon_busy_backoff` so operators can
+  distinguish a temporary deferral from a cleanup-policy mismatch;
 - `nix_daemon_contention` deferral when dry-run GC itself reports SQLite or
   store lock contention and `skip_when_daemon_busy` is enabled;
 - visible GC roots when dry-run GC reports no reclaimable store space;
@@ -47,6 +51,9 @@ Runtime behavior:
 - dry-run GC lock or SQLite contention is treated like active Nix work when
   `skip_when_daemon_busy` is enabled, so the plan is deferred instead of
   continuing into generation inspection;
+- active-work, process-inspection, and store-contention deferrals are surfaced
+  as protected dry-run targets with no reclaim estimate, plus retry guidance
+  based on `daemon_busy_backoff`;
 - real generation deletion and GC commands also treat those contention
   signatures as deferred no-op cleanup steps when `skip_when_daemon_busy` is
   enabled;

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -131,6 +131,12 @@ For macOS Podman VM disk compaction, review
 `applehv` raw images is advisory and is not counted as host-side reclaimed
 space.
 
+For Nix, active build, Home Manager, rebuild, `nix-store`, and worker-style
+`nix-daemon` activity defers cleanup when `skip_when_daemon_busy` is enabled.
+The dry-run plan reports protected active-work or store-contention targets and
+`retry_after` metadata from `nix.daemon_busy_backoff`; treat those as temporary
+operator backoff signals, not reclaim candidates.
+
 For Darwin IDE and tool caches, review
 [darwin-dev-caches.md](darwin-dev-caches.md). These targets are reported for
 operator review, and real deletion requires `darwin_dev_caches.enforce: true`.

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -91,19 +91,26 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 	}
 
 	if busy, err := p.activeNixProcesses(ctx); err != nil {
-		plan.Warnings = append(plan.Warnings, fmt.Sprintf("could not inspect active Nix processes: %v", err))
 		if cfg.Nix.SkipWhenDaemonBusy {
-			plan.WouldRun = false
-			plan.SkipReason = "nix_process_inspection_failed"
-			plan.Summary = "Nix cleanup is deferred because active process inspection failed"
+			nixDeferPlan(&plan,
+				"nix_process_inspection_failed",
+				"Nix cleanup is deferred because active process inspection failed",
+				cfg.Nix,
+				[]CleanupTarget{nixDeferralTarget("nix_process_inspection", "active Nix process inspection", "protect_process_inspection", false, fmt.Sprintf("could not inspect active Nix processes: %v", err), cfg.Nix.DaemonBusyBackoff)},
+				fmt.Sprintf("could not inspect active Nix processes: %v", err),
+			)
 			return plan
 		}
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("could not inspect active Nix processes: %v", err))
 	} else if len(busy) > 0 {
 		plan.Metadata["active_nix_processes"] = strings.Join(busy, ", ")
 		if cfg.Nix.SkipWhenDaemonBusy {
-			plan.WouldRun = false
-			plan.SkipReason = "nix_daemon_busy"
-			plan.Summary = "Nix cleanup is deferred because active Nix work was detected"
+			nixDeferPlan(&plan,
+				"nix_daemon_busy",
+				"Nix cleanup is deferred because active Nix work was detected",
+				cfg.Nix,
+				nixActiveWorkTargets(busy, cfg.Nix.DaemonBusyBackoff),
+			)
 			return plan
 		}
 	}
@@ -113,9 +120,12 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 			plan.Metadata["nix_contention"] = reason
 			plan.Warnings = append(plan.Warnings, fmt.Sprintf("nix-collect-garbage dry-run reported store contention: %s", reason))
 			if cfg.Nix.SkipWhenDaemonBusy {
-				plan.WouldRun = false
-				plan.SkipReason = "nix_daemon_contention"
-				plan.Summary = "Nix cleanup is deferred because dry-run reported store contention"
+				nixDeferPlan(&plan,
+					"nix_daemon_contention",
+					"Nix cleanup is deferred because dry-run reported store contention",
+					cfg.Nix,
+					[]CleanupTarget{nixDeferralTarget("nix_store_contention", reason, "protect_store_contention", true, "Nix store lock or SQLite contention was reported by dry-run GC", cfg.Nix.DaemonBusyBackoff)},
+				)
 				return plan
 			}
 		}
@@ -146,6 +156,23 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 	}
 
 	return plan
+}
+
+func nixDeferPlan(plan *CleanupPlan, skipReason string, summary string, cfg config.NixConfig, targets []CleanupTarget, warnings ...string) {
+	if plan.Metadata == nil {
+		plan.Metadata = map[string]string{}
+	}
+	plan.WouldRun = false
+	plan.SkipReason = skipReason
+	plan.Summary = summary
+	plan.Targets = append(plan.Targets, targets...)
+	plan.Metadata["deferral_reason"] = skipReason
+	plan.Metadata["retry_after"] = cfg.DaemonBusyBackoff
+	plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
+	plan.Warnings = append(plan.Warnings, warnings...)
+	if cfg.DaemonBusyBackoff != "" {
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("retry Nix cleanup after %s once active work is idle and process inspection is available", cfg.DaemonBusyBackoff))
+	}
 }
 
 // Cleanup performs Nix garbage collection at the specified level.
@@ -442,6 +469,30 @@ func (p *NixPlugin) activeNixProcesses(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	return nixBusyProcessReasons(string(output)), nil
+}
+
+func nixActiveWorkTargets(reasons []string, backoff string) []CleanupTarget {
+	targets := make([]CleanupTarget, 0, len(reasons))
+	for _, reason := range reasons {
+		targets = append(targets, nixDeferralTarget("nix_active_work", reason, "protect_active_work", true, "active Nix work is using the store", backoff))
+	}
+	return targets
+}
+
+func nixDeferralTarget(targetType string, name string, action string, active bool, reason string, backoff string) CleanupTarget {
+	if backoff != "" {
+		reason = fmt.Sprintf("%s; retry after %s once idle", reason, backoff)
+	}
+	target := CleanupTarget{
+		Type:      targetType,
+		Name:      name,
+		Active:    active,
+		Protected: true,
+		Action:    action,
+		Reason:    reason,
+	}
+	annotateCleanupTargetPolicy(&target, CleanupTierDisruptive, CleanupReclaimNone)
+	return target
 }
 
 func nixPlanSteps(level CleanupLevel, cfg config.NixConfig) []string {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -1,8 +1,11 @@
 package plugins
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 func TestNixPluginParseDryRunFreedSpace(t *testing.T) {
@@ -85,6 +88,51 @@ func TestNixBusyProcessReasons(t *testing.T) {
 		if reasons[i] != want[i] {
 			t.Fatalf("got reasons %v, want %v", reasons, want)
 		}
+	}
+}
+
+func TestNixActiveWorkTargetsProtectStoreWork(t *testing.T) {
+	targets := nixActiveWorkTargets([]string{"home-manager switch", "nix build"}, "30m")
+	if len(targets) != 2 {
+		t.Fatalf("got %d targets, want 2", len(targets))
+	}
+
+	for _, target := range targets {
+		if target.Action != "protect_active_work" || !target.Active || !target.Protected {
+			t.Fatalf("active Nix work target should be protected: %+v", target)
+		}
+		if target.Tier != CleanupTierDisruptive || target.Reclaim != CleanupReclaimNone {
+			t.Fatalf("active Nix work should be disruptive/no-reclaim: %+v", target)
+		}
+		if target.HostReclaimsSpace == nil || *target.HostReclaimsSpace {
+			t.Fatalf("active Nix work target should not reclaim host space: %+v", target)
+		}
+		if !strings.Contains(target.Reason, "retry after 30m") {
+			t.Fatalf("active Nix work target should include retry guidance: %+v", target)
+		}
+	}
+}
+
+func TestNixDeferPlanAddsOperatorRetryMetadata(t *testing.T) {
+	plan := CleanupPlan{
+		WouldRun: true,
+		Metadata: map[string]string{},
+	}
+	cfg := config.NixConfig{DaemonBusyBackoff: "15m"}
+
+	nixDeferPlan(&plan, "nix_daemon_busy", "deferred", cfg, nixActiveWorkTargets([]string{"nix build"}, cfg.DaemonBusyBackoff))
+
+	if plan.WouldRun || plan.SkipReason != "nix_daemon_busy" || plan.Summary != "deferred" {
+		t.Fatalf("unexpected deferred plan state: %+v", plan)
+	}
+	if plan.Metadata["retry_after"] != "15m" || plan.Metadata["deferral_reason"] != "nix_daemon_busy" || plan.Metadata["target_count"] != "1" {
+		t.Fatalf("deferred plan metadata missing retry details: %+v", plan.Metadata)
+	}
+	if len(plan.Targets) != 1 || plan.Targets[0].Action != "protect_active_work" {
+		t.Fatalf("deferred plan should include active work target: %+v", plan.Targets)
+	}
+	if len(plan.Warnings) != 1 || !strings.Contains(plan.Warnings[0], "retry Nix cleanup after 15m") || !strings.Contains(plan.Warnings[0], "process inspection is available") {
+		t.Fatalf("deferred plan should include retry warning: %+v", plan.Warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add protected Nix dry-run targets for active work, process-inspection failure, and store-contention deferrals
- expose `deferral_reason`, `retry_after`, and target count metadata when Nix cleanup stops before mutation
- document Nix deferrals as temporary operator backoff signals instead of reclaim candidates

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build -o /tmp/tinyland-cleanup-lab/tinyland-cleanup .`
- `git diff --check`
- `/tmp/tinyland-cleanup-lab/tinyland-cleanup --config /tmp/tinyland-cleanup-lab/config.yaml --once --dry-run --level critical --plugins nix --output text`
- `nix build .#default --no-link --print-build-logs`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`

## Lab Notes

The bounded Nix dry-run was non-mutating. In this sandboxed run, process inspection was denied by `/bin/ps`, and the plan now reports a protected `nix_process_inspection` target plus `retry_after: 30m` rather than only a skip reason.
