### PR TITLE
[codex] Report large temporary dev artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ All notable changes to this project will be documented in this file.
   server-only output bases, and aggressive/critical cleanup can stop stale idle
   servers before deleting their output bases when `allow_stop_idle_servers` is
   enabled.
+- Dev-artifacts dry-runs now surface large top-level temporary proof/output
+  directories as protected review-only targets with active process path
+  evidence.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Constrain review to specific plugins before scanning broad cache surfaces:
 tinyland-cleanup --once --dry-run --level critical --plugins bazel,nix --output text
 ```
 
+For temporary proof/output pressure, keep the review bounded:
+
+```sh
+tinyland-cleanup --once --dry-run --level critical --plugins dev-artifacts --output text
+```
+
 For a one-off run, override the configured maximum used-space target without
 editing the config file:
 

--- a/config/config.go
+++ b/config/config.go
@@ -246,6 +246,14 @@ type ICloudConfig struct {
 type DevArtifactsConfig struct {
 	// ScanPaths is the list of directories to scan for dev artifacts
 	ScanPaths []string `yaml:"scan_paths"`
+	// TempArtifacts enables review-only reporting for large top-level temp artifacts
+	TempArtifacts bool `yaml:"temp_artifacts"`
+	// TempScanPaths are top-level temporary directories scanned for large generated artifacts
+	TempScanPaths []string `yaml:"temp_scan_paths"`
+	// TempArtifactMinMB is the minimum physical size for review-only temporary artifact targets
+	TempArtifactMinMB int `yaml:"temp_artifact_min_mb"`
+	// TempArtifactStaleAfter is the age after which temp artifacts become review candidates
+	TempArtifactStaleAfter string `yaml:"temp_artifact_stale_after"`
 	// NodeModules enables node_modules cleanup
 	NodeModules bool `yaml:"node_modules"`
 	// PythonVenvs enables .venv cleanup
@@ -338,6 +346,10 @@ func DefaultConfig() *Config {
 		filepath.Join(home, "src"),
 		filepath.Join(home, "projects"),
 	}
+	defaultTempScanPaths := []string{"/tmp"}
+	if runtime.GOOS == "darwin" {
+		defaultTempScanPaths = []string{"/private/tmp"}
+	}
 	bazeliskCache := filepath.Join(home, ".cache", "bazelisk")
 	if runtime.GOOS == "darwin" {
 		bazeliskCache = filepath.Join(home, "Library", "Caches", "bazelisk")
@@ -423,6 +435,10 @@ func DefaultConfig() *Config {
 		},
 		DevArtifacts: DevArtifactsConfig{
 			ScanPaths:               defaultScanPaths,
+			TempArtifacts:           true,
+			TempScanPaths:           defaultTempScanPaths,
+			TempArtifactMinMB:       256,
+			TempArtifactStaleAfter:  "6h",
 			NodeModules:             true,
 			PythonVenvs:             true,
 			RustTargets:             true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -324,6 +324,23 @@ func TestBazelPolicyDefaults(t *testing.T) {
 	}
 }
 
+func TestDevArtifactPolicyDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if !cfg.DevArtifacts.TempArtifacts {
+		t.Error("DevArtifacts.TempArtifacts should default to true")
+	}
+	if len(cfg.DevArtifacts.TempScanPaths) == 0 {
+		t.Fatal("DevArtifacts.TempScanPaths should have defaults")
+	}
+	if cfg.DevArtifacts.TempArtifactMinMB != 256 {
+		t.Errorf("DevArtifacts.TempArtifactMinMB should default to 256, got %d", cfg.DevArtifacts.TempArtifactMinMB)
+	}
+	if cfg.DevArtifacts.TempArtifactStaleAfter != "6h" {
+		t.Errorf("DevArtifacts.TempArtifactStaleAfter should default to 6h, got %q", cfg.DevArtifacts.TempArtifactStaleAfter)
+	}
+}
+
 func TestDarwinDevCacheDefaults(t *testing.T) {
 	cfg := DefaultConfig()
 	if runtime.GOOS == "darwin" && !cfg.DarwinDevCaches.Enabled {
@@ -385,6 +402,11 @@ dev_artifacts:
   scan_paths:
     - ~/git
     - ~/src
+  temp_artifacts: false
+  temp_scan_paths:
+    - /tmp/tinyland-cleanup
+  temp_artifact_min_mb: 128
+  temp_artifact_stale_after: 2h
   node_modules: true
   python_venvs: true
   rust_targets: false
@@ -479,6 +501,18 @@ darwin_dev_caches:
 	}
 	if len(cfg.DevArtifacts.ScanPaths) != 2 {
 		t.Errorf("expected 2 scan paths, got %d", len(cfg.DevArtifacts.ScanPaths))
+	}
+	if cfg.DevArtifacts.TempArtifacts {
+		t.Error("DevArtifacts.TempArtifacts should be false per config")
+	}
+	if len(cfg.DevArtifacts.TempScanPaths) != 1 || cfg.DevArtifacts.TempScanPaths[0] != "/tmp/tinyland-cleanup" {
+		t.Errorf("unexpected DevArtifacts.TempScanPaths: %#v", cfg.DevArtifacts.TempScanPaths)
+	}
+	if cfg.DevArtifacts.TempArtifactMinMB != 128 {
+		t.Errorf("DevArtifacts.TempArtifactMinMB should be 128 per config, got %d", cfg.DevArtifacts.TempArtifactMinMB)
+	}
+	if cfg.DevArtifacts.TempArtifactStaleAfter != "2h" {
+		t.Errorf("DevArtifacts.TempArtifactStaleAfter should be 2h per config, got %q", cfg.DevArtifacts.TempArtifactStaleAfter)
 	}
 	if cfg.DevArtifacts.RustTargets {
 		t.Error("DevArtifacts.RustTargets should be false per config")

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -148,6 +148,13 @@ dev_artifacts:
     - ~/git
     - ~/src
     - ~/projects
+  # Review-only: surface large top-level temp proof/output trees without
+  # deleting them automatically. Darwin compiled defaults use /private/tmp.
+  temp_artifacts: true
+  temp_scan_paths:
+    - /private/tmp
+  temp_artifact_min_mb: 256
+  temp_artifact_stale_after: 6h
   node_modules: true
   python_venvs: true
   rust_targets: true

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -181,12 +181,16 @@ targets with their mount point so operators know to detach them before any
 manual cleanup or compaction. Sparsebundle targets also report logical size
 from `Info.plist` when available; detached APFS sparsebundles may still reject
 `hdiutil compact`, so treat them as manual migrate/delete decisions rather than
-automatic reclaim. The plan also protects matching artifact families when
-active package manager, compiler, language server, runtime, or LM Studio
-processes are visible, and it preserves any candidate artifact directory that
-contains files tracked by Git. Zig `.zig-cache` and `zig-out` targets are also
-preserved when they contain files modified within the recent-output grace
-window, even at critical pressure.
+automatic reclaim. The plan also surfaces large top-level temporary
+proof/output directories from configured `dev_artifacts.temp_scan_paths`, but
+those targets are review-only and excluded from estimated reclaim; active
+process command lines that reference the temp root mark the target active and
+protected. The plan also protects matching artifact families when active
+package manager, compiler, language server, runtime, or LM Studio processes are
+visible, and it preserves any candidate artifact directory that contains files
+tracked by Git. Zig `.zig-cache` and `zig-out` targets are also preserved when
+they contain files modified within the recent-output grace window, even at
+critical pressure.
 
 For Docker, the plan reports Docker daemon disk-usage rows from `docker system
 df`, including images, stopped containers, local volumes, and build cache when

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -90,6 +90,12 @@ dev_artifacts:
     - ~/git
     - ~/src
     - ~/projects
+  temp_artifacts: true
+  temp_scan_paths:
+    - /tmp
+    - /var/tmp
+  temp_artifact_min_mb: 512
+  temp_artifact_stale_after: 12h
   node_modules: true
   python_venvs: true
   rust_targets: false

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,6 +24,8 @@ import (
 )
 
 const devArtifactRecentOutputGrace = 2 * time.Hour
+
+var tempArtifactPathPattern = regexp.MustCompile(`(?:/private)?/tmp/[^\s"'<>]+|/var/tmp/[^\s"'<>]+`)
 
 // DevArtifactsPlugin handles stale development artifact cleanup.
 type DevArtifactsPlugin struct {
@@ -68,14 +71,16 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 		WouldRun: true,
 		Steps: []string{
 			"Scan configured development workspaces for rebuildable artifact directories",
+			"Surface large top-level temporary proof/output directories for manual review without deleting them",
 			"Use project marker mtimes to classify stale node_modules, .venv, Rust target, and Zig artifact directories",
 			"Protect artifact families when matching package manager, compiler, language server, or runtime processes are active",
 			"Report large disk images and VM bundles for manual review without deleting them",
 			"Honor configured protected paths before any deletion candidate is eligible",
 		},
 		Metadata: map[string]string{
-			"scan_path_count": strconv.Itoa(len(daCfg.ScanPaths)),
-			"mutates":         strconv.FormatBool(mutates),
+			"scan_path_count":      strconv.Itoa(len(daCfg.ScanPaths)),
+			"temp_scan_path_count": strconv.Itoa(len(daCfg.TempScanPaths)),
+			"mutates":              strconv.FormatBool(mutates),
 		},
 	}
 	if !mutates {
@@ -96,6 +101,18 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 	}
 
 	var targets []CleanupTarget
+	if daCfg.TempArtifacts {
+		activeTempRoots := activeTempArtifactRoots(ctx, daCfg.TempScanPaths, home)
+		tempMinBytes := tempArtifactMinBytes(daCfg)
+		tempStaleAfter := parseNixPolicyDuration(daCfg.TempArtifactStaleAfter, 6*time.Hour)
+		for _, scanPath := range daCfg.TempScanPaths {
+			expanded := expandHome(scanPath, home)
+			if !pathExistsAndIsDir(expanded) {
+				continue
+			}
+			p.planTemporaryArtifacts(expanded, tempMinBytes, tempStaleAfter, daCfg.ProtectPaths, activeTempRoots, &targets)
+		}
+	}
 	for _, scanPath := range daCfg.ScanPaths {
 		expanded := expandHome(scanPath, home)
 		if !pathExistsAndIsDir(expanded) {
@@ -303,6 +320,66 @@ func (p *DevArtifactsPlugin) planLargeLocalArtifacts(scanPath string, minBytes i
 	p.findLargeLocalArtifacts(scanPath, minBytes, protectPaths, mountedImages, func(target CleanupTarget) {
 		*targets = append(*targets, target)
 	})
+}
+
+func (p *DevArtifactsPlugin) planTemporaryArtifacts(scanPath string, minBytes int64, staleAfter time.Duration, protectPaths []string, activeRoots map[string]string, targets *[]CleanupTarget) {
+	entries, err := os.ReadDir(scanPath)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(scanPath, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		size := getDirAllocatedBytes(path)
+		if size < minBytes {
+			continue
+		}
+		*targets = append(*targets, p.temporaryArtifactTarget(path, size, info.ModTime(), staleAfter, now, p.isProtected(path, protectPaths), activeRoots[canonicalTempArtifactPath(path)]))
+	}
+}
+
+func (p *DevArtifactsPlugin) temporaryArtifactTarget(path string, physicalBytes int64, modTime time.Time, staleAfter time.Duration, now time.Time, protected bool, activeReason string) CleanupTarget {
+	action := "review_temp_artifact"
+	reason := fmt.Sprintf("large top-level temporary artifact is older than %s; manual review required before deletion", formatDevArtifactAge(staleAfter))
+	active := activeReason != ""
+	isProtected := true
+	switch {
+	case active:
+		action = "protect"
+		reason = "active process references this temporary path: " + activeReason
+	case protected:
+		action = "protect"
+		reason = "path is covered by dev_artifacts.protect_paths"
+	case staleAfter > 0 && modTime.After(now.Add(-staleAfter)):
+		action = "protect"
+		reason = fmt.Sprintf("temporary artifact is newer than %s", formatDevArtifactAge(staleAfter))
+	}
+	target := CleanupTarget{
+		Type:      "temporary-dev-artifact",
+		Name:      filepath.Base(path),
+		Path:      path,
+		Bytes:     physicalBytes,
+		Active:    active,
+		Protected: isProtected,
+		Action:    action,
+		Reason:    reason,
+	}
+	annotateCleanupTargetPolicy(&target, CleanupTierDestructive, CleanupReclaimNone)
+	return target
+}
+
+func tempArtifactMinBytes(cfg config.DevArtifactsConfig) int64 {
+	if cfg.TempArtifactMinMB <= 0 {
+		return 256 * 1024 * 1024
+	}
+	return int64(cfg.TempArtifactMinMB) * 1024 * 1024
 }
 
 func (p *DevArtifactsPlugin) findLargeLocalArtifacts(scanPath string, minBytes int64, protectPaths []string, mountedImages map[string]string, callback func(CleanupTarget)) {
@@ -797,6 +874,73 @@ func devArtifactBusyProcessReasons(output string) map[string]string {
 		}
 	}
 	return active
+}
+
+func activeTempArtifactRoots(ctx context.Context, scanPaths []string, home string) map[string]string {
+	if len(scanPaths) == 0 {
+		return nil
+	}
+	psCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(psCtx, "ps", "-axo", "comm=,args=")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	return tempArtifactRootsFromProcessOutput(string(output), scanPaths, home)
+}
+
+func tempArtifactRootsFromProcessOutput(output string, scanPaths []string, home string) map[string]string {
+	roots := map[string]string{}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		command := filepath.Base(fields[0])
+		if len(fields) > 1 {
+			command = filepath.Base(fields[1])
+		}
+		for _, rawPath := range tempArtifactPathPattern.FindAllString(line, -1) {
+			if root := tempArtifactRootForPath(rawPath, scanPaths, home); root != "" {
+				if _, ok := roots[root]; !ok {
+					roots[root] = command
+				}
+			}
+		}
+	}
+	return roots
+}
+
+func tempArtifactRootForPath(path string, scanPaths []string, home string) string {
+	path = canonicalTempArtifactPath(path)
+	for _, scanPath := range scanPaths {
+		root := canonicalTempArtifactPath(expandHome(scanPath, home))
+		rel, err := filepath.Rel(root, path)
+		if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			continue
+		}
+		first := strings.Split(rel, string(os.PathSeparator))[0]
+		if first == "" || first == "." || first == ".." {
+			continue
+		}
+		return filepath.Join(root, first)
+	}
+	return ""
+}
+
+func canonicalTempArtifactPath(path string) string {
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	if strings.HasPrefix(path, "/tmp/") {
+		if resolved, err := filepath.EvalSymlinks("/tmp"); err == nil {
+			return filepath.Join(resolved, strings.TrimPrefix(path, "/tmp/"))
+		}
+	}
+	return path
 }
 
 func devArtifactActivityReasons(active map[string]string) []string {

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -547,6 +547,7 @@ func TestPlanCleanupWarningReportsDevArtifacts(t *testing.T) {
 	cfg.DevArtifacts.ZigArtifacts = false
 	cfg.DevArtifacts.GoBuildCache = false
 	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.TempArtifacts = false
 
 	plan := p.PlanCleanup(context.Background(), LevelWarning, cfg, logger)
 	target := findDevArtifactTarget(t, plan.Targets, "node_modules", filepath.Join(project, "node_modules"))
@@ -593,6 +594,7 @@ func TestPlanCleanupModerateClassifiesDevArtifacts(t *testing.T) {
 	cfg.DevArtifacts.ZigArtifacts = false
 	cfg.DevArtifacts.GoBuildCache = false
 	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.TempArtifacts = false
 	cfg.DevArtifacts.ProtectPaths = []string{protectedProject}
 
 	plan := p.PlanCleanup(context.Background(), LevelModerate, cfg, logger)
@@ -785,6 +787,61 @@ func TestPlanLargeLocalArtifactsHonorsProtectPaths(t *testing.T) {
 	target := findDevArtifactTarget(t, targets, "large-local-artifact", imagePath)
 	if target.Action != "protect" || !target.Protected {
 		t.Fatalf("expected protected large local artifact target, got %#v", target)
+	}
+}
+
+func TestPlanTemporaryArtifactsReportsReviewOnlyTargets(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	oldPath := filepath.Join(tmpDir, "old-proof-output")
+	freshPath := filepath.Join(tmpDir, "fresh-proof-output")
+	activePath := filepath.Join(tmpDir, "active-proof-output")
+	for _, path := range []string{oldPath, freshPath, activePath} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "artifact"), []byte("artifact"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldTime := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	p.planTemporaryArtifacts(tmpDir, 1, 6*time.Hour, nil, map[string]string{
+		canonicalTempArtifactPath(activePath): "bazel",
+	}, &targets)
+
+	oldTarget := findDevArtifactTarget(t, targets, "temporary-dev-artifact", oldPath)
+	if oldTarget.Action != "review_temp_artifact" || !oldTarget.Protected || oldTarget.Tier != CleanupTierDestructive || oldTarget.Reclaim != CleanupReclaimNone {
+		t.Fatalf("expected review-only temporary artifact target, got %#v", oldTarget)
+	}
+	if !strings.Contains(oldTarget.Reason, "manual review required") {
+		t.Fatalf("expected manual review reason, got %q", oldTarget.Reason)
+	}
+
+	freshTarget := findDevArtifactTarget(t, targets, "temporary-dev-artifact", freshPath)
+	if freshTarget.Action != "protect" || !freshTarget.Protected {
+		t.Fatalf("expected fresh temporary artifact to be protected, got %#v", freshTarget)
+	}
+
+	activeTarget := findDevArtifactTarget(t, targets, "temporary-dev-artifact", activePath)
+	if activeTarget.Action != "protect" || !activeTarget.Protected || !activeTarget.Active {
+		t.Fatalf("expected active temporary artifact to be protected, got %#v", activeTarget)
+	}
+}
+
+func TestTempArtifactRootsFromProcessOutput(t *testing.T) {
+	output := `
+bazel(workspace) bazel(workspace) --output_user_root=/tmp/crush-dots-bazel-output --output_base=/tmp/crush-dots-bazel-output/817/output
+/usr/bin/zsh zsh -lc echo /tmp/not-active
+`
+	roots := tempArtifactRootsFromProcessOutput(output, []string{"/tmp"}, "")
+	want := tempArtifactRootForPath("/tmp/crush-dots-bazel-output/817/output", []string{"/tmp"}, "")
+	if roots[want] != "bazel(workspace)" {
+		t.Fatalf("expected active root %q from bazel process, got %#v", want, roots)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add review-only `dev-artifacts` planning for large top-level temp proof/output directories
- add config defaults for `temp_artifacts`, `temp_scan_paths`, `temp_artifact_min_mb`, and `temp_artifact_stale_after`
- mark temp roots active/protected when visible process command lines reference them
- keep temp artifact targets protected with `reclaim=none`; this PR adds operator evidence, not automatic deletion
- update defaults, Linux packaging config, docs, changelog, and tests

## Local dogfood

A bounded Darwin dry-run with a throwaway `HOME` surfaced `/private/tmp/crush-dots-bazel-output` as active/protected because `bazel(lab)` referenced it, and listed other large temp proof/cache dirs as protected review-only targets with no estimated reclaim.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./config ./plugins -run 'TestDevArtifact|TestPlanTemporary|TestTempArtifact|TestPlanCleanup'`
- `env HOME=/tmp/tinyland-cleanup-dry-home GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go run . --once --dry-run --level critical --plugins dev-artifacts --output text`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
