### PR TITLE
[codex] Protect recent Zig artifacts

### DIFF
--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -177,7 +177,9 @@ always protected and excluded from estimated reclaim because they can be
 developer-owned state. The plan also protects matching artifact families when
 active package manager, compiler, language server, runtime, or LM Studio
 processes are visible, and it preserves any candidate artifact directory that
-contains files tracked by Git.
+contains files tracked by Git. Zig `.zig-cache` and `zig-out` targets are also
+preserved when they contain files modified within the recent-output grace
+window, even at critical pressure.
 
 For Docker, the plan reports Docker daemon disk-usage rows from `docker system
 df`, including images, stopped containers, local volumes, and build cache when

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -6,6 +6,7 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -18,6 +19,8 @@ import (
 
 	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
+
+const devArtifactRecentOutputGrace = 2 * time.Hour
 
 // DevArtifactsPlugin handles stale development artifact cleanup.
 type DevArtifactsPlugin struct {
@@ -250,7 +253,7 @@ func (p *DevArtifactsPlugin) planNodeModules(scanPath string, maxAge time.Durati
 	p.findArtifactDirs(scanPath, "node_modules", "package.json", func(dir string, size int64) {
 		marker := filepath.Join(filepath.Dir(dir), "package.json")
 		stale := maxAge == 0 || p.isFileStale(marker, maxAge)
-		*targets = append(*targets, p.devArtifactTarget("node_modules", "node_modules", dir, size, stale, mutates, p.isProtected(dir, protectPaths), devArtifactContainsTrackedFiles(dir), "package.json", maxAge, active))
+		*targets = append(*targets, p.devArtifactTarget("node_modules", "node_modules", dir, size, stale, mutates, p.isProtected(dir, protectPaths), "", devArtifactContainsTrackedFiles(dir), "package.json", maxAge, active))
 	})
 }
 
@@ -258,7 +261,7 @@ func (p *DevArtifactsPlugin) planPythonVenvs(scanPath string, maxAge time.Durati
 	markers := []string{"pyproject.toml", "setup.py", "requirements.txt"}
 	p.findArtifactDirs(scanPath, ".venv", "", func(dir string, size int64) {
 		stale := maxAge == 0 || p.pythonProjectStale(filepath.Dir(dir), markers, maxAge)
-		*targets = append(*targets, p.devArtifactTarget("python-venv", ".venv", dir, size, stale, mutates, p.isProtected(dir, protectPaths), devArtifactContainsTrackedFiles(dir), strings.Join(markers, ", "), maxAge, active))
+		*targets = append(*targets, p.devArtifactTarget("python-venv", ".venv", dir, size, stale, mutates, p.isProtected(dir, protectPaths), "", devArtifactContainsTrackedFiles(dir), strings.Join(markers, ", "), maxAge, active))
 	})
 }
 
@@ -266,7 +269,7 @@ func (p *DevArtifactsPlugin) planRustTargets(scanPath string, maxAge time.Durati
 	p.findArtifactDirs(scanPath, "target", "Cargo.toml", func(dir string, size int64) {
 		marker := filepath.Join(filepath.Dir(dir), "Cargo.toml")
 		stale := maxAge == 0 || p.isFileStale(marker, maxAge)
-		*targets = append(*targets, p.devArtifactTarget("rust-target", "target", dir, size, stale, mutates, p.isProtected(dir, protectPaths), devArtifactContainsTrackedFiles(dir), "Cargo.toml", maxAge, active))
+		*targets = append(*targets, p.devArtifactTarget("rust-target", "target", dir, size, stale, mutates, p.isProtected(dir, protectPaths), "", devArtifactContainsTrackedFiles(dir), "Cargo.toml", maxAge, active))
 	})
 }
 
@@ -275,7 +278,13 @@ func (p *DevArtifactsPlugin) planZigArtifacts(scanPath string, maxAge time.Durat
 		p.findArtifactDirs(scanPath, artifactName, "build.zig", func(dir string, size int64) {
 			marker := filepath.Join(filepath.Dir(dir), "build.zig")
 			stale := maxAge == 0 || p.isFileStale(marker, maxAge)
-			*targets = append(*targets, p.devArtifactTarget("zig-artifact", artifactName, dir, size, stale, mutates, p.isProtected(dir, protectPaths), devArtifactContainsTrackedFiles(dir), "build.zig", maxAge, active))
+			protected := p.isProtected(dir, protectPaths)
+			tracked := devArtifactContainsTrackedFiles(dir)
+			recentReason := ""
+			if !protected && !tracked {
+				recentReason = devArtifactRecentOutputProtectReason(dir)
+			}
+			*targets = append(*targets, p.devArtifactTarget("zig-artifact", artifactName, dir, size, stale, mutates, protected || recentReason != "", recentReason, tracked, "build.zig", maxAge, active))
 		})
 	}
 }
@@ -388,7 +397,7 @@ func largeLocalArtifactDirKinds() map[string]string {
 	}
 }
 
-func (p *DevArtifactsPlugin) devArtifactTarget(targetType, name, path string, bytes int64, stale, mutates, protected, tracked bool, marker string, maxAge time.Duration, active map[string]string) CleanupTarget {
+func (p *DevArtifactsPlugin) devArtifactTarget(targetType, name, path string, bytes int64, stale, mutates, protected bool, protectReason string, tracked bool, marker string, maxAge time.Duration, active map[string]string) CleanupTarget {
 	activeReason, isActive := active[targetType]
 	target := CleanupTarget{
 		Type:      targetType,
@@ -403,8 +412,11 @@ func (p *DevArtifactsPlugin) devArtifactTarget(targetType, name, path string, by
 		target.Action = "protect"
 		target.Reason = "active development process detected: " + activeReason
 	case protected:
+		if protectReason == "" {
+			protectReason = "path is covered by dev_artifacts.protect_paths"
+		}
 		target.Action = "protect"
-		target.Reason = "path is covered by dev_artifacts.protect_paths"
+		target.Reason = protectReason
 	case tracked:
 		target.Action = "protect"
 		target.Reason = "artifact directory contains files tracked by Git"
@@ -690,6 +702,32 @@ func devArtifactContainsTrackedFiles(path string) bool {
 	return listCmd.Run() == nil
 }
 
+var errRecentDevArtifactContent = errors.New("recent dev artifact content")
+
+func devArtifactRecentOutputProtectReason(path string) string {
+	if !devArtifactHasRecentContent(path, devArtifactRecentOutputGrace) {
+		return ""
+	}
+	return fmt.Sprintf("artifact directory contains files modified within recent output grace %s", formatDevArtifactAge(devArtifactRecentOutputGrace))
+}
+
+func devArtifactHasRecentContent(path string, grace time.Duration) bool {
+	cutoff := time.Now().Add(-grace)
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		if info.ModTime().After(cutoff) {
+			return errRecentDevArtifactContent
+		}
+		return nil
+	})
+	return errors.Is(err, errRecentDevArtifactContent)
+}
+
 // reportArtifacts reports sizes of all detected dev artifacts without cleaning.
 func (p *DevArtifactsPlugin) reportArtifacts(ctx context.Context, daCfg config.DevArtifactsConfig, home string, logger *slog.Logger) {
 	for _, scanPath := range daCfg.ScanPaths {
@@ -912,6 +950,10 @@ func (p *DevArtifactsPlugin) cleanZigArtifacts(ctx context.Context, scanPath str
 			}
 			if devArtifactContainsTrackedFiles(dir) {
 				logger.Debug("preserving Zig artifact containing tracked files", "path", dir)
+				return
+			}
+			if reason := devArtifactRecentOutputProtectReason(dir); reason != "" {
+				logger.Debug("preserving recent Zig artifact", "path", dir, "reason", reason)
 				return
 			}
 

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -304,12 +305,16 @@ func TestCleanZigArtifactsStale(t *testing.T) {
 	project := filepath.Join(tmpDir, "old-zig")
 	os.MkdirAll(filepath.Join(project, ".zig-cache", "o"), 0755)
 	os.MkdirAll(filepath.Join(project, "zig-out", "bin"), 0755)
-	os.WriteFile(filepath.Join(project, ".zig-cache", "o", "artifact"), []byte("cache"), 0644)
-	os.WriteFile(filepath.Join(project, "zig-out", "bin", "tool"), []byte("binary"), 0644)
+	cacheArtifact := filepath.Join(project, ".zig-cache", "o", "artifact")
+	outputArtifact := filepath.Join(project, "zig-out", "bin", "tool")
+	os.WriteFile(cacheArtifact, []byte("cache"), 0644)
+	os.WriteFile(outputArtifact, []byte("binary"), 0644)
 	buildZig := filepath.Join(project, "build.zig")
 	os.WriteFile(buildZig, []byte("const std = @import(\"std\");"), 0644)
 	oldTime := time.Now().Add(-60 * 24 * time.Hour)
 	os.Chtimes(buildZig, oldTime, oldTime)
+	os.Chtimes(cacheArtifact, oldTime, oldTime)
+	os.Chtimes(outputArtifact, oldTime, oldTime)
 
 	freed := p.cleanZigArtifacts(context.Background(), tmpDir, 30*24*time.Hour, nil, logger)
 	if freed == 0 {
@@ -336,6 +341,68 @@ func TestCleanZigArtifactsFresh(t *testing.T) {
 	freed := p.cleanZigArtifacts(context.Background(), tmpDir, 30*24*time.Hour, nil, logger)
 	if freed != 0 {
 		t.Fatal("expected fresh Zig artifacts to be preserved")
+	}
+	if !pathExists(filepath.Join(project, ".zig-cache")) {
+		t.Error(".zig-cache should still exist")
+	}
+}
+
+func TestPlanZigArtifactsProtectsRecentOutputAtCritical(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+
+	project := filepath.Join(tmpDir, "recent-zig")
+	if err := os.MkdirAll(filepath.Join(project, ".zig-cache", "o"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".zig-cache", "o", "artifact"), []byte("cache"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	buildZig := filepath.Join(project, "build.zig")
+	if err := os.WriteFile(buildZig, []byte("const std = @import(\"std\");"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	if err := os.Chtimes(buildZig, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	p.planZigArtifacts(tmpDir, 0, true, nil, nil, &targets)
+
+	target := findDevArtifactTarget(t, targets, "zig-artifact", filepath.Join(project, ".zig-cache"))
+	if target.Action != "protect" || !target.Protected {
+		t.Fatalf("expected recent Zig output to be protected, got %#v", target)
+	}
+	if !strings.Contains(target.Reason, "recent output grace") {
+		t.Fatalf("expected recent-output protection reason, got %q", target.Reason)
+	}
+}
+
+func TestCleanZigArtifactsPreservesRecentOutputAtCritical(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	project := filepath.Join(tmpDir, "recent-zig")
+	if err := os.MkdirAll(filepath.Join(project, ".zig-cache", "o"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".zig-cache", "o", "artifact"), []byte("cache"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	buildZig := filepath.Join(project, "build.zig")
+	if err := os.WriteFile(buildZig, []byte("const std = @import(\"std\");"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	if err := os.Chtimes(buildZig, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	freed := p.cleanZigArtifacts(context.Background(), tmpDir, 0, nil, logger)
+	if freed != 0 {
+		t.Fatalf("expected recent Zig output to be preserved, freed %d bytes", freed)
 	}
 	if !pathExists(filepath.Join(project, ".zig-cache")) {
 		t.Error(".zig-cache should still exist")


### PR DESCRIPTION
## Summary

- protect Zig `.zig-cache` and `zig-out` directories when they contain files modified within a recent-output grace window
- keep configured protect paths and Git-tracked artifact protection ahead of the recent-output fallback
- document the new operator-facing dry-run behavior

## Why

A critical dry-run on a disk-pressure Darwin workstation proposed deleting fresh `oauth-mux` Zig outputs because the existing policy only considered the sibling `build.zig` mtime. That is too aggressive for active developer machines where release artifacts or just-built cache contents can be newer than the project marker.

This keeps the critical cleanup path conservative while still allowing truly stale Zig artifacts to be reclaimed.

Part of #2.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test(PlanZigArtifacts|CleanZigArtifacts|DevArtifact)'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `/tmp/tinyland-cleanup-current -dry-run -output json -plugins dev-artifacts -level critical -config /Users/jess/.config/tinyland-cleanup/config.yaml`

The local dry-run now protects `/Users/jess/git/oauth-mux/.zig-cache` and `/Users/jess/git/oauth-mux/zig-out` with the recent-output reason instead of proposing deletion.
