### PR TITLE
Add Zig and large local artifact planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,12 @@ All notable changes to this project will be documented in this file.
 - Persistent daemon cleanup state with per-plugin cooldowns for non-critical
   daemon-triggered cleanup cycles.
 - Structured dry-run targets for development artifacts such as stale
-  `node_modules`, Python virtualenvs, Rust `target/` directories, Go build
-  cache, Haskell caches, and opt-in LM Studio model caches.
+  `node_modules`, Python virtualenvs, Rust `target/` directories, Zig
+  `.zig-cache` and `zig-out` directories, Go build cache, Haskell caches, and
+  opt-in LM Studio model caches.
+- Review-only large local artifact targets for disk images and VM bundles such
+  as `.dmg`, `.img`, `.qcow2`, `.raw`, `.iso`, `.sparsebundle`, `.utm`, `.pvm`,
+  and `.vmwarevm` paths.
 - Opt-in Darwin developer-cache enforcement for typed JetBrains, Playwright,
   Bazelisk, and pip cache targets.
 - Nix low-reclaim dry-runs now emit protected GC-root attribution targets so
@@ -47,7 +51,7 @@ All notable changes to this project will be documented in this file.
   configured budget.
 - Repo-local Bazel symlink cleanup after successful stale output-base deletion.
 - Active-process protection for development artifact cleanup families such as
-  Node.js, Python, Rust, Go, Haskell, and LM Studio.
+  Node.js, Python, Rust, Zig, Go, Haskell, and LM Studio.
 - Typed Darwin developer-cache targets for VS Code and Cursor cache-only
   directories, with active-editor protection.
 - CLI `--plugins` filter for bounded dry-run evidence collection and targeted

--- a/config/config.go
+++ b/config/config.go
@@ -252,12 +252,18 @@ type DevArtifactsConfig struct {
 	PythonVenvs bool `yaml:"python_venvs"`
 	// RustTargets enables Rust target/ cleanup
 	RustTargets bool `yaml:"rust_targets"`
+	// ZigArtifacts enables Zig .zig-cache/ and zig-out/ cleanup
+	ZigArtifacts bool `yaml:"zig_artifacts"`
 	// GoBuildCache enables Go build cache cleanup
 	GoBuildCache bool `yaml:"go_build_cache"`
 	// HaskellCache enables .ghcup/cache and .cabal/store cleanup
 	HaskellCache bool `yaml:"haskell_cache"`
 	// LMStudioModels enables .lmstudio model cleanup (opt-in)
 	LMStudioModels bool `yaml:"lmstudio_models"`
+	// LargeLocalArtifacts enables review-only reporting for large disk images and VM bundles
+	LargeLocalArtifacts bool `yaml:"large_local_artifacts"`
+	// LargeLocalArtifactMinMB is the minimum physical size for review-only large local artifact targets
+	LargeLocalArtifactMinMB int `yaml:"large_local_artifact_min_mb"`
 	// ProtectPaths are paths that should never be cleaned
 	ProtectPaths []string `yaml:"protect_paths"`
 }
@@ -416,14 +422,17 @@ func DefaultConfig() *Config {
 			MinFileSizeMB:  10,
 		},
 		DevArtifacts: DevArtifactsConfig{
-			ScanPaths:      defaultScanPaths,
-			NodeModules:    true,
-			PythonVenvs:    true,
-			RustTargets:    true,
-			GoBuildCache:   true,
-			HaskellCache:   true,
-			LMStudioModels: false,
-			ProtectPaths:   []string{},
+			ScanPaths:               defaultScanPaths,
+			NodeModules:             true,
+			PythonVenvs:             true,
+			RustTargets:             true,
+			ZigArtifacts:            true,
+			GoBuildCache:            true,
+			HaskellCache:            true,
+			LMStudioModels:          false,
+			LargeLocalArtifacts:     true,
+			LargeLocalArtifactMinMB: 1024,
+			ProtectPaths:            []string{},
 		},
 		DarwinDevCaches: DarwinDevCachesConfig{
 			Enabled:    runtime.GOOS == "darwin",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -174,6 +174,9 @@ func TestDevArtifactsConfigDefaults(t *testing.T) {
 	if !cfg.DevArtifacts.RustTargets {
 		t.Error("DevArtifacts.RustTargets should be true by default")
 	}
+	if !cfg.DevArtifacts.ZigArtifacts {
+		t.Error("DevArtifacts.ZigArtifacts should be true by default")
+	}
 	if !cfg.DevArtifacts.GoBuildCache {
 		t.Error("DevArtifacts.GoBuildCache should be true by default")
 	}
@@ -182,6 +185,12 @@ func TestDevArtifactsConfigDefaults(t *testing.T) {
 	}
 	if cfg.DevArtifacts.LMStudioModels {
 		t.Error("DevArtifacts.LMStudioModels should be false by default (opt-in)")
+	}
+	if !cfg.DevArtifacts.LargeLocalArtifacts {
+		t.Error("DevArtifacts.LargeLocalArtifacts should be true by default")
+	}
+	if cfg.DevArtifacts.LargeLocalArtifactMinMB <= 0 {
+		t.Error("DevArtifacts.LargeLocalArtifactMinMB should be positive by default")
 	}
 }
 
@@ -473,6 +482,9 @@ darwin_dev_caches:
 	}
 	if cfg.DevArtifacts.RustTargets {
 		t.Error("DevArtifacts.RustTargets should be false per config")
+	}
+	if !cfg.DevArtifacts.ZigArtifacts {
+		t.Error("DevArtifacts.ZigArtifacts should stay true by default when omitted")
 	}
 	if !cfg.DevArtifacts.LMStudioModels {
 		t.Error("DevArtifacts.LMStudioModels should be true per config")

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -34,6 +34,7 @@ enable:
   gitlab_runner: true   # GitLab runner cache cleanup
   github_runner: true   # GitHub Actions runner cleanup (Linux only)
   yum: true             # DNF/YUM package cache cleanup (Linux only)
+  dev_artifacts: true   # Rebuildable workspace artifacts
   bazel: true           # Bazel output base and cache cleanup planning
 
 # GitHub Actions runner settings (Linux only)
@@ -138,6 +139,24 @@ bazel:
     - ~/git/GloriousFlywheel
   allow_stop_idle_servers: true
   allow_delete_active_output_bases: false
+
+# Workspace development artifact settings
+dev_artifacts:
+  scan_paths:
+    - ~/git
+    - ~/src
+    - ~/projects
+  node_modules: true
+  python_venvs: true
+  rust_targets: true
+  zig_artifacts: true
+  go_build_cache: true
+  haskell_cache: true
+  lmstudio_models: false
+  # Review-only: report large local disk images and VM bundles, never auto-delete.
+  large_local_artifacts: true
+  large_local_artifact_min_mb: 1024
+  protect_paths: []
 
 # Darwin developer-cache review settings.
 # Enforcement is opt-in; keep false until dry-run targets are reviewed.

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -146,11 +146,16 @@ and active editor or IDE processes.
 
 For workspace build artifacts, the `dev-artifacts` plan reports rebuildable
 targets such as `node_modules`, Python virtualenvs, Rust `target/` directories,
-Go build cache, Haskell caches, and opt-in LM Studio model caches. Warning
-level reports only; moderate and above mark eligible stale artifacts as
-deletion or cache-clean targets while preserving configured protected paths.
-The plan also protects matching artifact families when active package manager,
-compiler, language server, runtime, or LM Studio processes are visible.
+Zig `.zig-cache` and `zig-out` directories, Go build cache, Haskell caches,
+opt-in LM Studio model caches, and review-only large local disk/image artifacts
+such as `.dmg`, `.img`, `.qcow2`, `.raw`, `.iso`, `.sparsebundle`, `.utm`,
+`.pvm`, and `.vmwarevm` targets. Warning level reports only; moderate and above
+mark eligible stale artifacts as deletion or cache-clean targets while
+preserving configured protected paths. Large local disk/image artifacts are
+always protected and excluded from estimated reclaim because they can be
+developer-owned state. The plan also protects matching artifact families when
+active package manager, compiler, language server, runtime, or LM Studio
+processes are visible.
 
 For Docker, the plan reports Docker daemon disk-usage rows from `docker system
 df`, including images, stopped containers, local volumes, and build cache when

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -93,9 +93,12 @@ dev_artifacts:
   node_modules: true
   python_venvs: true
   rust_targets: false
+  zig_artifacts: true
   go_build_cache: true
   haskell_cache: true
   lmstudio_models: false
+  large_local_artifacts: true
+  large_local_artifact_min_mb: 1024
 
 notify:
   enabled: false

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -1,6 +1,7 @@
 // Package plugins provides cleanup plugin implementations.
 // devartifacts.go scans for stale development artifacts like node_modules,
-// .venv, Rust target/, Go build cache, Haskell caches, and LM Studio models.
+// .venv, Rust target/, Zig artifacts, Go build cache, Haskell caches,
+// LM Studio models, and review-only large local artifacts.
 package plugins
 
 import (
@@ -35,7 +36,7 @@ func (p *DevArtifactsPlugin) Name() string {
 
 // Description returns the plugin description.
 func (p *DevArtifactsPlugin) Description() string {
-	return "Cleans stale development artifacts (node_modules, .venv, target/, go cache, haskell, lmstudio)"
+	return "Cleans stale development artifacts (node_modules, .venv, target/, zig, go cache, haskell, lmstudio) and reports large local artifacts"
 }
 
 // SupportedPlatforms returns supported platforms (all).
@@ -54,7 +55,7 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 
 	home, _ := os.UserHomeDir()
 	daCfg := cfg.DevArtifacts
-	nodeAge, venvAge, rustAge, mutates := devArtifactThresholds(level)
+	nodeAge, venvAge, rustAge, zigAge, mutates := devArtifactThresholds(level)
 	plan := CleanupPlan{
 		Plugin:   p.Name(),
 		Level:    level.String(),
@@ -62,8 +63,9 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 		WouldRun: true,
 		Steps: []string{
 			"Scan configured development workspaces for rebuildable artifact directories",
-			"Use project marker mtimes to classify stale node_modules, .venv, and Rust target directories",
+			"Use project marker mtimes to classify stale node_modules, .venv, Rust target, and Zig artifact directories",
 			"Protect artifact families when matching package manager, compiler, language server, or runtime processes are active",
+			"Report large disk images and VM bundles for manual review without deleting them",
 			"Honor configured protected paths before any deletion candidate is eligible",
 		},
 		Metadata: map[string]string{
@@ -96,6 +98,12 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 		}
 		if daCfg.RustTargets {
 			p.planRustTargets(expanded, rustAge, mutates, daCfg.ProtectPaths, active, &targets)
+		}
+		if daCfg.ZigArtifacts {
+			p.planZigArtifacts(expanded, zigAge, mutates, daCfg.ProtectPaths, active, &targets)
+		}
+		if daCfg.LargeLocalArtifacts {
+			p.planLargeLocalArtifacts(expanded, largeLocalArtifactMinBytes(daCfg), daCfg.ProtectPaths, &targets)
 		}
 	}
 
@@ -142,7 +150,7 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 	daCfg := cfg.DevArtifacts
 
 	// Determine staleness thresholds based on level
-	nodeAge, venvAge, rustAge, mutates := devArtifactThresholds(level)
+	nodeAge, venvAge, rustAge, zigAge, mutates := devArtifactThresholds(level)
 	if !mutates {
 		// Report only - no deletion
 		p.reportArtifacts(ctx, daCfg, home, logger)
@@ -185,6 +193,14 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 				result.ItemsCleaned++
 			}
 		}
+
+		if daCfg.ZigArtifacts && !devArtifactFamilyActive(active, "zig-artifact") {
+			freed := p.cleanZigArtifacts(ctx, expanded, zigAge, daCfg.ProtectPaths, logger)
+			result.BytesFreed += freed
+			if freed > 0 {
+				result.ItemsCleaned++
+			}
+		}
 	}
 
 	// Go build cache (not path-dependent - it's a global cache)
@@ -217,16 +233,16 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 	return result
 }
 
-func devArtifactThresholds(level CleanupLevel) (nodeAge, venvAge, rustAge time.Duration, mutates bool) {
+func devArtifactThresholds(level CleanupLevel) (nodeAge, venvAge, rustAge, zigAge time.Duration, mutates bool) {
 	switch level {
 	case LevelModerate:
-		return 30 * 24 * time.Hour, 60 * 24 * time.Hour, 30 * 24 * time.Hour, true
+		return 30 * 24 * time.Hour, 60 * 24 * time.Hour, 30 * 24 * time.Hour, 30 * 24 * time.Hour, true
 	case LevelAggressive:
-		return 7 * 24 * time.Hour, 14 * 24 * time.Hour, 7 * 24 * time.Hour, true
+		return 7 * 24 * time.Hour, 14 * 24 * time.Hour, 7 * 24 * time.Hour, 7 * 24 * time.Hour, true
 	case LevelCritical:
-		return 0, 0, 0, true
+		return 0, 0, 0, 0, true
 	default:
-		return 0, 0, 0, false
+		return 0, 0, 0, 0, false
 	}
 }
 
@@ -252,6 +268,124 @@ func (p *DevArtifactsPlugin) planRustTargets(scanPath string, maxAge time.Durati
 		stale := maxAge == 0 || p.isFileStale(marker, maxAge)
 		*targets = append(*targets, p.devArtifactTarget("rust-target", "target", dir, size, stale, mutates, p.isProtected(dir, protectPaths), "Cargo.toml", maxAge, active))
 	})
+}
+
+func (p *DevArtifactsPlugin) planZigArtifacts(scanPath string, maxAge time.Duration, mutates bool, protectPaths []string, active map[string]string, targets *[]CleanupTarget) {
+	for _, artifactName := range []string{".zig-cache", "zig-out"} {
+		p.findArtifactDirs(scanPath, artifactName, "build.zig", func(dir string, size int64) {
+			marker := filepath.Join(filepath.Dir(dir), "build.zig")
+			stale := maxAge == 0 || p.isFileStale(marker, maxAge)
+			*targets = append(*targets, p.devArtifactTarget("zig-artifact", artifactName, dir, size, stale, mutates, p.isProtected(dir, protectPaths), "build.zig", maxAge, active))
+		})
+	}
+}
+
+func (p *DevArtifactsPlugin) planLargeLocalArtifacts(scanPath string, minBytes int64, protectPaths []string, targets *[]CleanupTarget) {
+	p.findLargeLocalArtifacts(scanPath, minBytes, protectPaths, func(target CleanupTarget) {
+		*targets = append(*targets, target)
+	})
+}
+
+func (p *DevArtifactsPlugin) findLargeLocalArtifacts(scanPath string, minBytes int64, protectPaths []string, callback func(CleanupTarget)) {
+	scanDepth := strings.Count(scanPath, string(os.PathSeparator))
+	fileKinds := largeLocalArtifactFileKinds()
+	dirKinds := largeLocalArtifactDirKinds()
+
+	filepath.Walk(scanPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		currentDepth := strings.Count(path, string(os.PathSeparator)) - scanDepth
+		if currentDepth > 4 {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		baseName := filepath.Base(path)
+		lowerBase := strings.ToLower(baseName)
+		if info.IsDir() {
+			if strings.HasPrefix(baseName, ".") {
+				return filepath.SkipDir
+			}
+			if kind, ok := dirKinds[filepath.Ext(lowerBase)]; ok {
+				size := getDirAllocatedBytes(path)
+				if size >= minBytes {
+					callback(p.largeLocalArtifactTarget(kind, path, size, 0, p.isProtected(path, protectPaths)))
+				}
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		kind, ok := fileKinds[filepath.Ext(lowerBase)]
+		if !ok {
+			return nil
+		}
+		physicalBytes, err := getFileAllocatedBytes(path)
+		if err != nil {
+			physicalBytes = info.Size()
+		}
+		if physicalBytes < minBytes {
+			return nil
+		}
+		callback(p.largeLocalArtifactTarget(kind, path, physicalBytes, info.Size(), p.isProtected(path, protectPaths)))
+		return nil
+	})
+}
+
+func (p *DevArtifactsPlugin) largeLocalArtifactTarget(kind, path string, physicalBytes, logicalBytes int64, protected bool) CleanupTarget {
+	action := "review"
+	reason := "large local disk/image artifact requires manual review before removal"
+	if protected {
+		action = "protect"
+		reason = "path is covered by dev_artifacts.protect_paths"
+	}
+	target := CleanupTarget{
+		Type:         "large-local-artifact",
+		Name:         kind,
+		Path:         path,
+		Bytes:        physicalBytes,
+		LogicalBytes: logicalBytes,
+		Protected:    true,
+		Action:       action,
+		Reason:       reason,
+	}
+	annotateCleanupTargetPolicy(&target, CleanupTierDestructive, CleanupReclaimNone)
+	return target
+}
+
+func largeLocalArtifactMinBytes(cfg config.DevArtifactsConfig) int64 {
+	if cfg.LargeLocalArtifactMinMB <= 0 {
+		return 1024 * 1024 * 1024
+	}
+	return int64(cfg.LargeLocalArtifactMinMB) * 1024 * 1024
+}
+
+func largeLocalArtifactFileKinds() map[string]string {
+	return map[string]string{
+		".dmg":   "disk image",
+		".img":   "disk image",
+		".iso":   "ISO image",
+		".qcow2": "qcow2 disk image",
+		".raw":   "raw disk image",
+		".vhd":   "VHD disk image",
+		".vhdx":  "VHDX disk image",
+	}
+}
+
+func largeLocalArtifactDirKinds() map[string]string {
+	return map[string]string{
+		".pvm":          "Parallels VM bundle",
+		".sparsebundle": "sparse bundle disk image",
+		".utm":          "UTM VM bundle",
+		".vmwarevm":     "VMware VM bundle",
+	}
 }
 
 func (p *DevArtifactsPlugin) devArtifactTarget(targetType, name, path string, bytes int64, stale, mutates, protected bool, marker string, maxAge time.Duration, active map[string]string) CleanupTarget {
@@ -289,7 +423,7 @@ func devArtifactTier(targetType string) string {
 	switch targetType {
 	case "go-build-cache", "haskell-ghcup-cache":
 		return CleanupTierSafe
-	case "lmstudio-models":
+	case "lmstudio-models", "large-local-artifact":
 		return CleanupTierDestructive
 	default:
 		return CleanupTierWarm
@@ -484,6 +618,9 @@ func devArtifactBusyProcessReasons(output string) map[string]string {
 		case command == "cargo" || command == "rustc" || command == "rust-analyzer" ||
 			arg0 == "cargo" || arg0 == "rustc" || arg0 == "rust-analyzer":
 			add("rust-target", "Rust toolchain process")
+		case command == "zig" || command == "zls" ||
+			arg0 == "zig" || arg0 == "zls":
+			add("zig-artifact", "Zig toolchain process")
 		case (command == "go" || arg0 == "go") &&
 			(strings.Contains(normalized, " go build") ||
 				strings.Contains(normalized, " go test") ||
@@ -558,6 +695,22 @@ func (p *DevArtifactsPlugin) reportArtifacts(ctx context.Context, daCfg config.D
 		if daCfg.RustTargets {
 			p.findArtifactDirs(expanded, "target", "Cargo.toml", func(dir string, size int64) {
 				logger.Info("found Rust target", "path", dir, "size_mb", size/(1024*1024))
+			})
+		}
+
+		// Find and report Zig artifacts
+		if daCfg.ZigArtifacts {
+			for _, artifactName := range []string{".zig-cache", "zig-out"} {
+				p.findArtifactDirs(expanded, artifactName, "build.zig", func(dir string, size int64) {
+					logger.Info("found Zig artifact", "path", dir, "size_mb", size/(1024*1024))
+				})
+			}
+		}
+
+		// Find and report large local artifacts for manual review.
+		if daCfg.LargeLocalArtifacts {
+			p.findLargeLocalArtifacts(expanded, largeLocalArtifactMinBytes(daCfg), daCfg.ProtectPaths, func(target CleanupTarget) {
+				logger.Info("found large local artifact", "path", target.Path, "size_mb", target.Bytes/(1024*1024), "type", target.Name)
 			})
 		}
 	}
@@ -709,6 +862,38 @@ func (p *DevArtifactsPlugin) cleanRustTargets(ctx context.Context, scanPath stri
 
 	if totalFreed > 0 {
 		logger.Info("cleaned stale Rust targets", "freed_mb", totalFreed/(1024*1024))
+	}
+
+	return totalFreed
+}
+
+// cleanZigArtifacts removes stale Zig .zig-cache and zig-out directories.
+// A Zig artifact is stale if sibling build.zig hasn't been modified within maxAge.
+func (p *DevArtifactsPlugin) cleanZigArtifacts(ctx context.Context, scanPath string, maxAge time.Duration, protectPaths []string, logger *slog.Logger) int64 {
+	var totalFreed int64
+
+	for _, artifactName := range []string{".zig-cache", "zig-out"} {
+		p.findArtifactDirs(scanPath, artifactName, "build.zig", func(dir string, size int64) {
+			if p.isProtected(dir, protectPaths) {
+				return
+			}
+
+			buildZig := filepath.Join(filepath.Dir(dir), "build.zig")
+			if maxAge > 0 && !p.isFileStale(buildZig, maxAge) {
+				return
+			}
+
+			logger.Debug("removing stale Zig artifact", "path", dir, "size_mb", size/(1024*1024))
+			if err := os.RemoveAll(dir); err != nil {
+				logger.Debug("failed to remove Zig artifact", "path", dir, "error", err)
+				return
+			}
+			totalFreed += size
+		})
+	}
+
+	if totalFreed > 0 {
+		logger.Info("cleaned stale Zig artifacts", "freed_mb", totalFreed/(1024*1024))
 	}
 
 	return totalFreed

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -145,6 +145,12 @@ func TestFindArtifactDirs(t *testing.T) {
 	os.WriteFile(filepath.Join(project2, "Cargo.toml"), []byte("[package]\nname = \"test\""), 0644)
 	os.WriteFile(filepath.Join(project2, "target", "debug", "binary"), []byte("ELF"), 0644)
 
+	// Project 3: Zig
+	project3 := filepath.Join(tmpDir, "project3")
+	os.MkdirAll(filepath.Join(project3, ".zig-cache", "o"), 0755)
+	os.WriteFile(filepath.Join(project3, "build.zig"), []byte("const std = @import(\"std\");"), 0644)
+	os.WriteFile(filepath.Join(project3, ".zig-cache", "o", "artifact"), []byte("cache"), 0644)
+
 	// Find node_modules with marker
 	var foundNodeModules []string
 	p.findArtifactDirs(tmpDir, "node_modules", "package.json", func(dir string, size int64) {
@@ -163,6 +169,16 @@ func TestFindArtifactDirs(t *testing.T) {
 
 	if len(foundTargets) != 1 {
 		t.Errorf("expected 1 Rust target, found %d", len(foundTargets))
+	}
+
+	// Find Zig .zig-cache with build.zig marker
+	var foundZigCaches []string
+	p.findArtifactDirs(tmpDir, ".zig-cache", "build.zig", func(dir string, size int64) {
+		foundZigCaches = append(foundZigCaches, dir)
+	})
+
+	if len(foundZigCaches) != 1 {
+		t.Errorf("expected 1 Zig cache, found %d", len(foundZigCaches))
 	}
 }
 
@@ -261,6 +277,52 @@ func TestCleanNodeModulesProtected(t *testing.T) {
 	}
 }
 
+func TestCleanZigArtifactsStale(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	project := filepath.Join(tmpDir, "old-zig")
+	os.MkdirAll(filepath.Join(project, ".zig-cache", "o"), 0755)
+	os.MkdirAll(filepath.Join(project, "zig-out", "bin"), 0755)
+	os.WriteFile(filepath.Join(project, ".zig-cache", "o", "artifact"), []byte("cache"), 0644)
+	os.WriteFile(filepath.Join(project, "zig-out", "bin", "tool"), []byte("binary"), 0644)
+	buildZig := filepath.Join(project, "build.zig")
+	os.WriteFile(buildZig, []byte("const std = @import(\"std\");"), 0644)
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	os.Chtimes(buildZig, oldTime, oldTime)
+
+	freed := p.cleanZigArtifacts(context.Background(), tmpDir, 30*24*time.Hour, nil, logger)
+	if freed == 0 {
+		t.Fatal("expected stale Zig artifacts to be cleaned")
+	}
+	if pathExists(filepath.Join(project, ".zig-cache")) {
+		t.Error(".zig-cache should have been removed")
+	}
+	if pathExists(filepath.Join(project, "zig-out")) {
+		t.Error("zig-out should have been removed")
+	}
+}
+
+func TestCleanZigArtifactsFresh(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	project := filepath.Join(tmpDir, "fresh-zig")
+	os.MkdirAll(filepath.Join(project, ".zig-cache", "o"), 0755)
+	os.WriteFile(filepath.Join(project, ".zig-cache", "o", "artifact"), []byte("cache"), 0644)
+	os.WriteFile(filepath.Join(project, "build.zig"), []byte("const std = @import(\"std\");"), 0644)
+
+	freed := p.cleanZigArtifacts(context.Background(), tmpDir, 30*24*time.Hour, nil, logger)
+	if freed != 0 {
+		t.Fatal("expected fresh Zig artifacts to be preserved")
+	}
+	if !pathExists(filepath.Join(project, ".zig-cache")) {
+		t.Error(".zig-cache should still exist")
+	}
+}
+
 func TestCleanupWarningLevel(t *testing.T) {
 	p := NewDevArtifactsPlugin()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -291,6 +353,7 @@ func TestPlanCleanupWarningReportsDevArtifacts(t *testing.T) {
 	cfg.DevArtifacts.ScanPaths = []string{tmpDir}
 	cfg.DevArtifacts.PythonVenvs = false
 	cfg.DevArtifacts.RustTargets = false
+	cfg.DevArtifacts.ZigArtifacts = false
 	cfg.DevArtifacts.GoBuildCache = false
 	cfg.DevArtifacts.HaskellCache = false
 
@@ -336,6 +399,7 @@ func TestPlanCleanupModerateClassifiesDevArtifacts(t *testing.T) {
 	cfg.DevArtifacts.ScanPaths = []string{tmpDir}
 	cfg.DevArtifacts.PythonVenvs = false
 	cfg.DevArtifacts.RustTargets = false
+	cfg.DevArtifacts.ZigArtifacts = false
 	cfg.DevArtifacts.GoBuildCache = false
 	cfg.DevArtifacts.HaskellCache = false
 	cfg.DevArtifacts.ProtectPaths = []string{protectedProject}
@@ -391,11 +455,95 @@ func TestPlanNodeModulesProtectsActiveDevelopmentProcess(t *testing.T) {
 	}
 }
 
+func TestPlanZigArtifactsProtectsActiveDevelopmentProcess(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	project := filepath.Join(tmpDir, "active-zig")
+	if err := os.MkdirAll(filepath.Join(project, ".zig-cache", "o"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".zig-cache", "o", "artifact"), []byte("cache"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	buildZig := filepath.Join(project, "build.zig")
+	if err := os.WriteFile(buildZig, []byte("const std = @import(\"std\");"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	if err := os.Chtimes(buildZig, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	p.planZigArtifacts(tmpDir, 30*24*time.Hour, true, nil, map[string]string{
+		"zig-artifact": "Zig toolchain process",
+	}, &targets)
+
+	target := findDevArtifactTarget(t, targets, "zig-artifact", filepath.Join(project, ".zig-cache"))
+	if target.Action != "protect" || !target.Protected || !target.Active {
+		t.Fatalf("expected active Zig artifact to be protected, got %#v", target)
+	}
+}
+
+func TestPlanLargeLocalArtifactsReportsReviewOnlyTargets(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+
+	imagePath := filepath.Join(tmpDir, "betterkvm", "images", "pikvm.img")
+	if err := os.MkdirAll(filepath.Dir(imagePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(imagePath, []byte("disk image"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	bundlePath := filepath.Join(tmpDir, "linux-xr-case-sensitive.sparsebundle")
+	if err := os.MkdirAll(filepath.Join(bundlePath, "bands"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundlePath, "bands", "0"), []byte("bundle data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	p.planLargeLocalArtifacts(tmpDir, 1, nil, &targets)
+
+	image := findDevArtifactTarget(t, targets, "large-local-artifact", imagePath)
+	if image.Action != "review" || !image.Protected || image.Tier != CleanupTierDestructive || image.Reclaim != CleanupReclaimNone {
+		t.Fatalf("expected review-only destructive/no-reclaim image target, got %#v", image)
+	}
+	bundle := findDevArtifactTarget(t, targets, "large-local-artifact", bundlePath)
+	if bundle.Action != "review" || !bundle.Protected || bundle.Bytes <= 0 {
+		t.Fatalf("expected review-only sparsebundle target with bytes, got %#v", bundle)
+	}
+}
+
+func TestPlanLargeLocalArtifactsHonorsProtectPaths(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	imagePath := filepath.Join(tmpDir, "protected", "machine.qcow2")
+	if err := os.MkdirAll(filepath.Dir(imagePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(imagePath, []byte("disk image"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	p.planLargeLocalArtifacts(tmpDir, 1, []string{filepath.Dir(imagePath)}, &targets)
+
+	target := findDevArtifactTarget(t, targets, "large-local-artifact", imagePath)
+	if target.Action != "protect" || !target.Protected {
+		t.Fatalf("expected protected large local artifact target, got %#v", target)
+	}
+}
+
 func TestDevArtifactBusyProcessReasons(t *testing.T) {
 	ps := `
 /nix/store/node/bin/node node vite dev
 /nix/store/uv/bin/uv uv pip install -r requirements.txt
 /nix/store/rust/bin/cargo cargo build
+/nix/store/zig/bin/zig zig build
 /nix/store/go/bin/go go test ./...
 /nix/store/cabal/bin/cabal cabal build all
 /Applications/LM Studio.app/Contents/MacOS/LM Studio
@@ -406,6 +554,7 @@ func TestDevArtifactBusyProcessReasons(t *testing.T) {
 		"node_modules":    "Node.js package manager or runtime",
 		"python-venv":     "Python toolchain process",
 		"rust-target":     "Rust toolchain process",
+		"zig-artifact":    "Zig toolchain process",
 		"go-build-cache":  "Go toolchain process",
 		"haskell-cache":   "Haskell toolchain process",
 		"lmstudio-models": "LM Studio process",


### PR DESCRIPTION
## Summary
- add Zig `.zig-cache` and `zig-out` to dev-artifacts planning and cleanup, guarded by active `zig`/`zls` process detection
- add review-only large local artifact targets for disk images and VM bundles such as `.img`, `.qcow2`, `.sparsebundle`, `.utm`, and `.vmwarevm`
- update default/package configs, operator docs, changelog, and tests

## Local Evidence
- dev-artifacts dry-run reported the mounted linux-xr sparsebundle and PiKVM image as protected review-only targets with `reclaim=none`
- same dry-run identified rebuildable Zig cache targets separately from large local content

## Validation
- `go test ./plugins ./config`
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Refs #2