### PR TITLE
Discover explicit Bazel output bases

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -499,6 +499,7 @@ func defaultBazelRoots(home string) []string {
 				filepath.Join("/var", "tmp", "_bazel_"+user),
 			)
 		}
+		roots = append(roots, "/private/tmp")
 	}
 	return roots
 }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -124,6 +124,8 @@ nix:
 bazel:
   roots:
     - ~/.cache/bazel
+    # Darwin defaults also include /private/var/tmp/_bazel_$USER,
+    # /var/tmp/_bazel_$USER, and /private/tmp from compiled defaults.
   workspace_roots:
     - ~/git
     - ~/src

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -14,7 +14,9 @@ tinyland-cleanup --once --dry-run --level critical --output json
 The Bazel plan includes targets for:
 
 - `output_base`: Bazel output bases under configured roots such as
-  `~/.cache/bazel/_bazel_$USER/*` or Darwin `/private/var/tmp/_bazel_$USER/*`;
+  `~/.cache/bazel/_bazel_$USER/*`, Darwin
+  `/private/var/tmp/_bazel_$USER/*`, or direct explicit output bases under
+  `/private/tmp`;
 - `repository_cache`: shared external repository artifacts;
 - `disk_cache`: local action cache entries;
 - `bazelisk`: Bazelisk download cache entries.
@@ -25,6 +27,7 @@ protected status, the planned action, and a reason. Output bases are protected
 when:
 
 - a Bazel or Bazelisk process is active;
+- an active Bazel process exposes an explicit `--output_base`;
 - an output-base lock or server PID file is visible;
 - a configured protected workspace has `bazel-*` symlinks into that output base;
 - the output base is within `keep_recent_output_bases`;
@@ -36,6 +39,10 @@ Default policy:
 bazel:
   roots:
     - ~/.cache/bazel
+    # Darwin compiled defaults also include:
+    # - /private/var/tmp/_bazel_$USER
+    # - /var/tmp/_bazel_$USER
+    # - /private/tmp
   workspace_roots:
     - ~/git
     - ~/src
@@ -63,6 +70,8 @@ Runtime boundary:
   total Bazel footprint exceeds `max_total_gb`;
 - real cleanup skips Bazel mutation if active Bazel process inspection fails;
 - cache-tier cleanup is skipped while active Bazel or Bazelisk work is visible;
+- process-visible explicit `--output_base` directories are included in the plan
+  even when they are outside configured output-user roots;
 - deletion normalizes writable permissions first, and on Darwin attempts to
   clear `uchg` file flags with `chflags -R nouchg`;
 - after an output base is deleted, workspace roots are scanned shallowly for

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -20,7 +20,7 @@ import (
 
 const bazelGiB = int64(1024 * 1024 * 1024)
 
-var bazelCommandPattern = regexp.MustCompile(`\b(bazel|bazelisk)\s+(build|test|run|coverage|query|sync|fetch|clean|mobile-install|aquery|cquery)\b`)
+var bazelCommandPattern = regexp.MustCompile(`\b(bazel|bazelisk)\s+(build|test|run|coverage|query|sync|fetch|clean|mobile-install|aquery|cquery|mod)\b`)
 
 // BazelPlugin reports Bazel output bases and cache tiers.
 type BazelPlugin struct{}
@@ -36,6 +36,11 @@ type bazelCandidate struct {
 	Protected bool
 	Action    string
 	Reason    string
+}
+
+type bazelProcessInfo struct {
+	Reasons     []string
+	OutputBases []string
 }
 
 // NewBazelPlugin creates a new Bazel cleanup plugin.
@@ -95,15 +100,21 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 	}
 
 	home, _ := os.UserHomeDir()
-	activeReasons, activeErr := p.activeBazelProcesses(ctx)
+	activeInfo, activeErr := p.activeBazelProcessInfo(ctx)
 	if activeErr != nil {
 		plan.Warnings = append(plan.Warnings, fmt.Sprintf("could not inspect active Bazel processes: %v", activeErr))
-	} else if len(activeReasons) > 0 {
-		plan.Metadata["active_bazel_processes"] = strings.Join(activeReasons, ", ")
+	} else {
+		if len(activeInfo.Reasons) > 0 {
+			plan.Metadata["active_bazel_processes"] = strings.Join(activeInfo.Reasons, ", ")
+		}
+		if len(activeInfo.OutputBases) > 0 {
+			plan.Metadata["process_output_base_count"] = strconv.Itoa(len(activeInfo.OutputBases))
+		}
 	}
 
-	candidates := p.discoverCandidates(home, cfg.Bazel)
-	targets, totalPhysical := bazelPlanTargets(candidates, cfg.Bazel, level, time.Now(), len(activeReasons) > 0)
+	globalActive := len(activeInfo.Reasons) > 0 || len(activeInfo.OutputBases) > 0
+	candidates := p.discoverCandidates(home, cfg.Bazel, activeInfo.OutputBases)
+	targets, totalPhysical := bazelPlanTargets(candidates, cfg.Bazel, level, time.Now(), globalActive)
 	plan.Targets = targets
 	plan.EstimatedBytesFreed = bazelEstimatedCandidateBytes(targets)
 	plan.Metadata["target_count"] = strconv.Itoa(len(targets))
@@ -142,18 +153,23 @@ func (p *BazelPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *conf
 }
 
 func (p *BazelPlugin) activeBazelProcesses(ctx context.Context) ([]string, error) {
+	info, err := p.activeBazelProcessInfo(ctx)
+	return info.Reasons, err
+}
+
+func (p *BazelPlugin) activeBazelProcessInfo(ctx context.Context) (bazelProcessInfo, error) {
 	psCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(psCtx, "ps", "-axo", "comm=,args=")
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return bazelProcessInfo{}, err
 	}
-	return bazelBusyProcessReasons(string(output)), nil
+	return bazelBusyProcessInfo(string(output)), nil
 }
 
-func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig) []bazelCandidate {
+func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig, processOutputBases []string) []bazelCandidate {
 	var candidates []bazelCandidate
 	seen := map[string]bool{}
 
@@ -168,6 +184,12 @@ func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig) []
 	for _, root := range cfg.Roots {
 		expanded := expandHome(root, home)
 		for _, candidate := range discoverBazelRootCandidates(expanded) {
+			add(candidate)
+		}
+	}
+
+	for _, outputBase := range processOutputBases {
+		for _, candidate := range discoverBazelProcessOutputBase(outputBase) {
 			add(candidate)
 		}
 	}
@@ -190,6 +212,18 @@ func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig) []
 	}
 
 	return candidates
+}
+
+func discoverBazelProcessOutputBase(path string) []bazelCandidate {
+	path = filepath.Clean(path)
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() || !isBazelOutputBase(path) {
+		return nil
+	}
+	candidate := newBazelCandidate("output_base", filepath.Base(path), path, info.ModTime())
+	candidate.Active = true
+	candidate.Reason = "discovered from active Bazel process --output_base"
+	return []bazelCandidate{candidate}
 }
 
 func discoverBazelRootCandidates(root string) []bazelCandidate {
@@ -219,6 +253,10 @@ func discoverBazelRootCandidates(root string) []bazelCandidate {
 		}
 		path := filepath.Join(root, entry.Name())
 		switch {
+		case isBazelOutputBase(path):
+			if info, err := entry.Info(); err == nil {
+				candidates = append(candidates, newBazelCandidate("output_base", entry.Name(), path, info.ModTime()))
+			}
 		case strings.HasPrefix(entry.Name(), "_bazel_"):
 			candidates = append(candidates, discoverBazelOutputBases(path)...)
 		case entry.Name() == "repository_cache":
@@ -763,29 +801,83 @@ func normalizeBazelDeletionPermissions(root string, logger *slog.Logger) error {
 }
 
 func bazelBusyProcessReasons(output string) []string {
-	seen := map[string]bool{}
-	var reasons []string
+	return bazelBusyProcessInfo(output).Reasons
+}
+
+func bazelBusyProcessInfo(output string) bazelProcessInfo {
+	reasonSeen := map[string]bool{}
+	outputBaseSeen := map[string]bool{}
+	var info bazelProcessInfo
 	for _, line := range strings.Split(output, "\n") {
-		fields := strings.Fields(strings.ToLower(line))
-		if len(fields) < 2 {
+		originalFields := strings.Fields(line)
+		lowerFields := strings.Fields(strings.ToLower(line))
+		if len(lowerFields) < 2 {
 			continue
 		}
-		command := filepath.Base(fields[0])
-		arg0 := filepath.Base(fields[1])
-		if command != "bazel" && command != "bazelisk" && arg0 != "bazel" && arg0 != "bazelisk" {
+
+		if bazelProcessLineHasBazel(originalFields) {
+			for _, outputBase := range bazelOutputBaseArgs(originalFields) {
+				if !outputBaseSeen[outputBase] {
+					outputBaseSeen[outputBase] = true
+					info.OutputBases = append(info.OutputBases, outputBase)
+				}
+			}
+		}
+
+		command := filepath.Base(lowerFields[0])
+		arg0 := filepath.Base(lowerFields[1])
+		if !bazelCommandName(command) && !bazelCommandName(arg0) {
 			continue
 		}
-		normalized := strings.Join(fields[1:], " ")
+		normalized := strings.Join(lowerFields[1:], " ")
 		matches := bazelCommandPattern.FindStringSubmatch(normalized)
 		if len(matches) < 3 {
 			continue
 		}
 		reason := matches[1] + " " + matches[2]
-		if !seen[reason] {
-			seen[reason] = true
-			reasons = append(reasons, reason)
+		if !reasonSeen[reason] {
+			reasonSeen[reason] = true
+			info.Reasons = append(info.Reasons, reason)
 		}
 	}
-	sort.Strings(reasons)
-	return reasons
+	sort.Strings(info.Reasons)
+	sort.Strings(info.OutputBases)
+	return info
+}
+
+func bazelProcessLineHasBazel(fields []string) bool {
+	if len(fields) == 0 {
+		return false
+	}
+	for idx, field := range fields {
+		if idx > 1 {
+			break
+		}
+		if bazelCommandName(filepath.Base(strings.ToLower(field))) {
+			return true
+		}
+	}
+	return false
+}
+
+func bazelCommandName(command string) bool {
+	return command == "bazel" || command == "bazelisk" || strings.HasPrefix(command, "bazel(")
+}
+
+func bazelOutputBaseArgs(fields []string) []string {
+	var outputBases []string
+	for idx, field := range fields {
+		switch {
+		case strings.HasPrefix(field, "--output_base="):
+			outputBase := strings.TrimPrefix(field, "--output_base=")
+			if outputBase != "" {
+				outputBases = append(outputBases, outputBase)
+			}
+		case field == "--output_base" && idx+1 < len(fields):
+			if fields[idx+1] != "" {
+				outputBases = append(outputBases, fields[idx+1])
+			}
+		}
+	}
+	return outputBases
 }

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -16,19 +16,52 @@ func TestDiscoverBazelRootCandidates(t *testing.T) {
 	root := t.TempDir()
 	outputBase := filepath.Join(root, "_bazel_jess", "abc123")
 	makeBazelOutputBase(t, outputBase)
+	explicitOutputBase := filepath.Join(root, "tinyvectors-external-smoke-ob")
+	makeBazelOutputBase(t, explicitOutputBase)
 	mustMkdir(t, filepath.Join(root, "repository_cache"))
 	mustMkdir(t, filepath.Join(root, "disk_cache"))
 
 	candidates := discoverBazelRootCandidates(root)
 	byType := map[string]bool{}
+	byPath := map[string]bool{}
 	for _, candidate := range candidates {
 		byType[candidate.Type] = true
+		byPath[candidate.Path] = true
+	}
+	resolvedExplicitOutputBase, err := filepath.EvalSymlinks(explicitOutputBase)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	for _, candidateType := range []string{"output_base", "repository_cache", "disk_cache"} {
 		if !byType[candidateType] {
 			t.Fatalf("expected %s candidate, got %#v", candidateType, candidates)
 		}
+	}
+	if !byPath[resolvedExplicitOutputBase] {
+		t.Fatalf("expected direct explicit output base %s, got %#v", explicitOutputBase, candidates)
+	}
+}
+
+func TestDiscoverBazelCandidatesIncludesProcessOutputBases(t *testing.T) {
+	root := t.TempDir()
+	outputBase := filepath.Join(root, "process-ob")
+	makeBazelOutputBase(t, outputBase)
+
+	candidates := NewBazelPlugin().discoverCandidates(root, config.BazelConfig{}, []string{outputBase})
+	if len(candidates) != 1 {
+		t.Fatalf("got %d candidates, want 1: %#v", len(candidates), candidates)
+	}
+	resolvedOutputBase, err := filepath.EvalSymlinks(outputBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := candidates[0]
+	if candidate.Type != "output_base" || candidate.Path != resolvedOutputBase || !candidate.Active {
+		t.Fatalf("unexpected process output-base candidate: %#v", candidate)
+	}
+	if candidate.Reason != "discovered from active Bazel process --output_base" {
+		t.Fatalf("unexpected reason: %q", candidate.Reason)
 	}
 }
 
@@ -249,10 +282,11 @@ func TestBazelBusyProcessReasons(t *testing.T) {
 	ps := `
 /nix/store/abc/bin/bazel bazel build //...
 /Users/test/bin/bazelisk bazelisk test //...
+/usr/bin/bazel bazel mod graph --registry=file:///tmp/registry
 /usr/bin/zsh zsh -lc echo bazel query docs
 `
 	reasons := bazelBusyProcessReasons(ps)
-	want := []string{"bazel build", "bazelisk test"}
+	want := []string{"bazel build", "bazel mod", "bazelisk test"}
 
 	if len(reasons) != len(want) {
 		t.Fatalf("got %v, want %v", reasons, want)
@@ -260,6 +294,24 @@ func TestBazelBusyProcessReasons(t *testing.T) {
 	for i := range want {
 		if reasons[i] != want[i] {
 			t.Fatalf("got %v, want %v", reasons, want)
+		}
+	}
+}
+
+func TestBazelBusyProcessInfoExtractsOutputBases(t *testing.T) {
+	ps := `
+bazel(workspace) bazel(workspace) --output_base=/private/tmp/workspace-ob --workspace_directory=/Users/test/workspace
+/nix/store/abc/bin/bazel bazel test //... --output_base /private/var/tmp/_bazel_test/hash
+/usr/bin/zsh zsh -lc echo --output_base=/not/bazel
+`
+	info := bazelBusyProcessInfo(ps)
+	want := []string{"/private/tmp/workspace-ob", "/private/var/tmp/_bazel_test/hash"}
+	if len(info.OutputBases) != len(want) {
+		t.Fatalf("got output bases %v, want %v", info.OutputBases, want)
+	}
+	for i := range want {
+		if info.OutputBases[i] != want[i] {
+			t.Fatalf("got output bases %v, want %v", info.OutputBases, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- include Darwin /private/tmp in compiled Bazel discovery roots for direct explicit output bases
- discover process-visible Bazel --output_base paths and protect them while active
- treat bazel mod work as active Bazel usage for registry/module smoke flows
- document the explicit-output-base behavior in the Bazel cache policy

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test(DiscoverBazelRootCandidates|DiscoverBazelCandidatesIncludesProcessOutputBases|BazelBusyProcessReasons|BazelBusyProcessInfoExtractsOutputBases|BazelPlanTargetsProtectsCacheTiersWhenBazelActive)'
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...

## Local dry-run evidence
- /tmp/tinyland-cleanup-current -dry-run -output json -plugins bazel -level critical -config /Users/jess/.config/tinyland-cleanup/config.yaml
- dry-run reported process_output_base_count=2
- dry-run surfaced direct /private/tmp output_base targets and kept them protected while Bazel was active
- dry-run did not mutate disk state