### PR TITLE
Scope Bazel idle server activity to output bases

### DIFF
--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -69,9 +69,12 @@ Runtime boundary:
   cache, and Bazelisk download entries as `delete_cache_tier` only when the
   total Bazel footprint exceeds `max_total_gb`;
 - real cleanup skips Bazel mutation if active Bazel process inspection fails;
-- cache-tier cleanup is skipped while active Bazel or Bazelisk work is visible;
+- cache-tier cleanup is skipped while active Bazel or Bazelisk client commands
+  are visible;
 - process-visible explicit `--output_base` directories are included in the plan
-  even when they are outside configured output-user roots;
+  even when they are outside configured output-user roots; idle/server-only
+  output-base visibility protects that output base but does not globally block
+  unrelated cache-tier cleanup;
 - deletion normalizes writable permissions first, and on Darwin attempts to
   clear `uchg` file flags with `chflags -R nouchg`;
 - after an output base is deleted, workspace roots are scanned shallowly for

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -112,7 +112,7 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 		}
 	}
 
-	globalActive := len(activeInfo.Reasons) > 0 || len(activeInfo.OutputBases) > 0
+	globalActive := len(activeInfo.Reasons) > 0
 	candidates := p.discoverCandidates(home, cfg.Bazel, activeInfo.OutputBases)
 	targets, totalPhysical := bazelPlanTargets(candidates, cfg.Bazel, level, time.Now(), globalActive)
 	plan.Targets = targets

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -233,6 +233,47 @@ func TestBazelPlanTargetsProtectsCacheTiersWhenBazelActive(t *testing.T) {
 	}
 }
 
+func TestBazelPlanTargetsDoesNotUseIdleServerAsGlobalCacheActivity(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cfg := config.BazelConfig{
+		MaxTotalGB:                   1,
+		StaleAfter:                   "14d",
+		CriticalStaleAfter:           "3d",
+		AllowDeleteActiveOutputBases: false,
+		KeepRecentOutputBases:        0,
+	}
+	candidates := []bazelCandidate{
+		{
+			Type:     "output_base",
+			Name:     "idle-server-output-base",
+			Path:     "/tmp/idle-server-output-base",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+			Active:   true,
+		},
+		{
+			Type:     "disk_cache",
+			Name:     "disk_cache",
+			Path:     "/tmp/disk_cache",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+		},
+	}
+
+	targets, _ := bazelPlanTargets(candidates, cfg, LevelModerate, now, false)
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Name] = target
+	}
+
+	if actions["idle-server-output-base"].Action != "keep" || !actions["idle-server-output-base"].Protected {
+		t.Fatalf("idle server output base should be protected: %#v", actions["idle-server-output-base"])
+	}
+	if actions["disk_cache"].Action != "delete_cache_tier" || actions["disk_cache"].Protected || actions["disk_cache"].Active {
+		t.Fatalf("idle server output base should not globally protect cache tiers: %#v", actions["disk_cache"])
+	}
+}
+
 func TestDiscoverBazeliskCandidatesPrefersSha256Downloads(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "bazelisk")
 	sha := filepath.Join(root, "downloads", "sha256", "abc123")
@@ -313,6 +354,19 @@ bazel(workspace) bazel(workspace) --output_base=/private/tmp/workspace-ob --work
 		if info.OutputBases[i] != want[i] {
 			t.Fatalf("got output bases %v, want %v", info.OutputBases, want)
 		}
+	}
+}
+
+func TestBazelBusyProcessInfoSeparatesServerOutputBasesFromClientCommands(t *testing.T) {
+	ps := `
+bazel(workspace) bazel(workspace) --output_base=/private/tmp/workspace-ob --workspace_directory=/Users/test/workspace
+`
+	info := bazelBusyProcessInfo(ps)
+	if len(info.Reasons) != 0 {
+		t.Fatalf("server process should not be reported as active client work: %v", info.Reasons)
+	}
+	if len(info.OutputBases) != 1 || info.OutputBases[0] != "/private/tmp/workspace-ob" {
+		t.Fatalf("unexpected output bases: %v", info.OutputBases)
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat idle/server-only Bazel output-base visibility as protection for that output base only
- keep global cache-tier protection tied to visible Bazel/Bazelisk client commands
- document the runtime boundary for cache tiers versus process-visible output bases

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- /tmp/tinyland-cleanup-current -dry-run -output json -plugins bazel -level critical -config /Users/jess/.config/tinyland-cleanup/config.yaml

## Issue
- Continues #3