### PR TITLE
[codex] Add Podman compaction plan targets

### DIFF
--- a/docs/podman-darwin-compaction.md
+++ b/docs/podman-darwin-compaction.md
@@ -22,7 +22,14 @@ The Podman plan reports:
 - required temporary free space based on physical allocation plus headroom;
 - active-container status;
 - whether `qemu-img` is available;
+- protected targets for blocked VM disk compaction, scratch-space requirements,
+  and active-container quiescence;
 - the exact stop, convert, verify, replace, and start sequence.
+
+`estimated_bytes_freed` is counted only when the offline compaction preflight
+can run. Blocked compaction still reports the potential reclaim in
+`offline_compaction_estimated_reclaim_bytes` and on protected targets for
+operator review.
 
 ## Enable
 
@@ -44,6 +51,10 @@ The preflight skips compaction when the disk path is outside expected Podman
 machine directories, `qemu-img` is unavailable, active containers are running,
 the provider is unknown, a rollback backup already exists, or the filesystem
 does not have enough physical free space for the compacted copy.
+
+When `active_containers` or `insufficient_free_space` appears, treat the plan as
+a quiescence or scratch-capacity task. Do not force compaction on an active
+developer VM just because the raw image has large potential reclaim.
 
 ## Rollback Boundary
 

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -184,9 +184,12 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 
 			compaction := p.planOfflineCompaction(ctx, cfg, logger)
 			plan.RequiredFreeBytes = compaction.RequiredFreeBytes
-			plan.EstimatedBytesFreed = compaction.EstimatedReclaimBytes
+			if compaction.CanCompact {
+				plan.EstimatedBytesFreed = compaction.EstimatedReclaimBytes
+			}
 			plan.Warnings = append(plan.Warnings, compaction.Warnings...)
 			plan.Steps = append(plan.Steps, compaction.Steps...)
+			plan.Targets = append(plan.Targets, podmanCompactionTargets(compaction)...)
 			plan.Metadata["offline_compaction_enabled"] = strconv.FormatBool(compaction.ConfigEnabled)
 			plan.Metadata["offline_compaction_can_run"] = strconv.FormatBool(compaction.CanCompact)
 			plan.Metadata["offline_compaction_skip_reason"] = compaction.SkipReason
@@ -201,6 +204,7 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 			plan.Metadata["offline_compaction_required_free_bytes"] = strconv.FormatInt(compaction.RequiredFreeBytes, 10)
 			plan.Metadata["offline_compaction_estimated_reclaim_bytes"] = strconv.FormatInt(compaction.EstimatedReclaimBytes, 10)
 			plan.Metadata["offline_compaction_active_containers"] = strconv.FormatBool(compaction.ActiveContainers)
+			plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
 		}
 	}
 
@@ -782,6 +786,109 @@ func buildPodmanCompactionPlan(input podmanCompactionPlanInput) podmanCompaction
 	}
 
 	return plan
+}
+
+func podmanCompactionTargets(plan podmanCompactionPlan) []CleanupTarget {
+	if plan.DiskPath == "" && plan.RequiredFreeBytes == 0 && !plan.ActiveContainers {
+		return nil
+	}
+
+	var targets []CleanupTarget
+	if plan.DiskPath != "" {
+		action := "compact_disk_offline"
+		reclaim := CleanupReclaimHost
+		reason := "offline compaction is eligible and expected to reclaim host allocation"
+		if !plan.CanCompact {
+			action = "protect_offline_compaction"
+			reclaim = CleanupReclaimNone
+			reason = podmanCompactionSkipReason(plan.SkipReason)
+		}
+		target := CleanupTarget{
+			Type:         "podman_vm_disk",
+			Tier:         CleanupTierDisruptive,
+			Name:         plan.MachineName,
+			Path:         plan.DiskPath,
+			Bytes:        plan.EstimatedReclaimBytes,
+			LogicalBytes: plan.LogicalBytes,
+			Active:       plan.ActiveContainers,
+			Protected:    !plan.CanCompact,
+			Action:       action,
+			Reason:       reason,
+		}
+		annotateCleanupTargetPolicy(&target, target.Tier, reclaim)
+		targets = append(targets, target)
+	}
+
+	if plan.RequiredFreeBytes > 0 {
+		action := "review_required_free_space"
+		reason := "offline compaction needs temporary scratch space for the compacted image"
+		if plan.SkipReason == "insufficient_free_space" {
+			action = "protect_insufficient_free_space"
+			reason = "not enough free space is available beside the VM disk for offline compaction"
+		}
+		target := CleanupTarget{
+			Type:      "podman_compaction_scratch",
+			Tier:      CleanupTierDisruptive,
+			Name:      "offline compaction scratch space",
+			Path:      filepath.Dir(plan.DiskPath),
+			Bytes:     plan.RequiredFreeBytes,
+			Protected: true,
+			Action:    action,
+			Reason:    reason,
+		}
+		annotateCleanupTargetPolicy(&target, target.Tier, CleanupReclaimNone)
+		targets = append(targets, target)
+	}
+
+	if plan.ActiveContainers || plan.ActiveContainerCheckError != "" {
+		action := "protect_active_containers"
+		active := plan.ActiveContainers
+		reason := "active Podman containers must be quiesced before offline compaction"
+		if plan.ActiveContainerCheckError != "" {
+			action = "protect_container_inspection"
+			reason = fmt.Sprintf("could not inspect active Podman containers: %s", plan.ActiveContainerCheckError)
+		}
+		target := CleanupTarget{
+			Type:      "podman_active_containers",
+			Tier:      CleanupTierDisruptive,
+			Name:      "active Podman containers",
+			Active:    active,
+			Protected: true,
+			Action:    action,
+			Reason:    reason,
+		}
+		annotateCleanupTargetPolicy(&target, target.Tier, CleanupReclaimNone)
+		targets = append(targets, target)
+	}
+
+	return targets
+}
+
+func podmanCompactionSkipReason(reason string) string {
+	switch reason {
+	case "":
+		return "offline compaction is not eligible"
+	case "compact_disk_offline_disabled":
+		return "offline compaction is disabled by config"
+	case "active_containers":
+		return "active Podman containers must be stopped before offline compaction"
+	case "insufficient_free_space":
+		return "not enough scratch free space is available for offline compaction"
+	case "qemu_img_missing":
+		return "qemu-img is required for offline compaction"
+	case "backup_path_exists":
+		return "existing rollback backup must be resolved before offline compaction"
+	case "disk_path_outside_podman_machine_dirs":
+		return "VM disk path is outside expected Podman machine directories"
+	case "provider_not_allowlisted":
+		return "VM provider is not allowlisted for offline compaction"
+	case "unsupported_provider":
+		return "VM provider is not supported for offline compaction"
+	case "below_minimum_physical_allocation":
+		return "VM disk physical allocation is below the configured compaction threshold"
+	default:
+		return "offline compaction preflight blocked compaction: " + reason
+	}
 }
 
 func podmanDiskFormat(provider string) (string, bool) {

--- a/plugins/podman_compaction_test.go
+++ b/plugins/podman_compaction_test.go
@@ -135,6 +135,16 @@ func TestPodmanCompactionPlanRejectsActiveContainers(t *testing.T) {
 	if plan.SkipReason != "active_containers" {
 		t.Fatalf("expected active_containers, got %q", plan.SkipReason)
 	}
+
+	targets := podmanCompactionTargets(plan)
+	disk := findPodmanTarget(t, targets, "podman_vm_disk")
+	if disk.Action != "protect_offline_compaction" || !disk.Protected || !disk.Active {
+		t.Fatalf("expected blocked disk target for active containers: %#v", disk)
+	}
+	active := findPodmanTarget(t, targets, "podman_active_containers")
+	if active.Action != "protect_active_containers" || !active.Protected || !active.Active {
+		t.Fatalf("expected active-container target: %#v", active)
+	}
 }
 
 func TestPodmanCompactionPlanRejectsMissingQemuImg(t *testing.T) {
@@ -161,6 +171,69 @@ func TestPodmanCompactionPlanRejectsMissingQemuImg(t *testing.T) {
 	}
 }
 
+func TestPodmanCompactionTargetsExposeScratchDeficit(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:      "podman-machine-default",
+		Provider:         "applehv",
+		DiskPath:         "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ConfigEnabled:    true,
+		QemuImgAvailable: true,
+		DiskPathExpected: true,
+		LogicalBytes:     100 * podmanCompactionGiB,
+		PhysicalBytes:    12 * podmanCompactionGiB,
+		FreeBytes:        4 * podmanCompactionGiB,
+		Config:           cfg,
+	})
+
+	targets := podmanCompactionTargets(plan)
+	scratch := findPodmanTarget(t, targets, "podman_compaction_scratch")
+	if scratch.Action != "protect_insufficient_free_space" || !scratch.Protected {
+		t.Fatalf("expected protected scratch target, got %#v", scratch)
+	}
+	if scratch.Bytes != plan.RequiredFreeBytes {
+		t.Fatalf("scratch target should report required bytes %d, got %d", plan.RequiredFreeBytes, scratch.Bytes)
+	}
+	if scratch.Reclaim != CleanupReclaimNone {
+		t.Fatalf("scratch target should not be counted as reclaim: %#v", scratch)
+	}
+
+	disk := findPodmanTarget(t, targets, "podman_vm_disk")
+	if disk.Reclaim != CleanupReclaimNone || disk.HostReclaimsSpace == nil || *disk.HostReclaimsSpace {
+		t.Fatalf("blocked disk target should not count as host reclaim: %#v", disk)
+	}
+}
+
+func TestPodmanCompactionTargetsEligibleDiskReclaimsHost(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:      "podman-machine-default",
+		Provider:         "applehv",
+		DiskPath:         "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ConfigEnabled:    true,
+		QemuImgAvailable: true,
+		DiskPathExpected: true,
+		LogicalBytes:     100 * podmanCompactionGiB,
+		PhysicalBytes:    12 * podmanCompactionGiB,
+		FreeBytes:        14 * podmanCompactionGiB,
+		Config:           cfg,
+	})
+
+	targets := podmanCompactionTargets(plan)
+	disk := findPodmanTarget(t, targets, "podman_vm_disk")
+	if disk.Action != "compact_disk_offline" || disk.Protected {
+		t.Fatalf("expected eligible disk compaction target: %#v", disk)
+	}
+	if disk.Reclaim != CleanupReclaimHost || disk.HostReclaimsSpace == nil || !*disk.HostReclaimsSpace {
+		t.Fatalf("eligible disk target should count as host reclaim: %#v", disk)
+	}
+	if disk.Bytes != plan.EstimatedReclaimBytes {
+		t.Fatalf("disk target should carry estimated reclaim %d, got %d", plan.EstimatedReclaimBytes, disk.Bytes)
+	}
+}
+
 func TestPathWithinRoots(t *testing.T) {
 	root := t.TempDir()
 	diskPath := filepath.Join(root, "applehv", "podman-machine-default.raw")
@@ -171,6 +244,17 @@ func TestPathWithinRoots(t *testing.T) {
 	if pathWithinRoots(filepath.Join(t.TempDir(), "outside.raw"), []string{root}) {
 		t.Fatal("expected unrelated path to be outside root")
 	}
+}
+
+func findPodmanTarget(t *testing.T, targets []CleanupTarget, targetType string) CleanupTarget {
+	t.Helper()
+	for _, target := range targets {
+		if target.Type == targetType {
+			return target
+		}
+	}
+	t.Fatalf("target %s not found in %#v", targetType, targets)
+	return CleanupTarget{}
 }
 
 func testPodmanCompactionConfig() config.PodmanConfig {


### PR DESCRIPTION
## Summary

- add structured Podman offline-compaction targets for the VM disk, required scratch space, and active-container blockers
- count top-level `estimated_bytes_freed` only when offline compaction can actually run
- keep blocked potential reclaim visible through metadata and protected targets
- document blocked compaction as quiescence or scratch-capacity work, not direct reclaim

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build -o /tmp/tinyland-cleanup-lab/tinyland-cleanup .`
- `git diff --check`
- `/tmp/tinyland-cleanup-lab/tinyland-cleanup --config /tmp/tinyland-cleanup-lab/config.yaml --once --dry-run --level critical --plugins podman --output json`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
- `nix build .#default --no-link --print-build-logs`

## Lab Notes

The current host is critically low on disk, around 5-6 GiB free during the Podman dry-run. The live Podman machine was not running, so the runtime dry-run could not exercise the VM compaction path; the new compaction target behavior is covered by focused plan tests.
