### PR TITLE
Prioritize actionable Nix GC root attribution

### DIFF
--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -72,7 +72,8 @@ Runtime behavior:
 - low-reclaim dry-runs run `nix-store --gc --print-roots` and emit protected
   `nix_gc_root` targets so operators can see whether profiles, gcroots,
   workspace `result` links, temporary roots, or active processes are pinning the
-  store;
+  store; active process roots, temporary roots, and workspace result roots are
+  listed before generic unknown roots when attribution output is truncated;
 - `nix-store --optimize` runs only when `allow_store_optimize: true`.
 
 Recommended Darwin developer-machine defaults are the repo defaults above.

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -752,12 +752,34 @@ func parseNixGCRoots(output string) []nixGCRoot {
 	}
 
 	sort.Slice(roots, func(i, j int) bool {
-		if roots[i].Class == roots[j].Class {
+		iRank := nixGCRootClassRank(roots[i].Class)
+		jRank := nixGCRootClassRank(roots[j].Class)
+		if iRank == jRank {
+			if roots[i].Class != roots[j].Class {
+				return roots[i].Class < roots[j].Class
+			}
 			return roots[i].Root < roots[j].Root
 		}
-		return roots[i].Class < roots[j].Class
+		return iRank < jRank
 	})
 	return roots
+}
+
+func nixGCRootClassRank(class string) int {
+	switch class {
+	case "process_root":
+		return 0
+	case "temporary_root":
+		return 1
+	case "workspace_result":
+		return 2
+	case "auto_gcroot", "gcroot":
+		return 3
+	case "profile_root":
+		return 4
+	default:
+		return 5
+	}
 }
 
 func classifyNixGCRoot(root string) (string, bool) {
@@ -798,8 +820,10 @@ func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
 	targets := make([]CleanupTarget, 0, limit)
 	for _, root := range roots[:limit] {
 		reason := "visible Nix GC root retaining store path"
+		version := ""
 		if root.StorePath != "" {
-			reason = fmt.Sprintf("%s %s", reason, filepath.Base(root.StorePath))
+			version = filepath.Base(root.StorePath)
+			reason = fmt.Sprintf("%s %s", reason, version)
 		}
 		name := fmt.Sprintf("%s %s", root.Class, filepath.Base(root.Root))
 		if root.Active {
@@ -809,16 +833,50 @@ func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
 		target := CleanupTarget{
 			Type:      "nix_gc_root",
 			Name:      name,
+			Version:   version,
 			Path:      root.Root,
 			Active:    root.Active,
 			Protected: true,
-			Action:    "review_gc_root",
+			Action:    nixGCRootReviewAction(root.Class),
 			Reason:    reason,
 		}
-		annotateCleanupTargetPolicy(&target, CleanupTierSafe, CleanupReclaimNone)
+		annotateCleanupTargetPolicy(&target, nixGCRootTier(root.Class), nixGCRootReclaim(root.Class))
 		targets = append(targets, target)
 	}
 	return targets
+}
+
+func nixGCRootReviewAction(class string) string {
+	switch class {
+	case "process_root":
+		return "review_active_gc_root"
+	case "temporary_root":
+		return "review_temporary_gc_root"
+	case "workspace_result":
+		return "review_workspace_result_root"
+	default:
+		return "review_gc_root"
+	}
+}
+
+func nixGCRootTier(class string) string {
+	switch class {
+	case "process_root":
+		return CleanupTierDisruptive
+	case "workspace_result", "gcroot", "auto_gcroot", "unknown_root":
+		return CleanupTierWarm
+	default:
+		return CleanupTierSafe
+	}
+}
+
+func nixGCRootReclaim(class string) string {
+	switch class {
+	case "temporary_root", "workspace_result", "gcroot", "auto_gcroot":
+		return CleanupReclaimDeferred
+	default:
+		return CleanupReclaimNone
+	}
 }
 
 func nixGCRootClassSummary(roots []nixGCRoot) string {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -267,6 +267,9 @@ func TestParseNixGCRoots(t *testing.T) {
 	if active != 1 {
 		t.Fatalf("expected one active root, got %d", active)
 	}
+	if roots[0].Class != "process_root" || roots[1].Class != "workspace_result" {
+		t.Fatalf("roots should be sorted by operator-actionable class, got %#v", roots)
+	}
 }
 
 func TestNixGCRootTargetsAreProtectedAndLimited(t *testing.T) {
@@ -288,11 +291,42 @@ func TestNixGCRootTargetsAreProtectedAndLimited(t *testing.T) {
 	if len(targets) != 1 {
 		t.Fatalf("got %d targets, want 1", len(targets))
 	}
-	if targets[0].Action != "review_gc_root" || !targets[0].Protected {
+	if targets[0].Action != "review_active_gc_root" || !targets[0].Protected {
 		t.Fatalf("GC root target should be protected review-only: %+v", targets[0])
 	}
 	if !targets[0].Active {
 		t.Fatalf("process GC root should be marked active: %+v", targets[0])
+	}
+}
+
+func TestNixGCRootTargetsUseSpecificReviewActions(t *testing.T) {
+	roots := []nixGCRoot{
+		{
+			Root:      "/tmp/dev-env-profile-1-link",
+			StorePath: "/nix/store/222-dev-env",
+			Class:     "temporary_root",
+		},
+		{
+			Root:      "/Users/jess/git/kernel/result",
+			StorePath: "/nix/store/333-kernel",
+			Class:     "workspace_result",
+		},
+	}
+
+	targets := nixGCRootTargets(roots, 2)
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Path] = target
+	}
+
+	temporary := actions["/tmp/dev-env-profile-1-link"]
+	if temporary.Action != "review_temporary_gc_root" || temporary.Reclaim != CleanupReclaimDeferred || temporary.Version != "222-dev-env" {
+		t.Fatalf("temporary root target should carry specific review action and store path evidence: %+v", temporary)
+	}
+
+	workspace := actions["/Users/jess/git/kernel/result"]
+	if workspace.Action != "review_workspace_result_root" || workspace.Tier != CleanupTierWarm || workspace.Reclaim != CleanupReclaimDeferred {
+		t.Fatalf("workspace result target should carry warm deferred review policy: %+v", workspace)
 	}
 }
 


### PR DESCRIPTION
## Summary
- sort Nix GC-root attribution by operator-actionable classes before generic unknown roots
- add specific protected review actions for active process, temporary, and workspace result roots
- carry the retained store-path basename in GC-root targets for easier dry-run triage
- document the truncation ordering behavior

## Local validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test(Nix|ParseNix)'
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- /tmp/tinyland-cleanup-current -dry-run -output text -plugins nix -level critical -config /Users/jess/.config/tinyland-cleanup/config.yaml

## Dry-run notes
- non-mutating Nix-only dry-run now lists temporary GC roots first when attribution is truncated
- local dry-run still reports zero reclaimable Nix store bytes because live GC roots retain the store
- host was at roughly 12 GiB free during the dry-run, so no destructive local cleanup was attempted here

## Issue
- Continues #4