### PR TITLE
Label active Nix GC work explicitly

### DIFF
--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -13,7 +13,8 @@ tinyland-cleanup --once --dry-run --level critical --output json
 The Nix plan includes:
 
 - `estimated_bytes_freed` from `nix-collect-garbage --dry-run`;
-- detected active Nix work such as `nix build`, `home-manager switch`,
+- detected active Nix work such as `nix build`, `nix store gc`,
+  `nix-collect-garbage`, `nix-store --gc`, `home-manager switch`,
   `darwin-rebuild`, `nixos-rebuild`, and worker-style `nix-daemon` activity;
 - protected `nix_active_work`, `nix_process_inspection`, or
   `nix_store_contention` targets when cleanup is deferred before mutation;

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -828,6 +828,10 @@ func nixBusyProcessReasons(output string) []string {
 		}
 	}
 
+	nixCommandPattern := regexp.MustCompile(`\bnix\s+(build|develop|shell|flake|profile|store|copy|run|log)\b`)
+	nixStoreGCPattern := regexp.MustCompile(`\bnix-store\s+.*\s--gc\b|\bnix-store\s+--gc\b`)
+	nixStoreGCShortPattern := regexp.MustCompile(`\bnix\s+store\s+gc\b`)
+
 	for _, line := range strings.Split(output, "\n") {
 		normalized := strings.ToLower(strings.Join(strings.Fields(line), " "))
 		if normalized == "" {
@@ -843,10 +847,14 @@ func nixBusyProcessReasons(output string) []string {
 			add("nixos-rebuild")
 		case strings.Contains(normalized, "nix-collect-garbage"):
 			add("nix-collect-garbage")
+		case nixStoreGCShortPattern.MatchString(normalized):
+			add("nix store gc")
+		case nixStoreGCPattern.MatchString(normalized):
+			add("nix-store --gc")
 		case strings.Contains(normalized, "nix-store") && strings.ContainsAny(normalized, "-"):
 			add("nix-store")
-		case regexp.MustCompile(`\bnix\s+(build|develop|shell|flake|profile|store|copy|run|log)\b`).MatchString(normalized):
-			add("nix " + regexp.MustCompile(`\bnix\s+(build|develop|shell|flake|profile|store|copy|run|log)\b`).FindStringSubmatch(normalized)[1])
+		case nixCommandPattern.MatchString(normalized):
+			add("nix " + nixCommandPattern.FindStringSubmatch(normalized)[1])
 		case strings.Contains(normalized, "nix-daemon") &&
 			(strings.Contains(normalized, "--stdio") ||
 				strings.Contains(normalized, "--serve") ||

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -73,13 +73,16 @@ func TestParseNixPolicyDuration(t *testing.T) {
 func TestNixBusyProcessReasons(t *testing.T) {
 	ps := `
 /nix/var/nix/profiles/default/bin/nix nix build .#package
+/nix/var/nix/profiles/default/bin/nix nix store gc --dry-run
 /run/current-system/sw/bin/home-manager home-manager switch --flake .#jess
 /nix/store/abc/bin/nix-daemon nix-daemon --daemon
 /nix/store/def/bin/nix-daemon nix-daemon --stdio
+/nix/store/ghi/bin/nix-store nix-store --gc --print-roots
+/nix/store/jkl/bin/nix-collect-garbage nix-collect-garbage --dry-run
 /usr/bin/zsh zsh -lc echo idle
 `
 	reasons := nixBusyProcessReasons(ps)
-	want := []string{"home-manager switch", "nix build", "nix-daemon worker"}
+	want := []string{"home-manager switch", "nix build", "nix store gc", "nix-collect-garbage", "nix-daemon worker", "nix-store --gc"}
 
 	if len(reasons) != len(want) {
 		t.Fatalf("got reasons %v, want %v", reasons, want)


### PR DESCRIPTION
## Summary
- classify active `nix store gc`, `nix-collect-garbage`, and `nix-store --gc` work explicitly during Nix preflight
- keep existing daemon-busy deferral behavior, but make operator-facing reasons less vague than generic `nix store` / `nix-store`
- document the GC-specific active-work signals in the Nix cleanup policy

## Why
Today's lab cleanup found a Nix dry-run waiting on the global GC lock while another GC job was already active. This patch helps the daemon explain that case before it starts another dry-run.

## Validation
- `go test ./plugins -run TestNix`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

Refs #4