### PR TITLE
Add Podman compaction scratch preflight

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -180,6 +180,10 @@ type PodmanConfig struct {
 	CompactKeepBackupUntilRestart bool `yaml:"compact_keep_backup_until_restart"`
 	// CompactProviderAllowlist restricts offline compaction to known providers
 	CompactProviderAllowlist []string `yaml:"compact_provider_allowlist"`
+	// CompactScratchDir stores the temporary compacted image; empty keeps it beside the VM disk
+	CompactScratchDir string `yaml:"compact_scratch_dir"`
+	// CompactQemuImgPath overrides qemu-img discovery for offline compaction
+	CompactQemuImgPath string `yaml:"compact_qemu_img_path"`
 }
 
 // BazelConfig holds Bazel output base and cache cleanup settings.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -240,6 +240,12 @@ func TestPodmanCompactDefaults(t *testing.T) {
 	if len(cfg.Podman.CompactProviderAllowlist) == 0 {
 		t.Fatal("Podman.CompactProviderAllowlist should have defaults")
 	}
+	if cfg.Podman.CompactScratchDir != "" {
+		t.Errorf("Podman.CompactScratchDir should default to empty, got %q", cfg.Podman.CompactScratchDir)
+	}
+	if cfg.Podman.CompactQemuImgPath != "" {
+		t.Errorf("Podman.CompactQemuImgPath should default to empty, got %q", cfg.Podman.CompactQemuImgPath)
+	}
 }
 
 func TestNixPolicyDefaults(t *testing.T) {
@@ -390,6 +396,8 @@ podman:
   compact_min_reclaim_gb: 12
   compact_require_no_active_containers: false
   compact_keep_backup_until_restart: false
+  compact_scratch_dir: /Volumes/TinylandSSD/tinyland-cleanup-podman
+  compact_qemu_img_path: /nix/store/example-qemu/bin/qemu-img
   compact_provider_allowlist:
     - applehv
 nix:
@@ -498,6 +506,12 @@ darwin_dev_caches:
 	}
 	if len(cfg.Podman.CompactProviderAllowlist) != 1 || cfg.Podman.CompactProviderAllowlist[0] != "applehv" {
 		t.Errorf("unexpected Podman.CompactProviderAllowlist: %#v", cfg.Podman.CompactProviderAllowlist)
+	}
+	if cfg.Podman.CompactScratchDir != "/Volumes/TinylandSSD/tinyland-cleanup-podman" {
+		t.Errorf("Podman.CompactScratchDir should be custom path, got %q", cfg.Podman.CompactScratchDir)
+	}
+	if cfg.Podman.CompactQemuImgPath != "/nix/store/example-qemu/bin/qemu-img" {
+		t.Errorf("Podman.CompactQemuImgPath should be custom path, got %q", cfg.Podman.CompactQemuImgPath)
 	}
 	if cfg.Nix.MinUserGenerations != 7 {
 		t.Errorf("Nix.MinUserGenerations should be 7 per config, got %d", cfg.Nix.MinUserGenerations)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -69,6 +69,34 @@ docker:
   # Don't prune images used by running containers
   protect_running_containers: true
 
+# Podman-specific settings
+podman:
+  prune_images_age: "24h"
+  protect_running_containers: true
+  machine_names:
+    - podman-machine-default
+  clean_inside_vm: true
+  trim_vm_disk: true
+
+  # Offline VM disk compaction is disruptive and remains opt-in.
+  compact_disk_offline: false
+  compact_min_reclaim_gb: 8
+  compact_require_no_active_containers: true
+  compact_keep_backup_until_restart: true
+  compact_provider_allowlist:
+    - applehv
+    - libkrun
+    - qemu
+
+  # Empty scratch dir keeps the compacted temp image beside the VM disk.
+  # Configured scratch dirs must be on the same filesystem until the
+  # cross-device replacement flow is implemented.
+  compact_scratch_dir: ""
+
+  # Optional absolute qemu-img path when the daemon environment does not have
+  # qemu-img on PATH.
+  compact_qemu_img_path: ""
+
 # Nix store and profile generation cleanup settings
 nix:
   # Preserve rollback safety even under disk pressure

--- a/docs/podman-darwin-compaction.md
+++ b/docs/podman-darwin-compaction.md
@@ -18,10 +18,11 @@ The Podman plan reports:
 
 - provider and running state;
 - disk format and disk path;
+- scratch directory, temp image path, and rollback backup path;
 - logical image size and physical host allocation;
 - required temporary free space based on physical allocation plus headroom;
 - active-container status;
-- whether `qemu-img` is available;
+- whether `qemu-img` is available and which executable path will be used;
 - protected targets for blocked VM disk compaction, scratch-space requirements,
   and active-container quiescence;
 - the exact stop, convert, verify, replace, and start sequence.
@@ -41,6 +42,8 @@ podman:
   compact_min_reclaim_gb: 8
   compact_require_no_active_containers: true
   compact_keep_backup_until_restart: true
+  compact_scratch_dir: ""
+  compact_qemu_img_path: ""
   compact_provider_allowlist:
     - applehv
     - libkrun
@@ -51,6 +54,18 @@ The preflight skips compaction when the disk path is outside expected Podman
 machine directories, `qemu-img` is unavailable, active containers are running,
 the provider is unknown, a rollback backup already exists, or the filesystem
 does not have enough physical free space for the compacted copy.
+
+`compact_scratch_dir` may point at a reviewed scratch directory when the default
+VM disk directory cannot hold the temporary compacted image. The current
+mutation flow only supports scratch directories on the same filesystem as the VM
+disk, because replacement is performed with filesystem renames. Cross-device
+scratch directories are reported as protected targets with
+`scratch_dir_cross_device_replace_unsupported` until a separate copy-and-verify
+replacement flow lands.
+
+`compact_qemu_img_path` is optional. Set it only when the daemon environment does
+not have `qemu-img` on `PATH`, for example when operators intentionally provide
+the executable from a Nix profile or wrapped package.
 
 When `active_containers` or `insufficient_free_space` appears, treat the plan as
 a quiescence or scratch-capacity task. Do not force compaction on an active

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -47,14 +47,19 @@ type podmanCompactionPlan struct {
 	Provider                  string
 	DiskFormat                string
 	DiskPath                  string
+	ScratchDir                string
 	TempPath                  string
 	BackupPath                string
 	ConfigEnabled             bool
+	QemuImgPath               string
 	QemuImgAvailable          bool
 	ActiveContainers          bool
 	ActiveContainerCheckError string
 	DiskPathExpected          bool
 	BackupExists              bool
+	ScratchDirConfigured      bool
+	ScratchDirAvailable       bool
+	ScratchDirCrossDevice     bool
 	LogicalBytes              int64
 	PhysicalBytes             int64
 	FreeBytes                 int64
@@ -70,12 +75,17 @@ type podmanCompactionPlanInput struct {
 	MachineName               string
 	Provider                  string
 	DiskPath                  string
+	ScratchDir                string
 	ConfigEnabled             bool
+	QemuImgPath               string
 	QemuImgAvailable          bool
 	ActiveContainers          bool
 	ActiveContainerCheckError string
 	DiskPathExpected          bool
 	BackupExists              bool
+	ScratchDirConfigured      bool
+	ScratchDirAvailable       bool
+	ScratchDirCrossDevice     bool
 	LogicalBytes              int64
 	PhysicalBytes             int64
 	FreeBytes                 int64
@@ -196,14 +206,19 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 			plan.Metadata["offline_compaction_provider"] = compaction.Provider
 			plan.Metadata["offline_compaction_format"] = compaction.DiskFormat
 			plan.Metadata["offline_compaction_disk_path"] = compaction.DiskPath
+			plan.Metadata["offline_compaction_scratch_dir"] = compaction.ScratchDir
 			plan.Metadata["offline_compaction_temp_path"] = compaction.TempPath
 			plan.Metadata["offline_compaction_backup_path"] = compaction.BackupPath
+			plan.Metadata["offline_compaction_qemu_img_path"] = compaction.QemuImgPath
 			plan.Metadata["offline_compaction_logical_bytes"] = strconv.FormatInt(compaction.LogicalBytes, 10)
 			plan.Metadata["offline_compaction_physical_bytes"] = strconv.FormatInt(compaction.PhysicalBytes, 10)
 			plan.Metadata["offline_compaction_free_bytes"] = strconv.FormatInt(compaction.FreeBytes, 10)
 			plan.Metadata["offline_compaction_required_free_bytes"] = strconv.FormatInt(compaction.RequiredFreeBytes, 10)
 			plan.Metadata["offline_compaction_estimated_reclaim_bytes"] = strconv.FormatInt(compaction.EstimatedReclaimBytes, 10)
 			plan.Metadata["offline_compaction_active_containers"] = strconv.FormatBool(compaction.ActiveContainers)
+			plan.Metadata["offline_compaction_scratch_dir_configured"] = strconv.FormatBool(compaction.ScratchDirConfigured)
+			plan.Metadata["offline_compaction_scratch_dir_available"] = strconv.FormatBool(compaction.ScratchDirAvailable)
+			plan.Metadata["offline_compaction_scratch_dir_cross_device"] = strconv.FormatBool(compaction.ScratchDirCrossDevice)
 			plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
 		}
 	}
@@ -634,11 +649,13 @@ func parseFstrimOutput(output string) int64 {
 }
 
 func (p *PodmanPlugin) planOfflineCompaction(ctx context.Context, cfg *config.Config, logger *slog.Logger) podmanCompactionPlan {
+	qemuImgPath, qemuImgAvailable := resolveQemuImgPath(cfg.Podman.CompactQemuImgPath)
 	input := podmanCompactionPlanInput{
 		MachineName:      p.environment.MachineName,
 		Provider:         p.environment.VMProvider,
 		ConfigEnabled:    cfg.Podman.CompactDiskOffline,
-		QemuImgAvailable: commandAvailable("qemu-img"),
+		QemuImgPath:      qemuImgPath,
+		QemuImgAvailable: qemuImgAvailable,
 		Config:           cfg.Podman,
 	}
 
@@ -654,6 +671,8 @@ func (p *PodmanPlugin) planOfflineCompaction(ctx context.Context, cfg *config.Co
 	input.DiskPath = diskPath
 	input.DiskPathExpected = expectedPodmanMachineDiskPath(diskPath)
 	input.BackupExists = pathExists(diskPath + ".backup")
+	input.ScratchDir = filepath.Dir(diskPath)
+	input.ScratchDirAvailable = true
 
 	if stat, err := os.Stat(diskPath); err == nil {
 		input.LogicalBytes = stat.Size()
@@ -672,10 +691,38 @@ func (p *PodmanPlugin) planOfflineCompaction(ctx context.Context, cfg *config.Co
 		input.PhysicalBytes = input.LogicalBytes
 	}
 
-	if free, err := getFreeDiskSpace(filepath.Dir(diskPath)); err == nil {
+	if configuredScratchDir := strings.TrimSpace(cfg.Podman.CompactScratchDir); configuredScratchDir != "" {
+		home, _ := os.UserHomeDir()
+		input.ScratchDirConfigured = true
+		input.ScratchDir = filepath.Clean(expandHome(configuredScratchDir, home))
+		stat, err := os.Stat(input.ScratchDir)
+		if err != nil {
+			logger.Debug("Podman compaction scratch directory preflight failed", "scratch_dir", input.ScratchDir, "error", err)
+			input.ScratchDirAvailable = false
+			plan := buildPodmanCompactionPlan(input)
+			plan.SkipReason = "scratch_dir_unavailable"
+			plan.Warnings = append(plan.Warnings, err.Error())
+			return plan
+		}
+		if !stat.IsDir() {
+			logger.Debug("Podman compaction scratch path is not a directory", "scratch_dir", input.ScratchDir)
+			input.ScratchDirAvailable = false
+			plan := buildPodmanCompactionPlan(input)
+			plan.SkipReason = "scratch_dir_not_directory"
+			return plan
+		}
+	}
+
+	if diskDevice, err := deviceID(filepath.Dir(diskPath)); err == nil {
+		if scratchDevice, err := deviceID(input.ScratchDir); err == nil {
+			input.ScratchDirCrossDevice = diskDevice != scratchDevice
+		}
+	}
+
+	if free, err := getFreeDiskSpace(input.ScratchDir); err == nil {
 		input.FreeBytes = int64FromUint64(free)
 	} else {
-		logger.Debug("Podman disk free-space preflight failed", "disk", diskPath, "error", err)
+		logger.Debug("Podman disk free-space preflight failed", "scratch_dir", input.ScratchDir, "error", err)
 		plan := buildPodmanCompactionPlan(input)
 		plan.SkipReason = "free_space_check_failed"
 		plan.Warnings = append(plan.Warnings, err.Error())
@@ -695,11 +742,20 @@ func (p *PodmanPlugin) planOfflineCompaction(ctx context.Context, cfg *config.Co
 
 func buildPodmanCompactionPlan(input podmanCompactionPlanInput) podmanCompactionPlan {
 	diskFormat, supportedProvider := podmanDiskFormat(input.Provider)
+	scratchDir := input.ScratchDir
 	tempPath := ""
 	backupPath := ""
 	if input.DiskPath != "" {
-		tempPath = input.DiskPath + ".compact"
+		if scratchDir == "" {
+			scratchDir = filepath.Dir(input.DiskPath)
+		}
+		tempPath = filepath.Join(scratchDir, filepath.Base(input.DiskPath)+".compact")
 		backupPath = input.DiskPath + ".backup"
+	}
+	scratchDirAvailable := input.ScratchDirAvailable || (!input.ScratchDirConfigured && scratchDir != "")
+	qemuImgPath := input.QemuImgPath
+	if qemuImgPath == "" {
+		qemuImgPath = "qemu-img"
 	}
 
 	physicalBytes := input.PhysicalBytes
@@ -721,14 +777,19 @@ func buildPodmanCompactionPlan(input podmanCompactionPlanInput) podmanCompaction
 		Provider:                  input.Provider,
 		DiskFormat:                diskFormat,
 		DiskPath:                  input.DiskPath,
+		ScratchDir:                scratchDir,
 		TempPath:                  tempPath,
 		BackupPath:                backupPath,
 		ConfigEnabled:             input.ConfigEnabled,
+		QemuImgPath:               qemuImgPath,
 		QemuImgAvailable:          input.QemuImgAvailable,
 		ActiveContainers:          input.ActiveContainers,
 		ActiveContainerCheckError: input.ActiveContainerCheckError,
 		DiskPathExpected:          input.DiskPathExpected,
 		BackupExists:              input.BackupExists,
+		ScratchDirConfigured:      input.ScratchDirConfigured,
+		ScratchDirAvailable:       scratchDirAvailable,
+		ScratchDirCrossDevice:     input.ScratchDirCrossDevice,
 		LogicalBytes:              input.LogicalBytes,
 		PhysicalBytes:             physicalBytes,
 		FreeBytes:                 input.FreeBytes,
@@ -736,9 +797,10 @@ func buildPodmanCompactionPlan(input podmanCompactionPlanInput) podmanCompaction
 		EstimatedReclaimBytes:     estimatedReclaimBytes,
 		Steps: []string{
 			fmt.Sprintf("Inspect Podman machine %q disk metadata", input.MachineName),
+			fmt.Sprintf("Check offline compaction scratch space at %s", scratchDir),
 			"Confirm no active containers are running",
 			fmt.Sprintf("Stop Podman machine %q", input.MachineName),
-			fmt.Sprintf("Convert %s to %s with qemu-img convert -f %s -O %s", input.DiskPath, tempPath, diskFormat, diskFormat),
+			fmt.Sprintf("Convert %s to %s with %s convert -f %s -O %s", input.DiskPath, tempPath, qemuImgPath, diskFormat, diskFormat),
 			"Verify the compacted image before replacing the original",
 			"Preserve the original disk image as rollback backup until restart succeeds",
 			fmt.Sprintf("Replace %s with compacted image", input.DiskPath),
@@ -775,6 +837,10 @@ func buildPodmanCompactionPlan(input podmanCompactionPlanInput) podmanCompaction
 		plan.SkipReason = "active_containers"
 	case !input.QemuImgAvailable:
 		plan.SkipReason = "qemu_img_missing"
+	case !scratchDirAvailable:
+		plan.SkipReason = "scratch_dir_unavailable"
+	case input.ScratchDirConfigured && input.ScratchDirCrossDevice:
+		plan.SkipReason = "scratch_dir_cross_device_replace_unsupported"
 	case physicalBytes <= 0:
 		plan.SkipReason = "physical_size_unknown"
 	case minReclaimBytes > 0 && physicalBytes < minReclaimBytes:
@@ -822,15 +888,28 @@ func podmanCompactionTargets(plan podmanCompactionPlan) []CleanupTarget {
 	if plan.RequiredFreeBytes > 0 {
 		action := "review_required_free_space"
 		reason := "offline compaction needs temporary scratch space for the compacted image"
+		scratchPath := plan.ScratchDir
+		if scratchPath == "" && plan.DiskPath != "" {
+			scratchPath = filepath.Dir(plan.DiskPath)
+		}
 		if plan.SkipReason == "insufficient_free_space" {
 			action = "protect_insufficient_free_space"
-			reason = "not enough free space is available beside the VM disk for offline compaction"
+			reason = "not enough free space is available in the offline compaction scratch directory"
+		} else if plan.SkipReason == "scratch_dir_unavailable" {
+			action = "protect_scratch_dir_unavailable"
+			reason = "configured offline compaction scratch directory is unavailable"
+		} else if plan.SkipReason == "scratch_dir_not_directory" {
+			action = "protect_scratch_dir_unavailable"
+			reason = "configured offline compaction scratch path is not a directory"
+		} else if plan.SkipReason == "scratch_dir_cross_device_replace_unsupported" {
+			action = "protect_cross_device_scratch"
+			reason = "configured scratch directory is on a different filesystem than the VM disk"
 		}
 		target := CleanupTarget{
 			Type:      "podman_compaction_scratch",
 			Tier:      CleanupTierDisruptive,
 			Name:      "offline compaction scratch space",
-			Path:      filepath.Dir(plan.DiskPath),
+			Path:      scratchPath,
 			Bytes:     plan.RequiredFreeBytes,
 			Protected: true,
 			Action:    action,
@@ -876,6 +955,12 @@ func podmanCompactionSkipReason(reason string) string {
 		return "not enough scratch free space is available for offline compaction"
 	case "qemu_img_missing":
 		return "qemu-img is required for offline compaction"
+	case "scratch_dir_unavailable":
+		return "configured offline compaction scratch directory is unavailable"
+	case "scratch_dir_not_directory":
+		return "configured offline compaction scratch path is not a directory"
+	case "scratch_dir_cross_device_replace_unsupported":
+		return "configured offline compaction scratch directory is on a different filesystem than the VM disk"
 	case "backup_path_exists":
 		return "existing rollback backup must be resolved before offline compaction"
 	case "disk_path_outside_podman_machine_dirs":
@@ -970,9 +1055,19 @@ func (p *PodmanPlugin) hasActiveContainers(ctx context.Context) (bool, error) {
 	return strings.TrimSpace(output) != "", nil
 }
 
-func commandAvailable(name string) bool {
-	_, err := exec.LookPath(name)
-	return err == nil
+func resolveQemuImgPath(configuredPath string) (string, bool) {
+	if strings.TrimSpace(configuredPath) != "" {
+		home, _ := os.UserHomeDir()
+		path := filepath.Clean(expandHome(strings.TrimSpace(configuredPath), home))
+		info, err := os.Stat(path)
+		return path, err == nil && !info.IsDir()
+	}
+
+	path, err := exec.LookPath("qemu-img")
+	if err != nil {
+		return "qemu-img", false
+	}
+	return path, true
 }
 
 func int64FromUint64(value uint64) int64 {
@@ -1027,7 +1122,11 @@ func (p *PodmanPlugin) compactRawDisk(ctx context.Context, cfg *config.Config, l
 
 	// 2. Convert to sparse copy
 	logger.Info("compacting Podman machine disk", "machine", p.environment.MachineName)
-	convertCmd := exec.CommandContext(ctx, "qemu-img", "convert",
+	qemuImgPath := plan.QemuImgPath
+	if qemuImgPath == "" {
+		qemuImgPath = "qemu-img"
+	}
+	convertCmd := exec.CommandContext(ctx, qemuImgPath, "convert",
 		"-f", plan.DiskFormat, "-O", plan.DiskFormat, plan.DiskPath, plan.TempPath)
 	if output, err := convertCmd.CombinedOutput(); err != nil {
 		os.Remove(plan.TempPath)
@@ -1039,7 +1138,7 @@ func (p *PodmanPlugin) compactRawDisk(ctx context.Context, cfg *config.Config, l
 
 	// 3. Verify if qcow2 format
 	if plan.DiskFormat == "qcow2" {
-		checkCmd := exec.CommandContext(ctx, "qemu-img", "check", plan.TempPath)
+		checkCmd := exec.CommandContext(ctx, qemuImgPath, "check", plan.TempPath)
 		if output, err := checkCmd.CombinedOutput(); err != nil {
 			os.Remove(plan.TempPath)
 			exec.CommandContext(ctx, "podman", "machine", "start", p.environment.MachineName).Run()

--- a/plugins/podman_compaction_test.go
+++ b/plugins/podman_compaction_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Jesssullivan/tinyland-cleanup/config"
@@ -202,6 +203,121 @@ func TestPodmanCompactionTargetsExposeScratchDeficit(t *testing.T) {
 	disk := findPodmanTarget(t, targets, "podman_vm_disk")
 	if disk.Reclaim != CleanupReclaimNone || disk.HostReclaimsSpace == nil || *disk.HostReclaimsSpace {
 		t.Fatalf("blocked disk target should not count as host reclaim: %#v", disk)
+	}
+}
+
+func TestPodmanCompactionPlanUsesConfiguredScratchDir(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+	scratchDir := "/Volumes/TinylandSSD/tinyland-cleanup-podman"
+	qemuImgPath := "/nix/store/example-qemu/bin/qemu-img"
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:          "podman-machine-default",
+		Provider:             "applehv",
+		DiskPath:             "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ScratchDir:           scratchDir,
+		ConfigEnabled:        true,
+		QemuImgPath:          qemuImgPath,
+		QemuImgAvailable:     true,
+		DiskPathExpected:     true,
+		ScratchDirConfigured: true,
+		ScratchDirAvailable:  true,
+		LogicalBytes:         100 * podmanCompactionGiB,
+		PhysicalBytes:        12 * podmanCompactionGiB,
+		FreeBytes:            14 * podmanCompactionGiB,
+		Config:               cfg,
+	})
+
+	if !plan.CanCompact {
+		t.Fatalf("expected configured scratch dir compaction to be eligible, got skip reason %q", plan.SkipReason)
+	}
+	expectedTemp := filepath.Join(scratchDir, "podman-machine-default.raw.compact")
+	if plan.TempPath != expectedTemp {
+		t.Fatalf("expected temp path %q, got %q", expectedTemp, plan.TempPath)
+	}
+	if plan.ScratchDir != scratchDir {
+		t.Fatalf("expected scratch dir %q, got %q", scratchDir, plan.ScratchDir)
+	}
+	if plan.QemuImgPath != qemuImgPath {
+		t.Fatalf("expected qemu-img path %q, got %q", qemuImgPath, plan.QemuImgPath)
+	}
+	if !strings.Contains(strings.Join(plan.Steps, "\n"), qemuImgPath+" convert") {
+		t.Fatalf("expected plan steps to include configured qemu-img path: %#v", plan.Steps)
+	}
+
+	targets := podmanCompactionTargets(plan)
+	scratch := findPodmanTarget(t, targets, "podman_compaction_scratch")
+	if scratch.Path != scratchDir {
+		t.Fatalf("expected scratch target path %q, got %q", scratchDir, scratch.Path)
+	}
+}
+
+func TestPodmanCompactionPlanRejectsCrossDeviceScratchDir(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+	scratchDir := "/Volumes/TinylandSSD/tinyland-cleanup-podman"
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:           "podman-machine-default",
+		Provider:              "applehv",
+		DiskPath:              "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ScratchDir:            scratchDir,
+		ConfigEnabled:         true,
+		QemuImgAvailable:      true,
+		DiskPathExpected:      true,
+		ScratchDirConfigured:  true,
+		ScratchDirAvailable:   true,
+		ScratchDirCrossDevice: true,
+		LogicalBytes:          100 * podmanCompactionGiB,
+		PhysicalBytes:         12 * podmanCompactionGiB,
+		FreeBytes:             80 * podmanCompactionGiB,
+		Config:                cfg,
+	})
+
+	if plan.CanCompact {
+		t.Fatal("expected cross-device scratch dir to block compaction")
+	}
+	if plan.SkipReason != "scratch_dir_cross_device_replace_unsupported" {
+		t.Fatalf("expected scratch_dir_cross_device_replace_unsupported, got %q", plan.SkipReason)
+	}
+
+	targets := podmanCompactionTargets(plan)
+	scratch := findPodmanTarget(t, targets, "podman_compaction_scratch")
+	if scratch.Action != "protect_cross_device_scratch" || scratch.Path != scratchDir {
+		t.Fatalf("expected protected cross-device scratch target, got %#v", scratch)
+	}
+}
+
+func TestPodmanCompactionPlanRejectsUnavailableScratchDir(t *testing.T) {
+	cfg := testPodmanCompactionConfig()
+	scratchDir := "/Volumes/TinylandSSD/tinyland-cleanup-podman"
+
+	plan := buildPodmanCompactionPlan(podmanCompactionPlanInput{
+		MachineName:          "podman-machine-default",
+		Provider:             "applehv",
+		DiskPath:             "/Users/test/.local/share/containers/podman/machine/applehv/podman-machine-default.raw",
+		ScratchDir:           scratchDir,
+		ConfigEnabled:        true,
+		QemuImgAvailable:     true,
+		DiskPathExpected:     true,
+		ScratchDirConfigured: true,
+		ScratchDirAvailable:  false,
+		LogicalBytes:         100 * podmanCompactionGiB,
+		PhysicalBytes:        12 * podmanCompactionGiB,
+		FreeBytes:            0,
+		Config:               cfg,
+	})
+
+	if plan.CanCompact {
+		t.Fatal("expected unavailable scratch dir to block compaction")
+	}
+	if plan.SkipReason != "scratch_dir_unavailable" {
+		t.Fatalf("expected scratch_dir_unavailable, got %q", plan.SkipReason)
+	}
+
+	targets := podmanCompactionTargets(plan)
+	scratch := findPodmanTarget(t, targets, "podman_compaction_scratch")
+	if scratch.Action != "protect_scratch_dir_unavailable" || scratch.Path != scratchDir {
+		t.Fatalf("expected protected unavailable scratch target, got %#v", scratch)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add configurable Podman offline-compaction scratch dir and qemu-img path
- expose scratch/qemu metadata in critical dry-run plans and protected targets
- document the current same-filesystem scratch boundary and cross-device blocker

## Validation

- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build -o /tmp/tinyland-cleanup-compact-preflight .
- git diff --check
- dry-run Podman critical preflight with configured qemu-img path
- dry-run Podman critical preflight with missing external scratch dir

Local Nix/Bazel validation intentionally deferred to PR CI because the attended Darwin host is at critical disk pressure and local cache-heavy validation would perturb the machine.

Refs #6
Refs #2