### PR TITLE
[codex] Handle stale idle Bazel servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ All notable changes to this project will be documented in this file.
 - Human-readable text reports now include target paths when a target has both a
   label and filesystem path, making review-only Nix GC roots and large artifact
   targets actionable without switching to JSON.
+- Bazel cleanup now distinguishes active client output bases from idle
+  server-only output bases, and aggressive/critical cleanup can stop stale idle
+  servers before deleting their output bases when `allow_stop_idle_servers` is
+  enabled.
 
 ### Changed
 

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -75,6 +75,11 @@ Runtime boundary:
   even when they are outside configured output-user roots; idle/server-only
   output-base visibility protects that output base but does not globally block
   unrelated cache-tier cleanup;
+- aggressive and critical cleanup may classify stale idle-server-only output
+  bases as `stop_idle_server_then_delete_output_base` when
+  `allow_stop_idle_servers` is enabled; real cleanup runs
+  `bazel --output_base=<path> shutdown`, re-checks the output base, and deletes
+  it only if it is no longer active;
 - deletion normalizes writable permissions first, and on Darwin attempts to
   clear `uchg` file flags with `chflags -R nouchg`;
 - after an output base is deleted, workspace roots are scanned shallowly for
@@ -85,11 +90,10 @@ Runtime boundary:
 - Bazel output bases, repository caches, and disk caches are `warm` targets
   because they are rebuildable but expensive; Bazelisk downloads are `safe`
   targets;
-- `delete_output_base` and `delete_cache_tier` targets advertise
-  `reclaim=host` and `host_reclaims_space=true`; review and protected targets
-  advertise `reclaim=none`;
-- idle Bazel server stop remains a follow-up guarded by
-  `allow_stop_idle_servers`.
+- `delete_output_base`, `delete_cache_tier`, and
+  `stop_idle_server_then_delete_output_base` targets advertise `reclaim=host`
+  and `host_reclaims_space=true`; review and protected targets advertise
+  `reclaim=none`.
 
 Do not disable active-output-base protection on developer machines or shared
 runners unless an operator has already drained the relevant jobs and accepted

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -26,21 +26,26 @@ var bazelCommandPattern = regexp.MustCompile(`\b(bazel|bazelisk)\s+(build|test|r
 type BazelPlugin struct{}
 
 type bazelCandidate struct {
-	Type      string
-	Name      string
-	Path      string
-	ModTime   time.Time
-	Logical   int64
-	Physical  int64
-	Active    bool
-	Protected bool
-	Action    string
-	Reason    string
+	Type          string
+	Name          string
+	Path          string
+	ModTime       time.Time
+	Logical       int64
+	Physical      int64
+	Active        bool
+	ActiveClient  bool
+	IdleServer    bool
+	ProcessServer bool
+	Protected     bool
+	Action        string
+	Reason        string
 }
 
 type bazelProcessInfo struct {
-	Reasons     []string
-	OutputBases []string
+	Reasons           []string
+	OutputBases       []string
+	ClientOutputBases []string
+	ServerOutputBases []string
 }
 
 // NewBazelPlugin creates a new Bazel cleanup plugin.
@@ -110,10 +115,16 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 		if len(activeInfo.OutputBases) > 0 {
 			plan.Metadata["process_output_base_count"] = strconv.Itoa(len(activeInfo.OutputBases))
 		}
+		if len(activeInfo.ClientOutputBases) > 0 {
+			plan.Metadata["client_output_base_count"] = strconv.Itoa(len(activeInfo.ClientOutputBases))
+		}
+		if len(activeInfo.ServerOutputBases) > 0 {
+			plan.Metadata["idle_server_output_base_count"] = strconv.Itoa(len(activeInfo.ServerOutputBases))
+		}
 	}
 
 	globalActive := len(activeInfo.Reasons) > 0
-	candidates := p.discoverCandidates(home, cfg.Bazel, activeInfo.OutputBases)
+	candidates := p.discoverCandidates(home, cfg.Bazel, activeInfo)
 	targets, totalPhysical := bazelPlanTargets(candidates, cfg.Bazel, level, time.Now(), globalActive)
 	plan.Targets = targets
 	plan.EstimatedBytesFreed = bazelEstimatedCandidateBytes(targets)
@@ -169,15 +180,19 @@ func (p *BazelPlugin) activeBazelProcessInfo(ctx context.Context) (bazelProcessI
 	return bazelBusyProcessInfo(string(output)), nil
 }
 
-func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig, processOutputBases []string) []bazelCandidate {
+func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig, activeInfo bazelProcessInfo) []bazelCandidate {
 	var candidates []bazelCandidate
-	seen := map[string]bool{}
+	seen := map[string]int{}
 
 	add := func(candidate bazelCandidate) {
-		if candidate.Path == "" || seen[candidate.Path] {
+		if candidate.Path == "" {
 			return
 		}
-		seen[candidate.Path] = true
+		if idx, ok := seen[candidate.Path]; ok {
+			mergeBazelCandidate(&candidates[idx], candidate)
+			return
+		}
+		seen[candidate.Path] = len(candidates)
 		candidates = append(candidates, candidate)
 	}
 
@@ -188,8 +203,9 @@ func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig, pr
 		}
 	}
 
-	for _, outputBase := range processOutputBases {
-		for _, candidate := range discoverBazelProcessOutputBase(outputBase) {
+	processOutputBaseKinds := bazelProcessOutputBaseKinds(activeInfo)
+	for _, outputBase := range activeInfo.OutputBases {
+		for _, candidate := range discoverBazelProcessOutputBase(outputBase, processOutputBaseKinds[filepath.Clean(outputBase)]) {
 			add(candidate)
 		}
 	}
@@ -206,15 +222,53 @@ func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig, pr
 			candidates[i].Protected = true
 			candidates[i].Reason = "reachable from configured protected workspace"
 		}
-		if candidates[i].Type == "output_base" && bazelOutputBaseHasActiveLock(candidates[i].Path) {
-			candidates[i].Active = true
+		if candidates[i].Type == "output_base" {
+			activity := bazelOutputBaseActivity(candidates[i].Path)
+			if activity.Active {
+				mergeBazelCandidate(&candidates[i], bazelCandidate{
+					Active:        true,
+					ActiveClient:  activity.ActiveClient,
+					IdleServer:    activity.IdleServer,
+					ProcessServer: activity.ProcessServer,
+					Reason:        activity.Reason,
+				})
+			}
 		}
 	}
 
 	return candidates
 }
 
-func discoverBazelProcessOutputBase(path string) []bazelCandidate {
+func mergeBazelCandidate(existing *bazelCandidate, incoming bazelCandidate) {
+	if incoming.Active {
+		existing.Active = true
+	}
+	if incoming.ActiveClient {
+		existing.ActiveClient = true
+		existing.IdleServer = false
+		if incoming.Reason != "" && !existing.Protected {
+			existing.Reason = incoming.Reason
+		}
+	} else if incoming.IdleServer && !existing.ActiveClient {
+		existing.IdleServer = true
+		if incoming.ProcessServer {
+			existing.ProcessServer = true
+		}
+		if !existing.Protected && (existing.Reason == "" || !strings.Contains(existing.Reason, "idle Bazel server")) {
+			existing.Reason = incoming.Reason
+		}
+	} else if incoming.Active && !existing.Protected && existing.Reason == "" {
+		existing.Reason = incoming.Reason
+	}
+	if incoming.Protected {
+		existing.Protected = true
+		if incoming.Reason != "" {
+			existing.Reason = incoming.Reason
+		}
+	}
+}
+
+func discoverBazelProcessOutputBase(path string, kind string) []bazelCandidate {
 	path = filepath.Clean(path)
 	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() || !isBazelOutputBase(path) {
@@ -222,7 +276,17 @@ func discoverBazelProcessOutputBase(path string) []bazelCandidate {
 	}
 	candidate := newBazelCandidate("output_base", filepath.Base(path), path, info.ModTime())
 	candidate.Active = true
-	candidate.Reason = "discovered from active Bazel process --output_base"
+	switch kind {
+	case "client":
+		candidate.ActiveClient = true
+		candidate.Reason = "discovered from active Bazel client --output_base"
+	case "server":
+		candidate.IdleServer = true
+		candidate.ProcessServer = true
+		candidate.Reason = "discovered from idle Bazel server --output_base"
+	default:
+		candidate.Reason = "discovered from Bazel process --output_base"
+	}
 	return []bazelCandidate{candidate}
 }
 
@@ -394,14 +458,31 @@ func isBazelOutputBase(path string) bool {
 	return true
 }
 
-func bazelOutputBaseHasActiveLock(path string) bool {
+type bazelOutputBaseActivityInfo struct {
+	Active        bool
+	ActiveClient  bool
+	IdleServer    bool
+	ProcessServer bool
+	Reason        string
+}
+
+func bazelOutputBaseActivity(path string) bazelOutputBaseActivityInfo {
 	if bazelServerPIDIsAlive(filepath.Join(path, "server", "server.pid")) {
-		return true
+		return bazelOutputBaseActivityInfo{
+			Active:     true,
+			IdleServer: true,
+			Reason:     "idle Bazel server pid is alive",
+		}
 	}
 	if info, err := os.Stat(filepath.Join(path, "lock")); err == nil {
-		return time.Since(info.ModTime()) < 15*time.Minute
+		if time.Since(info.ModTime()) < 15*time.Minute {
+			return bazelOutputBaseActivityInfo{
+				Active: true,
+				Reason: "recent Bazel output-base lock detected",
+			}
+		}
 	}
-	return false
+	return bazelOutputBaseActivityInfo{}
 }
 
 func bazelServerPIDIsAlive(path string) bool {
@@ -515,6 +596,14 @@ func newestBazelOutputBases(candidates []bazelCandidate, keep int) map[string]bo
 
 func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration, now time.Time, protectedByRecent bool, globalActive bool, budgetExceeded bool, level CleanupLevel, cfg config.BazelConfig) CleanupTarget {
 	active := candidate.Active || globalActive
+	idleServerOnly := candidate.IdleServer && !candidate.ActiveClient && !globalActive
+	stale := !candidate.ModTime.After(now.Add(-staleAfter))
+	idleServerStopEligible := candidate.Type == "output_base" &&
+		idleServerOnly &&
+		candidate.ProcessServer &&
+		cfg.AllowStopIdleServers &&
+		level >= LevelAggressive &&
+		stale
 	protected := candidate.Protected || protectedByRecent || (active && !cfg.AllowDeleteActiveOutputBases)
 	action := "review"
 	reason := "Bazel cache candidate requires operator review"
@@ -526,9 +615,17 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 	case protectedByRecent:
 		action = "keep"
 		reason = "within configured newest output-base retention"
+	case idleServerStopEligible:
+		action = "stop_idle_server_then_delete_output_base"
+		protected = false
+		reason = "stale output base has only an idle Bazel server; allow_stop_idle_servers permits shutdown before deletion"
 	case active && !cfg.AllowDeleteActiveOutputBases:
 		action = "keep"
-		reason = "active Bazel process or output-base lock detected"
+		if candidate.Reason != "" {
+			reason = candidate.Reason
+		} else {
+			reason = "active Bazel process or output-base lock detected"
+		}
 	case level == LevelWarning:
 		action = "review"
 		reason = "warning level reports Bazel cache footprint only"
@@ -544,7 +641,7 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 			action = "delete_cache_tier"
 			reason = "cache tier exceeds budget and is older than configured Bazel stale threshold"
 		}
-	case candidate.ModTime.After(now.Add(-staleAfter)):
+	case !stale:
 		action = "keep"
 		protected = true
 		reason = "newer than configured Bazel stale threshold"
@@ -584,11 +681,21 @@ func bazelCandidateTier(candidateType string) string {
 func bazelEstimatedCandidateBytes(targets []CleanupTarget) int64 {
 	var total int64
 	for _, target := range targets {
-		if strings.HasPrefix(target.Action, "delete_") && !target.Protected && !target.Active {
+		if bazelTargetReclaimsHost(target) {
 			total += target.Bytes
 		}
 	}
 	return total
+}
+
+func bazelTargetReclaimsHost(target CleanupTarget) bool {
+	if target.Protected {
+		return false
+	}
+	if target.Action == "stop_idle_server_then_delete_output_base" {
+		return target.Type == "output_base"
+	}
+	return strings.HasPrefix(target.Action, "delete_") && !target.Active
 }
 
 func applyBazelCleanupTargets(ctx context.Context, plugin string, level CleanupLevel, targets []CleanupTarget, workspaceRoots []string, home string, logger *slog.Logger) CleanupResult {
@@ -601,7 +708,7 @@ func applyBazelCleanupTargets(ctx context.Context, plugin string, level CleanupL
 			result.Error = err
 			return result
 		}
-		if err := deleteBazelTarget(target, logger); err != nil {
+		if err := deleteBazelTarget(ctx, target, logger); err != nil {
 			logger.Warn("failed to delete Bazel target", "type", target.Type, "path", target.Path, "error", err)
 			continue
 		}
@@ -620,11 +727,16 @@ func applyBazelCleanupTargets(ctx context.Context, plugin string, level CleanupL
 }
 
 func bazelTargetEligibleForDeletion(target CleanupTarget) bool {
-	if target.Path == "" || target.Active || target.Protected {
+	if target.Path == "" || target.Protected {
+		return false
+	}
+	if target.Active && target.Action != "stop_idle_server_then_delete_output_base" {
 		return false
 	}
 	switch target.Action {
 	case "delete_output_base":
+		return target.Type == "output_base"
+	case "stop_idle_server_then_delete_output_base":
 		return target.Type == "output_base"
 	case "delete_cache_tier":
 		return target.Type == "repository_cache" || target.Type == "disk_cache" || target.Type == "bazelisk"
@@ -633,7 +745,10 @@ func bazelTargetEligibleForDeletion(target CleanupTarget) bool {
 	}
 }
 
-func deleteBazelTarget(target CleanupTarget, logger *slog.Logger) error {
+func deleteBazelTarget(ctx context.Context, target CleanupTarget, logger *slog.Logger) error {
+	if target.Action == "stop_idle_server_then_delete_output_base" {
+		return stopIdleBazelServerThenDeleteOutputBase(ctx, target.Path, logger)
+	}
 	switch target.Type {
 	case "output_base":
 		return deleteBazelOutputBase(target.Path, logger)
@@ -642,6 +757,37 @@ func deleteBazelTarget(target CleanupTarget, logger *slog.Logger) error {
 	default:
 		return fmt.Errorf("refusing to delete unsupported Bazel target type %q", target.Type)
 	}
+}
+
+func stopIdleBazelServerThenDeleteOutputBase(ctx context.Context, path string, logger *slog.Logger) error {
+	if err := shutdownBazelOutputBase(ctx, path, logger); err != nil {
+		return err
+	}
+	if activity := bazelOutputBaseActivity(path); activity.Active {
+		return fmt.Errorf("refusing to delete output base after shutdown because it is still active: %s", activity.Reason)
+	}
+	return deleteBazelOutputBase(path, logger)
+}
+
+func shutdownBazelOutputBase(ctx context.Context, path string, logger *slog.Logger) error {
+	bin, err := exec.LookPath("bazel")
+	if err != nil {
+		bin, err = exec.LookPath("bazelisk")
+	}
+	if err != nil {
+		return fmt.Errorf("cannot stop idle Bazel server because neither bazel nor bazelisk is on PATH")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(shutdownCtx, bin, "--output_base="+path, "shutdown")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bazel shutdown failed for %s: %w: %s", path, err, strings.TrimSpace(string(output)))
+	}
+	logger.Info("stopped idle Bazel server", "output_base", path)
+	return nil
 }
 
 func deleteBazelOutputBase(path string, logger *slog.Logger) error {
@@ -807,6 +953,8 @@ func bazelBusyProcessReasons(output string) []string {
 func bazelBusyProcessInfo(output string) bazelProcessInfo {
 	reasonSeen := map[string]bool{}
 	outputBaseSeen := map[string]bool{}
+	clientOutputBaseSeen := map[string]bool{}
+	serverOutputBaseSeen := map[string]bool{}
 	var info bazelProcessInfo
 	for _, line := range strings.Split(output, "\n") {
 		originalFields := strings.Fields(line)
@@ -815,8 +963,10 @@ func bazelBusyProcessInfo(output string) bazelProcessInfo {
 			continue
 		}
 
+		var outputBases []string
 		if bazelProcessLineHasBazel(originalFields) {
-			for _, outputBase := range bazelOutputBaseArgs(originalFields) {
+			outputBases = bazelOutputBaseArgs(originalFields)
+			for _, outputBase := range outputBases {
 				if !outputBaseSeen[outputBase] {
 					outputBaseSeen[outputBase] = true
 					info.OutputBases = append(info.OutputBases, outputBase)
@@ -831,7 +981,14 @@ func bazelBusyProcessInfo(output string) bazelProcessInfo {
 		}
 		normalized := strings.Join(lowerFields[1:], " ")
 		matches := bazelCommandPattern.FindStringSubmatch(normalized)
+		activeClient := false
 		if len(matches) < 3 {
+			for _, outputBase := range outputBases {
+				if !serverOutputBaseSeen[outputBase] {
+					serverOutputBaseSeen[outputBase] = true
+					info.ServerOutputBases = append(info.ServerOutputBases, outputBase)
+				}
+			}
 			continue
 		}
 		reason := matches[1] + " " + matches[2]
@@ -839,10 +996,38 @@ func bazelBusyProcessInfo(output string) bazelProcessInfo {
 			reasonSeen[reason] = true
 			info.Reasons = append(info.Reasons, reason)
 		}
+		activeClient = true
+		if activeClient {
+			for _, outputBase := range outputBases {
+				if !clientOutputBaseSeen[outputBase] {
+					clientOutputBaseSeen[outputBase] = true
+					info.ClientOutputBases = append(info.ClientOutputBases, outputBase)
+				}
+			}
+		}
 	}
 	sort.Strings(info.Reasons)
 	sort.Strings(info.OutputBases)
+	sort.Strings(info.ClientOutputBases)
+	sort.Strings(info.ServerOutputBases)
 	return info
+}
+
+func bazelProcessOutputBaseKinds(info bazelProcessInfo) map[string]string {
+	kinds := map[string]string{}
+	for _, outputBase := range info.ServerOutputBases {
+		kinds[filepath.Clean(outputBase)] = "server"
+	}
+	for _, outputBase := range info.ClientOutputBases {
+		kinds[filepath.Clean(outputBase)] = "client"
+	}
+	for _, outputBase := range info.OutputBases {
+		cleaned := filepath.Clean(outputBase)
+		if _, ok := kinds[cleaned]; !ok {
+			kinds[cleaned] = "unknown"
+		}
+	}
+	return kinds
 }
 
 func bazelProcessLineHasBazel(fields []string) bool {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -48,7 +49,10 @@ func TestDiscoverBazelCandidatesIncludesProcessOutputBases(t *testing.T) {
 	outputBase := filepath.Join(root, "process-ob")
 	makeBazelOutputBase(t, outputBase)
 
-	candidates := NewBazelPlugin().discoverCandidates(root, config.BazelConfig{}, []string{outputBase})
+	candidates := NewBazelPlugin().discoverCandidates(root, config.BazelConfig{}, bazelProcessInfo{
+		OutputBases:       []string{outputBase},
+		ClientOutputBases: []string{outputBase},
+	})
 	if len(candidates) != 1 {
 		t.Fatalf("got %d candidates, want 1: %#v", len(candidates), candidates)
 	}
@@ -57,10 +61,10 @@ func TestDiscoverBazelCandidatesIncludesProcessOutputBases(t *testing.T) {
 		t.Fatal(err)
 	}
 	candidate := candidates[0]
-	if candidate.Type != "output_base" || candidate.Path != resolvedOutputBase || !candidate.Active {
+	if candidate.Type != "output_base" || candidate.Path != resolvedOutputBase || !candidate.Active || !candidate.ActiveClient {
 		t.Fatalf("unexpected process output-base candidate: %#v", candidate)
 	}
-	if candidate.Reason != "discovered from active Bazel process --output_base" {
+	if candidate.Reason != "discovered from active Bazel client --output_base" {
 		t.Fatalf("unexpected reason: %q", candidate.Reason)
 	}
 }
@@ -274,6 +278,62 @@ func TestBazelPlanTargetsDoesNotUseIdleServerAsGlobalCacheActivity(t *testing.T)
 	}
 }
 
+func TestBazelPlanTargetsCanStopIdleServerBeforeDeletingStaleOutputBase(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cfg := config.BazelConfig{
+		StaleAfter:                   "14d",
+		CriticalStaleAfter:           "3d",
+		AllowStopIdleServers:         true,
+		AllowDeleteActiveOutputBases: false,
+		KeepRecentOutputBases:        0,
+	}
+	candidates := []bazelCandidate{
+		{
+			Type:          "output_base",
+			Name:          "idle-server-output-base",
+			Path:          "/tmp/idle-server-output-base",
+			ModTime:       now.Add(-30 * 24 * time.Hour),
+			Physical:      2 * bazelGiB,
+			Active:        true,
+			IdleServer:    true,
+			ProcessServer: true,
+		},
+	}
+
+	targets, _ := bazelPlanTargets(candidates, cfg, LevelAggressive, now, false)
+	if len(targets) != 1 {
+		t.Fatalf("expected one target, got %d", len(targets))
+	}
+	target := targets[0]
+	if target.Action != "stop_idle_server_then_delete_output_base" || target.Protected || !target.Active {
+		t.Fatalf("idle server output base should be a guarded shutdown/delete candidate: %#v", target)
+	}
+	if target.Reclaim != CleanupReclaimHost || target.HostReclaimsSpace == nil || !*target.HostReclaimsSpace {
+		t.Fatalf("idle server shutdown/delete should advertise host reclaim: %#v", target)
+	}
+	if got := bazelEstimatedCandidateBytes(targets); got != 2*bazelGiB {
+		t.Fatalf("estimated reclaim = %d, want %d", got, 2*bazelGiB)
+	}
+
+	targets, _ = bazelPlanTargets(candidates, cfg, LevelModerate, now, false)
+	if targets[0].Action != "keep" || !targets[0].Protected {
+		t.Fatalf("moderate level should not stop idle Bazel servers: %#v", targets[0])
+	}
+
+	cfg.AllowStopIdleServers = false
+	targets, _ = bazelPlanTargets(candidates, cfg, LevelAggressive, now, false)
+	if targets[0].Action != "keep" || !targets[0].Protected {
+		t.Fatalf("disabled idle-server stop should keep target protected: %#v", targets[0])
+	}
+
+	cfg.AllowStopIdleServers = true
+	candidates[0].ProcessServer = false
+	targets, _ = bazelPlanTargets(candidates, cfg, LevelAggressive, now, false)
+	if targets[0].Action != "keep" || !targets[0].Protected {
+		t.Fatalf("pid-only server evidence should keep target protected: %#v", targets[0])
+	}
+}
+
 func TestDiscoverBazeliskCandidatesPrefersSha256Downloads(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "bazelisk")
 	sha := filepath.Join(root, "downloads", "sha256", "abc123")
@@ -355,6 +415,12 @@ bazel(workspace) bazel(workspace) --output_base=/private/tmp/workspace-ob --work
 			t.Fatalf("got output bases %v, want %v", info.OutputBases, want)
 		}
 	}
+	if len(info.ClientOutputBases) != 1 || info.ClientOutputBases[0] != "/private/var/tmp/_bazel_test/hash" {
+		t.Fatalf("unexpected client output bases: %v", info.ClientOutputBases)
+	}
+	if len(info.ServerOutputBases) != 1 || info.ServerOutputBases[0] != "/private/tmp/workspace-ob" {
+		t.Fatalf("unexpected server output bases: %v", info.ServerOutputBases)
+	}
 }
 
 func TestBazelBusyProcessInfoSeparatesServerOutputBasesFromClientCommands(t *testing.T) {
@@ -367,6 +433,12 @@ bazel(workspace) bazel(workspace) --output_base=/private/tmp/workspace-ob --work
 	}
 	if len(info.OutputBases) != 1 || info.OutputBases[0] != "/private/tmp/workspace-ob" {
 		t.Fatalf("unexpected output bases: %v", info.OutputBases)
+	}
+	if len(info.ClientOutputBases) != 0 {
+		t.Fatalf("server process should not report client output bases: %v", info.ClientOutputBases)
+	}
+	if len(info.ServerOutputBases) != 1 || info.ServerOutputBases[0] != "/private/tmp/workspace-ob" {
+		t.Fatalf("unexpected server output bases: %v", info.ServerOutputBases)
 	}
 }
 
@@ -416,6 +488,55 @@ func TestApplyBazelCleanupTargetsDeletesEligibleOutputBase(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Join(workspace, "bazel-bin")); !os.IsNotExist(err) {
 		t.Fatalf("expected repo-local bazel-bin symlink to be removed, stat err=%v", err)
+	}
+}
+
+func TestApplyBazelCleanupTargetsStopsIdleServerBeforeDeletingOutputBase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bazel shell script is Unix-only")
+	}
+	root := t.TempDir()
+	outputBase := filepath.Join(root, "_bazel_jess", "stale-idle")
+	makeBazelOutputBase(t, outputBase)
+
+	binDir := filepath.Join(root, "bin")
+	mustMkdir(t, binDir)
+	argsPath := filepath.Join(root, "bazel-args")
+	fakeBazel := filepath.Join(binDir, "bazel")
+	if err := os.WriteFile(fakeBazel, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$BAZEL_SHUTDOWN_ARGS\"\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BAZEL_SHUTDOWN_ARGS", argsPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := applyBazelCleanupTargets(context.Background(), "bazel", LevelAggressive, []CleanupTarget{
+		{
+			Type:   "output_base",
+			Name:   "stale-idle",
+			Path:   outputBase,
+			Bytes:  123,
+			Active: true,
+			Action: "stop_idle_server_then_delete_output_base",
+		},
+	}, nil, root, logger)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.ItemsCleaned != 1 {
+		t.Fatalf("items cleaned = %d, want 1", result.ItemsCleaned)
+	}
+	if _, err := os.Stat(outputBase); !os.IsNotExist(err) {
+		t.Fatalf("expected output base to be deleted, stat err=%v", err)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs := "--output_base=" + outputBase + "\nshutdown\n"
+	if string(args) != wantArgs {
+		t.Fatalf("shutdown args = %q, want %q", string(args), wantArgs)
 	}
 }
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -159,6 +159,7 @@ func hostReclaimExpectation(reclaim string) *bool {
 func hostReclaimForAction(action string) string {
 	switch {
 	case strings.HasPrefix(action, "delete"),
+		action == "stop_idle_server_then_delete_output_base",
 		action == "clean-cache",
 		action == "clean-stale-files",
 		action == "thin_local_snapshots":


### PR DESCRIPTION
## Summary

- distinguish active Bazel client output bases from server-only output bases in process inspection
- classify stale server-only output bases as `stop_idle_server_then_delete_output_base` only at aggressive/critical levels when `allow_stop_idle_servers` is enabled
- run `bazel --output_base=<path> shutdown`, re-check activity, and delete only if the output base is no longer active
- document the new Bazel policy boundary and update changelog/tests

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run TestBazel`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go run . --once --dry-run --level critical --plugins bazel --output text`

## Notes

The stop/delete path requires process-visible server-only `--output_base` evidence. A live `server.pid` without process-visible server evidence remains protected rather than being stopped automatically.
