### PR TITLE
[codex] Report sparsebundle logical size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ All notable changes to this project will be documented in this file.
 - Dry-run cleanup targets now carry policy tier, logical byte, reclaim kind,
   and host-space reclaim expectation metadata where planner evidence is
   available.
+- Review-only sparsebundle targets now report logical size from `Info.plist`
+  when available, making APFS bundle physical-vs-logical accounting visible in
+  dry-run plans.
 - Darwin JetBrains cache planning now uses the configured `max_gb` budget to
   mark oldest inactive cache versions as opt-in aggressive cleanup candidates.
 - Nix dry-run GC lock and SQLite contention now surfaces as

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -176,8 +176,11 @@ preserving configured protected paths. Large local disk/image artifacts are
 always protected and excluded from estimated reclaim because they can be
 developer-owned state. Mounted disk images are reported as active protected
 targets with their mount point so operators know to detach them before any
-manual cleanup or compaction. The plan also protects matching artifact families
-when active package manager, compiler, language server, runtime, or LM Studio
+manual cleanup or compaction. Sparsebundle targets also report logical size
+from `Info.plist` when available; detached APFS sparsebundles may still reject
+`hdiutil compact`, so treat them as manual migrate/delete decisions rather than
+automatic reclaim. The plan also protects matching artifact families when
+active package manager, compiler, language server, runtime, or LM Studio
 processes are visible, and it preserves any candidate artifact directory that
 contains files tracked by Git. Zig `.zig-cache` and `zig-out` targets are also
 preserved when they contain files modified within the recent-output grace

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -6,8 +6,10 @@ package plugins
 
 import (
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -327,10 +329,11 @@ func (p *DevArtifactsPlugin) findLargeLocalArtifacts(scanPath string, minBytes i
 			if strings.HasPrefix(baseName, ".") {
 				return filepath.SkipDir
 			}
-			if kind, ok := dirKinds[filepath.Ext(lowerBase)]; ok {
+			ext := filepath.Ext(lowerBase)
+			if kind, ok := dirKinds[ext]; ok {
 				size := getDirAllocatedBytes(path)
 				if size >= minBytes {
-					callback(p.largeLocalArtifactTarget(kind, path, size, 0, p.isProtected(path, protectPaths), mountedImages[filepath.Clean(path)]))
+					callback(p.largeLocalArtifactTarget(kind, path, size, largeLocalArtifactDirLogicalBytes(ext, path), p.isProtected(path, protectPaths), mountedImages[filepath.Clean(path)]))
 				}
 				return filepath.SkipDir
 			}
@@ -358,7 +361,7 @@ func (p *DevArtifactsPlugin) findLargeLocalArtifacts(scanPath string, minBytes i
 
 func (p *DevArtifactsPlugin) largeLocalArtifactTarget(kind, path string, physicalBytes, logicalBytes int64, protected bool, mountPoint string) CleanupTarget {
 	action := "review"
-	reason := "large local disk/image artifact requires manual review before removal"
+	reason := largeLocalArtifactReviewReason(kind)
 	active := mountPoint != ""
 	if active {
 		action = "protect"
@@ -380,6 +383,82 @@ func (p *DevArtifactsPlugin) largeLocalArtifactTarget(kind, path string, physica
 	}
 	annotateCleanupTargetPolicy(&target, CleanupTierDestructive, CleanupReclaimNone)
 	return target
+}
+
+func largeLocalArtifactReviewReason(kind string) string {
+	if kind == "sparse bundle disk image" {
+		return "sparsebundle requires manual review; automatic compaction is not assumed to reclaim host space"
+	}
+	return "large local disk/image artifact requires manual review before removal"
+}
+
+func largeLocalArtifactDirLogicalBytes(ext string, path string) int64 {
+	if ext != ".sparsebundle" {
+		return 0
+	}
+	return sparseBundleLogicalBytes(path)
+}
+
+func sparseBundleLogicalBytes(path string) int64 {
+	value, err := plistIntegerValue(filepath.Join(path, "Info.plist"), "size")
+	if err != nil || value <= 0 {
+		return 0
+	}
+	return value
+}
+
+func plistIntegerValue(path string, key string) (int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	decoder := xml.NewDecoder(file)
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return 0, io.EOF
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		start, ok := token.(xml.StartElement)
+		if !ok || start.Name.Local != "key" {
+			continue
+		}
+
+		var foundKey string
+		if err := decoder.DecodeElement(&foundKey, &start); err != nil {
+			return 0, err
+		}
+		if strings.TrimSpace(foundKey) != key {
+			continue
+		}
+
+		for {
+			token, err := decoder.Token()
+			if errors.Is(err, io.EOF) {
+				return 0, io.EOF
+			}
+			if err != nil {
+				return 0, err
+			}
+			start, ok := token.(xml.StartElement)
+			if !ok {
+				continue
+			}
+			if start.Name.Local != "integer" {
+				return 0, fmt.Errorf("plist key %q is %s, not integer", key, start.Name.Local)
+			}
+			var rawValue string
+			if err := decoder.DecodeElement(&rawValue, &start); err != nil {
+				return 0, err
+			}
+			return strconv.ParseInt(strings.TrimSpace(rawValue), 10, 64)
+		}
+	}
 }
 
 func largeLocalMountedDiskImages(ctx context.Context) map[string]string {

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -692,6 +692,20 @@ func TestPlanLargeLocalArtifactsReportsReviewOnlyTargets(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(bundlePath, "bands"), 0755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(bundlePath, "Info.plist"), []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>band-size</key>
+	<integer>8388608</integer>
+	<key>diskimage-bundle-type</key>
+	<string>com.apple.diskimage.sparsebundle</string>
+	<key>size</key>
+	<integer>34359738368</integer>
+</dict>
+</plist>
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(bundlePath, "bands", "0"), []byte("bundle data"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -704,8 +718,11 @@ func TestPlanLargeLocalArtifactsReportsReviewOnlyTargets(t *testing.T) {
 		t.Fatalf("expected review-only destructive/no-reclaim image target, got %#v", image)
 	}
 	bundle := findDevArtifactTarget(t, targets, "large-local-artifact", bundlePath)
-	if bundle.Action != "review" || !bundle.Protected || bundle.Bytes <= 0 {
-		t.Fatalf("expected review-only sparsebundle target with bytes, got %#v", bundle)
+	if bundle.Action != "review" || !bundle.Protected || bundle.Bytes <= 0 || bundle.LogicalBytes != 34359738368 {
+		t.Fatalf("expected review-only sparsebundle target with physical and logical bytes, got %#v", bundle)
+	}
+	if !strings.Contains(bundle.Reason, "automatic compaction is not assumed") {
+		t.Fatalf("expected sparsebundle compaction caveat, got %q", bundle.Reason)
 	}
 }
 


### PR DESCRIPTION
## Summary

- report sparsebundle logical size from `Info.plist` on review-only large local artifact targets
- clarify sparsebundle target reasons so operators do not assume automatic compaction will reclaim host space
- document the detached APFS sparsebundle caveat in the operator workflow and changelog

## Why

Local validation found a detached APFS sparsebundle that occupied about 13 GiB physically with a 32 GiB logical size, while `hdiutil compact` failed with `Function not implemented`. The dry-run planner should expose that accounting directly and keep the artifact protected/manual.

Refs #2.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'TestPlanLargeLocalArtifacts|TestParseLargeLocalMountedDiskImages'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- targeted dry-run against `/Users/jess/git/linux-xr-case-sensitive.sparsebundle` showed `12.7 GiB` physical, `32.0 GiB` logical, `review`, `protected`, `reclaim=none`
