### PR TITLE
Prune generated artifacts inside temp roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ All notable changes to this project will be documented in this file.
   server-only output bases, and aggressive/critical cleanup can stop stale idle
   servers before deleting their output bases when `allow_stop_idle_servers` is
   enabled.
+- Dev-artifact cleanup now scans stale inactive temporary roots for narrower
+  generated-output targets, allowing Rust `target/`, `node_modules`, Python
+  virtualenv, and Zig output pruning without deleting the top-level temp root.
 - Dev-artifacts dry-runs now surface large top-level temporary proof/output
   directories as protected review-only targets with active process path
   evidence.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ For temporary proof/output pressure, keep the review bounded:
 tinyland-cleanup --once --dry-run --level critical --plugins dev-artifacts --output text
 ```
 
+Large top-level temp roots remain review-only, but stale inactive roots may
+also expose narrower generated-output targets such as Rust `target/`
+directories for safe pruning without deleting the worktree.
+
 For a one-off run, override the configured maximum used-space target without
 editing the config file:
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -183,9 +183,13 @@ from `Info.plist` when available; detached APFS sparsebundles may still reject
 `hdiutil compact`, so treat them as manual migrate/delete decisions rather than
 automatic reclaim. The plan also surfaces large top-level temporary
 proof/output directories from configured `dev_artifacts.temp_scan_paths`, but
-those targets are review-only and excluded from estimated reclaim; active
-process command lines that reference the temp root mark the target active and
-protected. The plan also protects matching artifact families when active
+those root targets are review-only and excluded from estimated reclaim. For
+stale inactive temporary roots, known generated subdirectories such as Rust
+`target/`, `node_modules`, Python virtualenvs, and Zig outputs can still appear
+as narrower reclaim candidates so cleanup can preserve the worktree or proof
+root while pruning rebuildable output. Active process command lines that
+reference the temp root mark the root active and suppress nested generated
+cleanup. The plan also protects matching artifact families when active
 package manager, compiler, language server, runtime, or LM Studio processes are
 visible, and it preserves any candidate artifact directory that contains files
 tracked by Git. Zig `.zig-cache` and `zig-out` targets are also preserved when

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -111,6 +111,7 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 				continue
 			}
 			p.planTemporaryArtifacts(expanded, tempMinBytes, tempStaleAfter, daCfg.ProtectPaths, activeTempRoots, &targets)
+			p.planTemporaryGeneratedArtifacts(expanded, tempMinBytes, tempStaleAfter, nodeAge, venvAge, rustAge, zigAge, mutates, daCfg, active, activeTempRoots, tracker, &targets)
 		}
 	}
 	for _, scanPath := range daCfg.ScanPaths {
@@ -233,6 +234,23 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 		}
 	}
 
+	if daCfg.TempArtifacts {
+		activeTempRoots := activeTempArtifactRoots(ctx, daCfg.TempScanPaths, home)
+		tempMinBytes := tempArtifactMinBytes(daCfg)
+		tempStaleAfter := parseNixPolicyDuration(daCfg.TempArtifactStaleAfter, 6*time.Hour)
+		for _, scanPath := range daCfg.TempScanPaths {
+			expanded := expandHome(scanPath, home)
+			if !pathExistsAndIsDir(expanded) {
+				continue
+			}
+			freed := p.cleanTemporaryGeneratedArtifacts(ctx, expanded, tempMinBytes, tempStaleAfter, nodeAge, venvAge, rustAge, zigAge, daCfg, active, activeTempRoots, tracker, logger)
+			result.BytesFreed += freed
+			if freed > 0 {
+				result.ItemsCleaned++
+			}
+		}
+	}
+
 	// Go build cache (not path-dependent - it's a global cache)
 	if daCfg.GoBuildCache && !devArtifactFamilyActive(active, "go-build-cache") {
 		freed := p.cleanGoBuildCache(ctx, level, logger)
@@ -342,6 +360,74 @@ func (p *DevArtifactsPlugin) planTemporaryArtifacts(scanPath string, minBytes in
 			continue
 		}
 		*targets = append(*targets, p.temporaryArtifactTarget(path, size, info.ModTime(), staleAfter, now, p.isProtected(path, protectPaths), activeRoots[canonicalTempArtifactPath(path)]))
+	}
+}
+
+func (p *DevArtifactsPlugin) planTemporaryGeneratedArtifacts(scanPath string, minBytes int64, staleAfter, nodeAge, venvAge, rustAge, zigAge time.Duration, mutates bool, daCfg config.DevArtifactsConfig, active, activeRoots map[string]string, tracker *devArtifactGitTracker, targets *[]CleanupTarget) {
+	p.forEachStaleTemporaryRoot(scanPath, minBytes, staleAfter, daCfg.ProtectPaths, activeRoots, func(root string) {
+		if daCfg.NodeModules {
+			p.planNodeModules(root, nodeAge, mutates, daCfg.ProtectPaths, active, tracker, targets)
+		}
+		if daCfg.PythonVenvs {
+			p.planPythonVenvs(root, venvAge, mutates, daCfg.ProtectPaths, active, tracker, targets)
+		}
+		if daCfg.RustTargets {
+			p.planRustTargets(root, rustAge, mutates, daCfg.ProtectPaths, active, tracker, targets)
+		}
+		if daCfg.ZigArtifacts {
+			p.planZigArtifacts(root, zigAge, mutates, daCfg.ProtectPaths, active, tracker, targets)
+		}
+	})
+}
+
+func (p *DevArtifactsPlugin) cleanTemporaryGeneratedArtifacts(ctx context.Context, scanPath string, minBytes int64, staleAfter, nodeAge, venvAge, rustAge, zigAge time.Duration, daCfg config.DevArtifactsConfig, active, activeRoots map[string]string, tracker *devArtifactGitTracker, logger *slog.Logger) int64 {
+	var totalFreed int64
+	p.forEachStaleTemporaryRoot(scanPath, minBytes, staleAfter, daCfg.ProtectPaths, activeRoots, func(root string) {
+		logger.Debug("scanning stale temporary root for generated artifacts", "path", root)
+		if daCfg.NodeModules && !devArtifactFamilyActive(active, "node_modules") {
+			totalFreed += p.cleanNodeModules(ctx, root, nodeAge, daCfg.ProtectPaths, tracker, logger)
+		}
+		if daCfg.PythonVenvs && !devArtifactFamilyActive(active, "python-venv") {
+			totalFreed += p.cleanPythonVenvs(ctx, root, venvAge, daCfg.ProtectPaths, tracker, logger)
+		}
+		if daCfg.RustTargets && !devArtifactFamilyActive(active, "rust-target") {
+			totalFreed += p.cleanRustTargets(ctx, root, rustAge, daCfg.ProtectPaths, tracker, logger)
+		}
+		if daCfg.ZigArtifacts && !devArtifactFamilyActive(active, "zig-artifact") {
+			totalFreed += p.cleanZigArtifacts(ctx, root, zigAge, daCfg.ProtectPaths, tracker, logger)
+		}
+	})
+	return totalFreed
+}
+
+func (p *DevArtifactsPlugin) forEachStaleTemporaryRoot(scanPath string, minBytes int64, staleAfter time.Duration, protectPaths []string, activeRoots map[string]string, callback func(root string)) {
+	entries, err := os.ReadDir(scanPath)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		root := filepath.Join(scanPath, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if p.isProtected(root, protectPaths) {
+			continue
+		}
+		if activeRoots[canonicalTempArtifactPath(root)] != "" {
+			continue
+		}
+		if staleAfter > 0 && info.ModTime().After(now.Add(-staleAfter)) {
+			continue
+		}
+		if minBytes > 0 && getDirAllocatedBytes(root) < minBytes {
+			continue
+		}
+		callback(root)
 	}
 }
 

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -833,6 +833,99 @@ func TestPlanTemporaryArtifactsReportsReviewOnlyTargets(t *testing.T) {
 	}
 }
 
+func TestPlanCleanupReportsGeneratedArtifactsInsideStaleTemporaryRoots(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "temp-rust-worktree")
+	targetDir := filepath.Join(root, "target", "debug")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cargoToml := filepath.Join(root, "Cargo.toml")
+	if err := os.WriteFile(cargoToml, []byte("[package]\nname = \"temp-rust-worktree\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "artifact"), make([]byte, 2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(root, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(cargoToml, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tempGeneratedArtifactConfig(tmpDir)
+	plan := p.PlanCleanup(context.Background(), LevelCritical, cfg, logger)
+
+	rootTarget := findDevArtifactTarget(t, plan.Targets, "temporary-dev-artifact", root)
+	if rootTarget.Action != "review_temp_artifact" || !rootTarget.Protected {
+		t.Fatalf("expected top-level temporary root to remain review-only, got %#v", rootTarget)
+	}
+	rustTarget := findDevArtifactTarget(t, plan.Targets, "rust-target", filepath.Join(root, "target"))
+	if rustTarget.Action != "delete" || rustTarget.Protected {
+		t.Fatalf("expected nested Rust target to be deletable, got %#v", rustTarget)
+	}
+	if plan.EstimatedBytesFreed <= 0 {
+		t.Fatal("expected nested generated artifact to contribute to reclaim estimate")
+	}
+}
+
+func TestCleanupPrunesGeneratedArtifactsInsideStaleTemporaryRoots(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "temp-rust-worktree")
+	targetDir := filepath.Join(root, "target", "debug")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cargoToml := filepath.Join(root, "Cargo.toml")
+	if err := os.WriteFile(cargoToml, []byte("[package]\nname = \"temp-rust-worktree\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "artifact"), make([]byte, 2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(root, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(cargoToml, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	result := p.Cleanup(context.Background(), LevelCritical, tempGeneratedArtifactConfig(tmpDir), logger)
+	if pathExists(filepath.Join(root, "target")) {
+		t.Fatal("expected generated Rust target inside stale temporary root to be removed")
+	}
+	if !pathExists(cargoToml) {
+		t.Fatal("temporary worktree source file should be preserved")
+	}
+	if result.BytesFreed <= 0 {
+		t.Fatalf("expected cleanup to report freed bytes, got %#v", result)
+	}
+}
+
+func tempGeneratedArtifactConfig(tmpDir string) *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.DevArtifacts.ScanPaths = nil
+	cfg.DevArtifacts.TempScanPaths = []string{tmpDir}
+	cfg.DevArtifacts.TempArtifactMinMB = 1
+	cfg.DevArtifacts.TempArtifactStaleAfter = "6h"
+	cfg.DevArtifacts.NodeModules = false
+	cfg.DevArtifacts.PythonVenvs = false
+	cfg.DevArtifacts.RustTargets = true
+	cfg.DevArtifacts.ZigArtifacts = false
+	cfg.DevArtifacts.GoBuildCache = false
+	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.LargeLocalArtifacts = false
+	cfg.DevArtifacts.LMStudioModels = false
+	return cfg
+}
+
 func TestTempArtifactRootsFromProcessOutput(t *testing.T) {
 	output := `
 bazel(workspace) bazel(workspace) --output_user_root=/tmp/crush-dots-bazel-output --output_base=/tmp/crush-dots-bazel-output/817/output


### PR DESCRIPTION
## Summary

- keep top-level temporary roots review-only while scanning stale inactive roots for narrower generated artifacts
- allow Rust target, node_modules, Python virtualenv, and Zig output pruning inside stale temp worktrees without deleting the worktree itself
- document the temp-root safety behavior and add focused planner/cleanup tests

## Validation

- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'TestPlanCleanupReportsGeneratedArtifactsInsideStaleTemporaryRoots|TestCleanupPrunesGeneratedArtifactsInsideStaleTemporaryRoots|TestPlanTemporaryArtifactsReportsReviewOnlyTargets'
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- dry-run dogfood: dev-artifacts critical scan on this Darwin host reports active Bazel protected and no broad temp-root deletion
