### PR TITLE
[codex] Show target paths in text reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ All notable changes to this project will be documented in this file.
 - Nix generation deletion and GC commands now treat the same contention
   signatures as skipped cleanup rather than hard failures when daemon-busy
   skipping is enabled.
+- Human-readable text reports now include target paths when a target has both a
+  label and filesystem path, making review-only Nix GC roots and large artifact
+  targets actionable without switching to JSON.
 
 ### Changed
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -12,7 +12,9 @@ tinyland-cleanup --once --dry-run --level critical --output text
 
 The text report is the operator explain view. It summarizes the selected level,
 monitored mounts, host free-space accounting, target free-space deficit, plugin
-plans, warnings, and the first few cleanup targets for review.
+plans, warnings, and the first few cleanup targets for review. Target rows show
+the filesystem path when a target has both a short label and a path, so
+review-only roots and artifacts can be acted on without switching formats.
 
 Use JSON when another tool needs the stable report schema:
 

--- a/main_test.go
+++ b/main_test.go
@@ -125,6 +125,7 @@ func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
 					Type:              "cache",
 					Tier:              plugins.CleanupTierWarm,
 					Name:              "example-cache",
+					Path:              "/tmp/example-cache",
 					Bytes:             1024,
 					Reclaim:           plugins.CleanupReclaimNone,
 					HostReclaimsSpace: &hostReclaims,
@@ -151,7 +152,7 @@ func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
 		"plan: estimated reclaim 1.0 MiB",
 		"- reporting: would run (dry_run)",
 		"reporting dry-run plan",
-		"example-cache [cache]: review, protected, tier=warm, reclaim=none, 1.0 KiB - operator review required",
+		"example-cache (/tmp/example-cache) [cache]: review, protected, tier=warm, reclaim=none, 1.0 KiB - operator review required",
 		"review before cleanup",
 	} {
 		if !strings.Contains(text, want) {

--- a/report_text.go
+++ b/report_text.go
@@ -251,6 +251,9 @@ func writeTextTarget(w io.Writer, target plugins.CleanupTarget) error {
 	if name == "" {
 		name = target.Type
 	}
+	if target.Path != "" && target.Path != name {
+		name = fmt.Sprintf("%s (%s)", name, target.Path)
+	}
 
 	if _, err := fmt.Fprintf(w, "  - %s [%s]: %s", name, target.Type, status); err != nil {
 		return err


### PR DESCRIPTION
## Summary

- include target filesystem paths in human-readable text reports when targets have both a short label and a path
- update the existing text-report test coverage for the new rendering
- document the operator-facing behavior in the workflow guide and changelog

## Why

Nix GC-root attribution can be truncated under heavy root pressure. The labels alone can collapse multiple roots into repeated names like `nix-out-link` or `flake-registry.json`; showing `name (path)` makes the text report actionable without requiring JSON inspection.

Refs #4.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test . -run TestRunOnceDryRunTextReportExplainsPlan`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- Nix-only critical dry-run confirmed text output now shows root paths such as `/private/tmp/crush-dots-bazel-output/.../nix-out-link`
