### PR TITLE
Add lock-free Nix profile generation planning

### DIFF
--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -25,6 +25,9 @@ The Nix plan includes:
 - visible GC roots when dry-run GC reports no reclaimable store space;
 - generation targets with `keep_generation`, `delete_generation`, or
   `review_privileged_generation` actions;
+- lock-free Home Manager generation targets discovered from
+  `~/.local/state/nix/profiles/home-manager-*-link`, reported as protected
+  `review_home_manager_generation` items when they fall outside policy;
 - configured minimum user and system generation retention;
 - whether critical `nix-store --optimize` is allowed.
 
@@ -60,6 +63,12 @@ Runtime behavior:
   enabled;
 - system or nix-darwin generations are reported for operator review but are not
   deleted by the unprivileged plugin path;
+- Home Manager generations are discovered from profile symlinks without taking a
+  `nix-env` profile lock; stale Home Manager generations are review-only until
+  an explicit profile deletion workflow is implemented;
+- user profile generations fall back to the same lock-free profile-link scan
+  when `nix-env --list-generations` is unavailable or cannot inspect the
+  profile;
 - low-reclaim dry-runs run `nix-store --gc --print-roots` and emit protected
   `nix_gc_root` targets so operators can see whether profiles, gcroots,
   workspace `result` links, temporary roots, or active processes are pinning the

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -401,10 +402,6 @@ func (p *NixPlugin) deleteUserGenerationsByPolicy(ctx context.Context, level Cle
 func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLevel, cfg config.NixConfig, logger *slog.Logger) ([]CleanupTarget, []string) {
 	_ = logger
 
-	if _, err := exec.LookPath("nix-env"); err != nil {
-		return nil, []string{"nix-env is not available; generation retention targets could not be inspected"}
-	}
-
 	olderThan := parseNixPolicyDuration(nixGenerationPolicyAge(level, cfg), 0)
 	if olderThan <= 0 {
 		return nil, nil
@@ -413,28 +410,62 @@ func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLeve
 	var targets []CleanupTarget
 	var warnings []string
 
-	userGenerations, err := p.listGenerations(ctx, "user", "", cfg)
-	if err != nil {
-		warnings = append(warnings, fmt.Sprintf("could not inspect user Nix generations: %v", err))
+	_, nixEnvErr := exec.LookPath("nix-env")
+	userGenerationsPlanned := false
+	if nixEnvErr != nil {
+		warnings = append(warnings, "nix-env is not available; falling back to lock-free profile link inspection where possible")
 	} else {
-		targets = append(targets, nixGenerationTargets(userGenerations, time.Now(), cfg.MinUserGenerations, olderThan)...)
+		userGenerations, err := p.listGenerations(ctx, "user", "", cfg)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not inspect user Nix generations with nix-env: %v", err))
+		} else {
+			targets = append(targets, nixGenerationTargets(userGenerations, time.Now(), cfg.MinUserGenerations, olderThan)...)
+			userGenerationsPlanned = true
+		}
 	}
 
-	systemProfile := "/nix/var/nix/profiles/system"
-	systemGenerations, err := p.listGenerations(ctx, "system", systemProfile, cfg)
-	if err != nil {
-		warnings = append(warnings, fmt.Sprintf("could not inspect system Nix generations: %v", err))
+	if home, err := os.UserHomeDir(); err != nil {
+		warnings = append(warnings, fmt.Sprintf("could not locate user home for lock-free Nix profile inspection: %v", err))
 	} else {
-		systemTargets := nixGenerationTargets(systemGenerations, time.Now(), cfg.MinSystemGenerations, olderThan)
-		for i := range systemTargets {
-			if systemTargets[i].Action == "delete_generation" {
-				systemTargets[i].Protected = true
-				systemTargets[i].Action = "review_privileged_generation"
-				systemTargets[i].Reason = "outside retention policy, but system generation deletion requires explicit privileged workflow"
-				annotateCleanupTargetPolicy(&systemTargets[i], CleanupTierPrivileged, CleanupReclaimDeferred)
+		stateProfilesDir := filepath.Join(home, ".local", "state", "nix", "profiles")
+		if !userGenerationsPlanned {
+			userLinkGenerations, err := discoverNixProfileLinkGenerations(stateProfilesDir, "profile", "user")
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("could not inspect user Nix profile links: %v", err))
+			} else if len(userLinkGenerations) > 0 {
+				targets = append(targets, nixGenerationTargets(userLinkGenerations, time.Now(), cfg.MinUserGenerations, olderThan)...)
+				warnings = append(warnings, "using lock-free user Nix profile link inspection after nix-env generation inspection was unavailable")
 			}
 		}
-		targets = append(targets, systemTargets...)
+
+		homeManagerGenerations, err := discoverNixProfileLinkGenerations(stateProfilesDir, "home-manager", "home-manager")
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not inspect Home Manager profile links: %v", err))
+		} else if len(homeManagerGenerations) > 0 {
+			homeManagerTargets := nixReviewOnlyGenerationTargets(
+				nixGenerationTargets(homeManagerGenerations, time.Now(), cfg.MinUserGenerations, olderThan),
+				"review_home_manager_generation",
+				"outside retention policy, but Home Manager generation deletion requires an explicit profile workflow",
+				CleanupTierWarm,
+			)
+			targets = append(targets, homeManagerTargets...)
+		}
+	}
+
+	if nixEnvErr == nil {
+		systemProfile := "/nix/var/nix/profiles/system"
+		systemGenerations, err := p.listGenerations(ctx, "system", systemProfile, cfg)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not inspect system Nix generations: %v", err))
+		} else {
+			systemTargets := nixReviewOnlyGenerationTargets(
+				nixGenerationTargets(systemGenerations, time.Now(), cfg.MinSystemGenerations, olderThan),
+				"review_privileged_generation",
+				"outside retention policy, but system generation deletion requires explicit privileged workflow",
+				CleanupTierPrivileged,
+			)
+			targets = append(targets, systemTargets...)
+		}
 	}
 
 	return targets, warnings
@@ -459,6 +490,55 @@ func (p *NixPlugin) listGenerations(ctx context.Context, scope, profile string, 
 	return parseNixGenerations(string(output), scope, profile)
 }
 
+func discoverNixProfileLinkGenerations(profileDir, profileName, scope string) ([]nixGeneration, error) {
+	entries, err := os.ReadDir(profileDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	currentLink := filepath.Join(profileDir, profileName)
+	currentTarget := ""
+	if target, err := os.Readlink(currentLink); err == nil {
+		currentTarget = filepath.Base(target)
+	}
+
+	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(profileName) + `-(\d+)-link$`)
+	var generations []nixGeneration
+	for _, entry := range entries {
+		matches := pattern.FindStringSubmatch(entry.Name())
+		if len(matches) != 2 {
+			continue
+		}
+
+		number, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+
+		path := filepath.Join(profileDir, entry.Name())
+		info, err := os.Lstat(path)
+		if err != nil {
+			return nil, err
+		}
+
+		generations = append(generations, nixGeneration{
+			Number:    number,
+			CreatedAt: info.ModTime(),
+			Current:   entry.Name() == currentTarget,
+			Scope:     scope,
+			Profile:   path,
+		})
+	}
+
+	sort.Slice(generations, func(i, j int) bool {
+		return generations[i].Number < generations[j].Number
+	})
+	return generations, nil
+}
+
 func (p *NixPlugin) activeNixProcesses(ctx context.Context) ([]string, error) {
 	psCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -469,6 +549,19 @@ func (p *NixPlugin) activeNixProcesses(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	return nixBusyProcessReasons(string(output)), nil
+}
+
+func nixReviewOnlyGenerationTargets(targets []CleanupTarget, action string, deleteReason string, tier string) []CleanupTarget {
+	for i := range targets {
+		if targets[i].Action != "delete_generation" {
+			continue
+		}
+		targets[i].Protected = true
+		targets[i].Action = action
+		targets[i].Reason = deleteReason
+		annotateCleanupTargetPolicy(&targets[i], tier, CleanupReclaimDeferred)
+	}
+	return targets
 }
 
 func nixActiveWorkTargets(reasons []string, backoff string) []CleanupTarget {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -198,6 +200,35 @@ func TestParseNixGenerations(t *testing.T) {
 	}
 }
 
+func TestDiscoverNixProfileLinkGenerations(t *testing.T) {
+	profileDir := t.TempDir()
+	for _, name := range []string{"home-manager-41-link", "home-manager-42-link"} {
+		if err := os.Symlink("/nix/store/"+name, filepath.Join(profileDir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("home-manager-42-link", filepath.Join(profileDir, "home-manager")); err != nil {
+		t.Fatal(err)
+	}
+
+	generations, err := discoverNixProfileLinkGenerations(profileDir, "home-manager", "home-manager")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(generations) != 2 {
+		t.Fatalf("got %d generations, want 2: %+v", len(generations), generations)
+	}
+	if generations[0].Number != 41 || generations[0].Current {
+		t.Fatalf("unexpected first generation: %+v", generations[0])
+	}
+	if generations[1].Number != 42 || !generations[1].Current {
+		t.Fatalf("current Home Manager generation not detected: %+v", generations[1])
+	}
+	if generations[1].Scope != "home-manager" || generations[1].Profile != filepath.Join(profileDir, "home-manager-42-link") {
+		t.Fatalf("generation metadata not populated: %+v", generations[1])
+	}
+}
+
 func TestParseNixGCRoots(t *testing.T) {
 	output := `
 /proc/1234/fd/5 -> /nix/store/111-source
@@ -262,6 +293,35 @@ func TestNixGCRootTargetsAreProtectedAndLimited(t *testing.T) {
 	}
 	if !targets[0].Active {
 		t.Fatalf("process GC root should be marked active: %+v", targets[0])
+	}
+}
+
+func TestNixReviewOnlyGenerationTargetsProtectsSelectedGenerations(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	generations := []nixGeneration{
+		{Number: 1, CreatedAt: now.Add(-30 * 24 * time.Hour), Scope: "home-manager"},
+		{Number: 2, CreatedAt: now.Add(-1 * 24 * time.Hour), Scope: "home-manager", Current: true},
+	}
+
+	targets := nixReviewOnlyGenerationTargets(
+		nixGenerationTargets(generations, now, 1, 7*24*time.Hour),
+		"review_home_manager_generation",
+		"outside retention policy, but Home Manager generation deletion requires an explicit profile workflow",
+		CleanupTierWarm,
+	)
+
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Version] = target
+	}
+	if actions["1"].Action != "review_home_manager_generation" || !actions["1"].Protected {
+		t.Fatalf("old Home Manager generation should be review-only and protected: %+v", actions["1"])
+	}
+	if actions["1"].Tier != CleanupTierWarm || actions["1"].Reclaim != CleanupReclaimDeferred {
+		t.Fatalf("old Home Manager generation policy mismatch: %+v", actions["1"])
+	}
+	if actions["2"].Action != "keep_generation" || !actions["2"].Protected {
+		t.Fatalf("current Home Manager generation should remain kept: %+v", actions["2"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add lock-free profile-link generation discovery for Nix dry-run planning
- report Home Manager generations as protected review-only targets when outside retention policy
- fall back to profile-link inspection for user generations when nix-env generation inspection is unavailable
- document the Home Manager/profile-link planning behavior

## Local validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test(Nix|ParseNix)'
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- /tmp/tinyland-cleanup-current -dry-run -output json -plugins nix -level critical -config /Users/jess/.config/tinyland-cleanup/config.yaml

## Dry-run notes
- non-mutating Nix-only dry-run reported no reclaimable store space and 241 visible GC roots
- user generations and Home Manager generations were surfaced as protected plan targets
- system generation inspection remained review-gated because /nix/var/nix/profiles/system.lock was not writable in the local context

## Issue
- Continues #4