### PR TITLE
[codex] Report mounted large artifacts

### DIFF
--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -174,8 +174,10 @@ such as `.dmg`, `.img`, `.qcow2`, `.raw`, `.iso`, `.sparsebundle`, `.utm`,
 mark eligible stale artifacts as deletion or cache-clean targets while
 preserving configured protected paths. Large local disk/image artifacts are
 always protected and excluded from estimated reclaim because they can be
-developer-owned state. The plan also protects matching artifact families when
-active package manager, compiler, language server, runtime, or LM Studio
+developer-owned state. Mounted disk images are reported as active protected
+targets with their mount point so operators know to detach them before any
+manual cleanup or compaction. The plan also protects matching artifact families
+when active package manager, compiler, language server, runtime, or LM Studio
 processes are visible, and it preserves any candidate artifact directory that
 contains files tracked by Git. Zig `.zig-cache` and `zig-out` targets are also
 preserved when they contain files modified within the recent-output grace

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -88,6 +88,11 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 	}
 
 	tracker := newDevArtifactGitTracker()
+	mountedImages := map[string]string{}
+	if daCfg.LargeLocalArtifacts {
+		mountedImages = largeLocalMountedDiskImages(ctx)
+	}
+
 	var targets []CleanupTarget
 	for _, scanPath := range daCfg.ScanPaths {
 		expanded := expandHome(scanPath, home)
@@ -107,7 +112,7 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 			p.planZigArtifacts(expanded, zigAge, mutates, daCfg.ProtectPaths, active, tracker, &targets)
 		}
 		if daCfg.LargeLocalArtifacts {
-			p.planLargeLocalArtifacts(expanded, largeLocalArtifactMinBytes(daCfg), daCfg.ProtectPaths, &targets)
+			p.planLargeLocalArtifacts(expanded, largeLocalArtifactMinBytes(daCfg), daCfg.ProtectPaths, mountedImages, &targets)
 		}
 	}
 
@@ -292,13 +297,13 @@ func (p *DevArtifactsPlugin) planZigArtifacts(scanPath string, maxAge time.Durat
 	}
 }
 
-func (p *DevArtifactsPlugin) planLargeLocalArtifacts(scanPath string, minBytes int64, protectPaths []string, targets *[]CleanupTarget) {
-	p.findLargeLocalArtifacts(scanPath, minBytes, protectPaths, func(target CleanupTarget) {
+func (p *DevArtifactsPlugin) planLargeLocalArtifacts(scanPath string, minBytes int64, protectPaths []string, mountedImages map[string]string, targets *[]CleanupTarget) {
+	p.findLargeLocalArtifacts(scanPath, minBytes, protectPaths, mountedImages, func(target CleanupTarget) {
 		*targets = append(*targets, target)
 	})
 }
 
-func (p *DevArtifactsPlugin) findLargeLocalArtifacts(scanPath string, minBytes int64, protectPaths []string, callback func(CleanupTarget)) {
+func (p *DevArtifactsPlugin) findLargeLocalArtifacts(scanPath string, minBytes int64, protectPaths []string, mountedImages map[string]string, callback func(CleanupTarget)) {
 	scanDepth := strings.Count(scanPath, string(os.PathSeparator))
 	fileKinds := largeLocalArtifactFileKinds()
 	dirKinds := largeLocalArtifactDirKinds()
@@ -325,7 +330,7 @@ func (p *DevArtifactsPlugin) findLargeLocalArtifacts(scanPath string, minBytes i
 			if kind, ok := dirKinds[filepath.Ext(lowerBase)]; ok {
 				size := getDirAllocatedBytes(path)
 				if size >= minBytes {
-					callback(p.largeLocalArtifactTarget(kind, path, size, 0, p.isProtected(path, protectPaths)))
+					callback(p.largeLocalArtifactTarget(kind, path, size, 0, p.isProtected(path, protectPaths), mountedImages[filepath.Clean(path)]))
 				}
 				return filepath.SkipDir
 			}
@@ -346,15 +351,19 @@ func (p *DevArtifactsPlugin) findLargeLocalArtifacts(scanPath string, minBytes i
 		if physicalBytes < minBytes {
 			return nil
 		}
-		callback(p.largeLocalArtifactTarget(kind, path, physicalBytes, info.Size(), p.isProtected(path, protectPaths)))
+		callback(p.largeLocalArtifactTarget(kind, path, physicalBytes, info.Size(), p.isProtected(path, protectPaths), mountedImages[filepath.Clean(path)]))
 		return nil
 	})
 }
 
-func (p *DevArtifactsPlugin) largeLocalArtifactTarget(kind, path string, physicalBytes, logicalBytes int64, protected bool) CleanupTarget {
+func (p *DevArtifactsPlugin) largeLocalArtifactTarget(kind, path string, physicalBytes, logicalBytes int64, protected bool, mountPoint string) CleanupTarget {
 	action := "review"
 	reason := "large local disk/image artifact requires manual review before removal"
-	if protected {
+	active := mountPoint != ""
+	if active {
+		action = "protect"
+		reason = "disk/image artifact is mounted at " + mountPoint + "; detach before manual cleanup"
+	} else if protected {
 		action = "protect"
 		reason = "path is covered by dev_artifacts.protect_paths"
 	}
@@ -364,12 +373,64 @@ func (p *DevArtifactsPlugin) largeLocalArtifactTarget(kind, path string, physica
 		Path:         path,
 		Bytes:        physicalBytes,
 		LogicalBytes: logicalBytes,
+		Active:       active,
 		Protected:    true,
 		Action:       action,
 		Reason:       reason,
 	}
 	annotateCleanupTargetPolicy(&target, CleanupTierDestructive, CleanupReclaimNone)
 	return target
+}
+
+func largeLocalMountedDiskImages(ctx context.Context) map[string]string {
+	hdiutil, err := exec.LookPath("hdiutil")
+	if err != nil {
+		return nil
+	}
+	infoCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(infoCtx, hdiutil, "info").Output()
+	if err != nil {
+		return nil
+	}
+	return parseLargeLocalMountedDiskImages(string(output))
+}
+
+func parseLargeLocalMountedDiskImages(output string) map[string]string {
+	mounted := map[string]string{}
+	currentImage := ""
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "image-path") {
+			if _, value, ok := strings.Cut(trimmed, ":"); ok {
+				currentImage = filepath.Clean(strings.TrimSpace(value))
+			}
+			continue
+		}
+		if currentImage == "" || !strings.HasPrefix(trimmed, "/dev/") {
+			continue
+		}
+		mountPoint := largeLocalMountPointFromHdiutilLine(trimmed)
+		if mountPoint != "" {
+			mounted[currentImage] = mountPoint
+		}
+	}
+	return mounted
+}
+
+func largeLocalMountPointFromHdiutilLine(line string) string {
+	parts := strings.Split(line, "\t")
+	if len(parts) > 1 {
+		mountPoint := strings.TrimSpace(parts[len(parts)-1])
+		if strings.HasPrefix(mountPoint, "/") {
+			return mountPoint
+		}
+	}
+	fields := strings.Fields(line)
+	if len(fields) > 0 && strings.HasPrefix(fields[len(fields)-1], "/") {
+		return fields[len(fields)-1]
+	}
+	return ""
 }
 
 func largeLocalArtifactMinBytes(cfg config.DevArtifactsConfig) int64 {
@@ -872,7 +933,7 @@ func (p *DevArtifactsPlugin) reportArtifacts(ctx context.Context, daCfg config.D
 
 		// Find and report large local artifacts for manual review.
 		if daCfg.LargeLocalArtifacts {
-			p.findLargeLocalArtifacts(expanded, largeLocalArtifactMinBytes(daCfg), daCfg.ProtectPaths, func(target CleanupTarget) {
+			p.findLargeLocalArtifacts(expanded, largeLocalArtifactMinBytes(daCfg), daCfg.ProtectPaths, nil, func(target CleanupTarget) {
 				logger.Info("found large local artifact", "path", target.Path, "size_mb", target.Bytes/(1024*1024), "type", target.Name)
 			})
 		}

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -697,7 +697,7 @@ func TestPlanLargeLocalArtifactsReportsReviewOnlyTargets(t *testing.T) {
 	}
 
 	var targets []CleanupTarget
-	p.planLargeLocalArtifacts(tmpDir, 1, nil, &targets)
+	p.planLargeLocalArtifacts(tmpDir, 1, nil, nil, &targets)
 
 	image := findDevArtifactTarget(t, targets, "large-local-artifact", imagePath)
 	if image.Action != "review" || !image.Protected || image.Tier != CleanupTierDestructive || image.Reclaim != CleanupReclaimNone {
@@ -706,6 +706,48 @@ func TestPlanLargeLocalArtifactsReportsReviewOnlyTargets(t *testing.T) {
 	bundle := findDevArtifactTarget(t, targets, "large-local-artifact", bundlePath)
 	if bundle.Action != "review" || !bundle.Protected || bundle.Bytes <= 0 {
 		t.Fatalf("expected review-only sparsebundle target with bytes, got %#v", bundle)
+	}
+}
+
+func TestPlanLargeLocalArtifactsReportsMountedImagesAsActive(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	bundlePath := filepath.Join(tmpDir, "linux-xr-case-sensitive.sparsebundle")
+	if err := os.MkdirAll(filepath.Join(bundlePath, "bands"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundlePath, "bands", "0"), []byte("bundle data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	p.planLargeLocalArtifacts(tmpDir, 1, nil, map[string]string{
+		filepath.Clean(bundlePath): "/Volumes/linux-xr-cs",
+	}, &targets)
+
+	target := findDevArtifactTarget(t, targets, "large-local-artifact", bundlePath)
+	if target.Action != "protect" || !target.Protected || !target.Active {
+		t.Fatalf("expected mounted sparsebundle to be active/protected, got %#v", target)
+	}
+	if !strings.Contains(target.Reason, "mounted at /Volumes/linux-xr-cs") {
+		t.Fatalf("expected mount point in reason, got %q", target.Reason)
+	}
+}
+
+func TestParseLargeLocalMountedDiskImages(t *testing.T) {
+	output := `
+image-path      : /Users/jess/Downloads/installer.dmg
+/dev/disk8s1	41504653-0000-11AA-AA11-00306543ECAC	/Volumes/Installer
+image-path      : /Users/jess/git/linux-xr-case-sensitive.sparsebundle
+/dev/disk9	EF57347C-0000-11AA-AA11-00306543ECAC
+/dev/disk9s1	41504653-0000-11AA-AA11-00306543ECAC	/Volumes/linux-xr-cs
+`
+	mounted := parseLargeLocalMountedDiskImages(output)
+	if mounted["/Users/jess/Downloads/installer.dmg"] != "/Volumes/Installer" {
+		t.Fatalf("installer mount missing: %#v", mounted)
+	}
+	if mounted["/Users/jess/git/linux-xr-case-sensitive.sparsebundle"] != "/Volumes/linux-xr-cs" {
+		t.Fatalf("sparsebundle mount missing: %#v", mounted)
 	}
 }
 
@@ -721,7 +763,7 @@ func TestPlanLargeLocalArtifactsHonorsProtectPaths(t *testing.T) {
 	}
 
 	var targets []CleanupTarget
-	p.planLargeLocalArtifacts(tmpDir, 1, []string{filepath.Dir(imagePath)}, &targets)
+	p.planLargeLocalArtifacts(tmpDir, 1, []string{filepath.Dir(imagePath)}, nil, &targets)
 
 	target := findDevArtifactTarget(t, targets, "large-local-artifact", imagePath)
 	if target.Action != "protect" || !target.Protected {


### PR DESCRIPTION
## Summary

- report mounted large local disk/image artifacts as active protected targets
- parse `hdiutil info` on Darwin to attach mount-point evidence to `.dmg` / `.sparsebundle` style candidates
- document that mounted disk images should be detached before manual cleanup or compaction

## Why

During local disk-pressure dogfood, the largest review-only candidate was `linux-xr-case-sensitive.sparsebundle`, but it was mounted at `/Volumes/linux-xr-cs`. The plan should expose that live state directly so an operator does not treat it as just another removable file.

This keeps large artifact handling conservative while making the manual next step explicit.

Part of #2.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test(PlanLargeLocalArtifacts|ParseLargeLocalMountedDiskImages)'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `/tmp/tinyland-cleanup-current -dry-run -output json -plugins dev-artifacts -level critical -config /Users/jess/.config/tinyland-cleanup/config.yaml`

Local dry-run confirmation: `/Users/jess/git/linux-xr-case-sensitive.sparsebundle` is now `active: true`, `action: protect`, with reason `disk/image artifact is mounted at /Volumes/linux-xr-cs; detach before manual cleanup`.
