### PR TITLE
Add Darwin volume probe mode

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "main.go",
         "report_text.go",
         "state.go",
+        "volume_probe.go",
     ] + select({
         "@platforms//os:macos": ["plugins_darwin.go"],
         "//conditions:default": ["plugins_other.go"],
@@ -47,6 +48,7 @@ go_test(
     srcs = [
         "main_test.go",
         "state_test.go",
+        "volume_probe_test.go",
     ],
     embed = [":tinyland-cleanup_lib"],
     deps = [

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ editing the config file:
 tinyland-cleanup --once --dry-run --level critical --target-used-percent 82
 ```
 
+For Darwin removable-volume or TCC diagnosis, use direct probe mode. It only
+lists the target path, reads xattrs, writes one temporary dotfile, and removes
+that file; it does not run cleanup plugins:
+
+```sh
+tinyland-cleanup \
+  --probe-volume-path /Volumes/TinylandSSD/tinyland \
+  --probe-result-path /tmp/tinyland-cleanup-probe.result
+```
+
 See [docs/operator-workflow.md](docs/operator-workflow.md) for the current
 dry-run, candidate policy tier, and host free-space accounting workflow.
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -84,6 +84,27 @@ Structured plugin targets may include policy metadata:
 Use this metadata to separate cheap cache cleanup from expensive rebuilds,
 privileged actions, and review-only evidence before applying a real cleanup.
 
+## Probe Darwin Volumes
+
+When a Darwin machine has a mounted external volume but a daemon or LaunchAgent
+cannot prove access, run direct probe mode before changing cleanup policy. This
+mode does not load config and does not run cleanup plugins. It lists the target
+path, reads xattrs, writes one temporary dotfile, removes that file, and writes
+key-value result codes for wrapper scripts.
+
+```sh
+tinyland-cleanup \
+  --probe-volume-path /Volumes/TinylandSSD/tinyland \
+  --probe-result-path /tmp/tinyland-cleanup-probe.result \
+  --probe-name tinyland-cleanup \
+  --probe-timeout-seconds 10
+```
+
+Result files use `ls_rc`, `xattr_rc`, `touch_rc`, and `rm_rc`. Exit code `0`
+for each operation means that the same binary path can perform that operation
+from the current execution context. Exit code `124` means the bounded child
+operation timed out.
+
 ## Apply
 
 After reviewing the plan, run the same level without `--dry-run`:

--- a/main.go
+++ b/main.go
@@ -22,6 +22,10 @@
 //	                 Override target maximum used-space percentage after cleanup
 //	-verbose          Enable verbose logging
 //	-version          Print version and exit
+//	-probe-volume-path string    Darwin-only: probe direct volume access and exit
+//	-probe-result-path string    Path to write the key=value probe result summary
+//	-probe-name string           Probe label used for the temporary write-test file
+//	-probe-timeout-seconds int   Timeout per direct probe operation
 package main
 
 import (
@@ -54,23 +58,45 @@ var (
 func main() {
 	// Parse command line flags
 	var (
-		configPath  = flag.String("config", "", "Path to configuration file")
-		runDaemon   = flag.Bool("daemon", false, "Run as a daemon")
-		once        = flag.Bool("once", false, "Run cleanup once and exit")
-		level       = flag.String("level", "", "Force cleanup level")
-		dryRun      = flag.Bool("dry-run", false, "Show what would be cleaned")
-		output      = flag.String("output", "text", "Output format: text, json")
-		listPlugins = flag.Bool("list-plugins", false, "List registered plugin names and exit")
-		pluginNames = flag.String("plugins", "", "Comma-separated plugin names to run or plan")
-		targetUsed  = flag.Int("target-used-percent", 0, "Override target maximum used-space percentage after cleanup")
-		verbose     = flag.Bool("verbose", false, "Enable verbose logging")
-		showVersion = flag.Bool("version", false, "Print version and exit")
+		configPath          = flag.String("config", "", "Path to configuration file")
+		runDaemon           = flag.Bool("daemon", false, "Run as a daemon")
+		once                = flag.Bool("once", false, "Run cleanup once and exit")
+		level               = flag.String("level", "", "Force cleanup level")
+		dryRun              = flag.Bool("dry-run", false, "Show what would be cleaned")
+		output              = flag.String("output", "text", "Output format: text, json")
+		listPlugins         = flag.Bool("list-plugins", false, "List registered plugin names and exit")
+		pluginNames         = flag.String("plugins", "", "Comma-separated plugin names to run or plan")
+		targetUsed          = flag.Int("target-used-percent", 0, "Override target maximum used-space percentage after cleanup")
+		verbose             = flag.Bool("verbose", false, "Enable verbose logging")
+		showVersion         = flag.Bool("version", false, "Print version and exit")
+		probeVolumePath     = flag.String("probe-volume-path", "", "Darwin-only: probe direct volume access and exit")
+		probeResultPath     = flag.String("probe-result-path", "", "Path to write the key=value probe result summary")
+		probeName           = flag.String("probe-name", "tinyland-cleanup-probe", "Probe label used for the temporary write-test file")
+		probeTimeoutSeconds = flag.Int("probe-timeout-seconds", 5, "Timeout per direct probe operation")
+
+		// Internal child-operation flags used by the direct volume probe mode.
+		probeVolumeOp  = flag.String("probe-volume-op", "", "internal volume probe operation")
+		probePath      = flag.String("probe-path", "", "internal volume probe path")
+		probeFile      = flag.String("probe-file", "", "internal volume probe file path")
+		probeErrorPath = flag.String("probe-error-path", "", "internal volume probe error path")
 	)
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Printf("tinyland-cleanup %s (%s) built %s\n", version, commit, date)
 		os.Exit(0)
+	}
+
+	if *probeVolumeOp != "" {
+		os.Exit(runVolumeProbeChildOperation(*probeVolumeOp, *probePath, *probeFile, *probeErrorPath))
+	}
+
+	if *probeVolumePath != "" {
+		if err := runVolumeAccessProbe(*probeVolumePath, *probeResultPath, *probeName, *probeTimeoutSeconds); err != nil {
+			fmt.Fprintf(os.Stderr, "volume probe failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	if *output != "text" && *output != "json" {

--- a/volume_probe.go
+++ b/volume_probe.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+const volumeProbeSkippedRemove = 99
+
+type volumeProbeSummary struct {
+	UID      int
+	User     string
+	PWD      string
+	ListRC   int
+	XattrRC  int
+	TouchRC  int
+	RemoveRC int
+}
+
+func runVolumeAccessProbe(volumePath, resultPath, probeName string, timeoutSeconds int) error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("volume probe mode only supports macOS")
+	}
+	if volumePath == "" {
+		return fmt.Errorf("volume probe path is required")
+	}
+	if resultPath == "" {
+		return fmt.Errorf("volume probe result path is required")
+	}
+	if probeName == "" {
+		return fmt.Errorf("volume probe name is required")
+	}
+	if timeoutSeconds <= 0 {
+		return fmt.Errorf("volume probe timeout must be positive")
+	}
+
+	probeFile := filepath.Join(volumePath, "."+probeName+"-write-test")
+	listErr := resultPath + ".ls.err"
+	xattrErr := resultPath + ".xattr.err"
+	touchErr := resultPath + ".touch.err"
+	removeErr := resultPath + ".rm.err"
+
+	_ = os.Remove(listErr)
+	_ = os.Remove(xattrErr)
+	_ = os.Remove(touchErr)
+	_ = os.Remove(removeErr)
+
+	listRC := runVolumeProbeOperationWithTimeout("list", volumePath, probeFile, listErr, timeoutSeconds)
+	xattrRC := runVolumeProbeOperationWithTimeout("xattr", volumePath, probeFile, xattrErr, timeoutSeconds)
+	touchRC := runVolumeProbeOperationWithTimeout("touch", volumePath, probeFile, touchErr, timeoutSeconds)
+	removeRC := volumeProbeSkippedRemove
+	if touchRC == 0 {
+		removeRC = runVolumeProbeOperationWithTimeout("rm", volumePath, probeFile, removeErr, timeoutSeconds)
+	}
+
+	currentUser := "unknown"
+	if userInfo, err := user.Current(); err == nil && userInfo.Username != "" {
+		currentUser = userInfo.Username
+	} else if envUser := os.Getenv("USER"); envUser != "" {
+		currentUser = envUser
+	}
+
+	currentWD := "unknown"
+	if wd, err := os.Getwd(); err == nil {
+		currentWD = wd
+	}
+
+	return writeVolumeProbeSummary(resultPath, volumeProbeSummary{
+		UID:      os.Getuid(),
+		User:     currentUser,
+		PWD:      currentWD,
+		ListRC:   listRC,
+		XattrRC:  xattrRC,
+		TouchRC:  touchRC,
+		RemoveRC: removeRC,
+	})
+}
+
+func runVolumeProbeOperationWithTimeout(op, volumePath, probeFile, errPath string, timeoutSeconds int) int {
+	executablePath, err := os.Executable()
+	if err != nil {
+		writeVolumeProbeError(errPath, "os.Executable failed: %v", err)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(
+		ctx,
+		executablePath,
+		"-probe-volume-op", op,
+		"-probe-path", volumePath,
+		"-probe-file", probeFile,
+		"-probe-error-path", errPath,
+	)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	err = cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		writeVolumeProbeError(errPath, "timed out after %d seconds", timeoutSeconds)
+		return 124
+	}
+	if err == nil {
+		return 0
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+
+	writeVolumeProbeError(errPath, "exec failed: %v", err)
+	return 1
+}
+
+func runVolumeProbeChildOperation(op, volumePath, probeFile, errPath string) int {
+	switch op {
+	case "list":
+		handle, err := os.Open(volumePath)
+		if err != nil {
+			writeVolumeProbeError(errPath, "%v", err)
+			return 1
+		}
+		if err := handle.Close(); err != nil {
+			writeVolumeProbeError(errPath, "%v", err)
+			return 1
+		}
+		return 0
+	case "xattr":
+		output, err := exec.Command("/usr/bin/xattr", "-l", volumePath).CombinedOutput()
+		if err != nil {
+			if len(output) > 0 {
+				writeVolumeProbeError(errPath, "%s", output)
+			} else {
+				writeVolumeProbeError(errPath, "%v", err)
+			}
+			return 1
+		}
+		return 0
+	case "touch":
+		handle, err := os.OpenFile(probeFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		if err != nil {
+			writeVolumeProbeError(errPath, "%v", err)
+			return 1
+		}
+		if err := handle.Close(); err != nil {
+			writeVolumeProbeError(errPath, "%v", err)
+			return 1
+		}
+		return 0
+	case "rm":
+		if err := os.Remove(probeFile); err != nil {
+			writeVolumeProbeError(errPath, "%v", err)
+			return 1
+		}
+		return 0
+	default:
+		writeVolumeProbeError(errPath, "unknown probe operation: %s", op)
+		return 2
+	}
+}
+
+func writeVolumeProbeSummary(resultPath string, summary volumeProbeSummary) error {
+	content := "" +
+		"uid=" + strconv.Itoa(summary.UID) + "\n" +
+		"user=" + summary.User + "\n" +
+		"pwd=" + summary.PWD + "\n" +
+		"ls_rc=" + strconv.Itoa(summary.ListRC) + "\n" +
+		"xattr_rc=" + strconv.Itoa(summary.XattrRC) + "\n" +
+		"touch_rc=" + strconv.Itoa(summary.TouchRC) + "\n" +
+		"rm_rc=" + strconv.Itoa(summary.RemoveRC) + "\n"
+
+	return os.WriteFile(resultPath, []byte(content), 0o644)
+}
+
+func writeVolumeProbeError(errPath, format string, args ...any) {
+	if errPath == "" {
+		return
+	}
+	message := fmt.Sprintf(format, args...)
+	_ = os.WriteFile(errPath, []byte(message+"\n"), 0o644)
+}

--- a/volume_probe_test.go
+++ b/volume_probe_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteVolumeProbeSummary(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "probe.result")
+
+	err := writeVolumeProbeSummary(resultPath, volumeProbeSummary{
+		UID:      501,
+		User:     "operator",
+		PWD:      "/tmp/example",
+		ListRC:   0,
+		XattrRC:  0,
+		TouchRC:  0,
+		RemoveRC: volumeProbeSkippedRemove,
+	})
+	if err != nil {
+		t.Fatalf("writeVolumeProbeSummary failed: %v", err)
+	}
+
+	contentBytes, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("reading probe result failed: %v", err)
+	}
+	content := string(contentBytes)
+	for _, want := range []string{
+		"uid=501\n",
+		"user=operator\n",
+		"pwd=/tmp/example\n",
+		"ls_rc=0\n",
+		"xattr_rc=0\n",
+		"touch_rc=0\n",
+		"rm_rc=99\n",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("probe summary missing %q:\n%s", want, content)
+		}
+	}
+}
+
+func TestRunVolumeProbeChildOperationFileOps(t *testing.T) {
+	dir := t.TempDir()
+	probeFile := filepath.Join(dir, ".probe-write-test")
+	errPath := filepath.Join(dir, "probe.err")
+
+	if rc := runVolumeProbeChildOperation("list", dir, probeFile, errPath); rc != 0 {
+		t.Fatalf("list rc=%d, want 0", rc)
+	}
+	if rc := runVolumeProbeChildOperation("touch", dir, probeFile, errPath); rc != 0 {
+		t.Fatalf("touch rc=%d, want 0", rc)
+	}
+	if _, err := os.Stat(probeFile); err != nil {
+		t.Fatalf("expected probe file after touch: %v", err)
+	}
+	if rc := runVolumeProbeChildOperation("rm", dir, probeFile, errPath); rc != 0 {
+		t.Fatalf("rm rc=%d, want 0", rc)
+	}
+	if _, err := os.Stat(probeFile); !os.IsNotExist(err) {
+		t.Fatalf("probe file still exists after rm, err=%v", err)
+	}
+}
+
+func TestRunVolumeProbeChildOperationUnknown(t *testing.T) {
+	dir := t.TempDir()
+	errPath := filepath.Join(dir, "probe.err")
+
+	if rc := runVolumeProbeChildOperation("bogus", dir, filepath.Join(dir, "probe"), errPath); rc != 2 {
+		t.Fatalf("unknown op rc=%d, want 2", rc)
+	}
+	content, err := os.ReadFile(errPath)
+	if err != nil {
+		t.Fatalf("expected error file: %v", err)
+	}
+	if !strings.Contains(string(content), "unknown probe operation: bogus") {
+		t.Fatalf("unexpected error content: %s", content)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a direct Darwin volume probe mode to `tinyland-cleanup` so lab and host wrappers can verify removable-volume access through the same binary path that launchd runs.

The probe mode:

- exits before config loading and cleanup plugin execution
- lists the target path, reads xattrs, writes one temporary dotfile, and removes it
- writes key-value result codes for wrapper scripts (`ls_rc`, `xattr_rc`, `touch_rc`, `rm_rc`)
- keeps the existing dry-run, output, plugin filter, and target-used CLI behavior intact

Lab context: `TIN-99` pzm SSD validation needs this because the deployed upstream package lacked the local lab fallback's `-probe-volume-path` support.

Linear: TIN-99
Greptile: not-applicable

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build -o /tmp/tinyland-cleanup-probe-test .`
- local probe smoke with `/tmp/tinyland-cleanup-probe-test -probe-volume-path <tmpdir> -probe-result-path <result>` returned `ls_rc=0`, `xattr_rc=0`, `touch_rc=0`, `rm_rc=0`
- `/tmp/tinyland-cleanup-probe-test --list-plugins`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
- `nix build .#default --no-link --print-build-logs`
- Nix-built store binary probe smoke returned `ls_rc=0`, `xattr_rc=0`, `touch_rc=0`, `rm_rc=0`
- GitHub CI: Go and Bazel passed

Note: the Nix build succeeded after the new source file was staged so the flake git source snapshot included it. The build emitted an expected FlakeHub cache 401 warning, then completed via the available caches/remote builder.