### PR TITLE
Gate Darwin cache cleanup on typed enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ All notable changes to this project will be documented in this file.
 - Dev-artifact cleanup now scans stale inactive temporary roots for narrower
   generated-output targets, allowing Rust `target/`, `node_modules`, Python
   virtualenv, and Zig output pruning without deleting the top-level temp root.
+- Darwin cache cleanup now treats the typed `darwin_dev_caches` plan as the
+  real-cleanup authority when enabled, so `enforce: false` prevents legacy
+  generic cache deletion paths from mutating developer machines.
 - Dev-artifacts dry-runs now surface large top-level temporary proof/output
   directories as protected review-only targets with active process path
   evidence.

--- a/docs/darwin-dev-caches.md
+++ b/docs/darwin-dev-caches.md
@@ -46,6 +46,12 @@ darwin_dev_caches:
   enforce: false
 ```
 
+When Darwin developer caches are enabled, real `cache` cleanup uses this typed
+target model as the authority. With `enforce: false`, cleanup returns without
+deleting legacy generic cache paths such as pip, npm, Go, Cargo, or broad
+`~/Library/Caches` entries. This keeps dry-run review and real mutation aligned
+on developer machines.
+
 When `enforce: true`, moderate cleanup can delete unprotected Playwright and
 Bazelisk entries outside the keep-latest policy, stale pip caches, and stale
 inactive editor cache directories. Aggressive cleanup can delete inactive stale

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -952,6 +952,18 @@ func (p *CachePlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *conf
 
 	home, _ := os.UserHomeDir()
 
+	if cfg.DarwinDevCaches.Enabled {
+		if !cfg.DarwinDevCaches.Enforce {
+			logger.Info("skipping Darwin cache cleanup because darwin_dev_caches.enforce is false")
+			return result
+		}
+		if level < LevelModerate {
+			logger.Info("skipping Darwin cache cleanup below moderate pressure")
+			return result
+		}
+		return p.cleanupDarwinDeveloperCacheTargets(ctx, level, home, cfg.DarwinDevCaches, logger)
+	}
+
 	// pip cache
 	pipCache := filepath.Join(home, ".cache", "pip")
 	if size := getDirSize(pipCache); size > 0 {
@@ -1052,16 +1064,6 @@ func (p *CachePlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *conf
 			sizeAfter := getDirSize(libraryCaches)
 			result.BytesFreed += sizeBefore - sizeAfter
 			logger.Debug("cleaned macOS Library/Caches", "freed_mb", (sizeBefore-sizeAfter)/(1024*1024))
-		}
-	}
-
-	if cfg.DarwinDevCaches.Enabled && cfg.DarwinDevCaches.Enforce && level >= LevelModerate {
-		darwinResult := p.cleanupDarwinDeveloperCacheTargets(ctx, level, home, cfg.DarwinDevCaches, logger)
-		result.BytesFreed += darwinResult.BytesFreed
-		result.EstimatedBytesFreed += darwinResult.EstimatedBytesFreed
-		result.ItemsCleaned += darwinResult.ItemsCleaned
-		if darwinResult.Error != nil {
-			result.Error = darwinResult.Error
 		}
 	}
 

--- a/plugins/darwin_dev_cache_test.go
+++ b/plugins/darwin_dev_cache_test.go
@@ -191,6 +191,69 @@ func TestCleanupDarwinDeveloperCacheTargetsDeletesOnlyEligibleTargets(t *testing
 	}
 }
 
+func TestCacheCleanupDarwinDevCachesDisabledEnforcementSkipsLegacyMutation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pipCache := filepath.Join(home, ".cache", "pip", "cache.bin")
+	npmCache := filepath.Join(home, ".npm", "_cacache", "cache.bin")
+	writeFileAt(t, pipCache, "pip")
+	writeFileAt(t, npmCache, "npm")
+
+	cfg := config.DefaultConfig()
+	cfg.DarwinDevCaches.Enabled = true
+	cfg.DarwinDevCaches.Enforce = false
+
+	plugin := &CachePlugin{}
+	result := plugin.Cleanup(context.Background(), LevelCritical, cfg, nilLogger())
+	if result.BytesFreed != 0 || result.ItemsCleaned != 0 {
+		t.Fatalf("expected no mutation when Darwin cache enforcement is disabled, got %#v", result)
+	}
+	if !pathExists(pipCache) || !pathExists(npmCache) {
+		t.Fatalf("legacy generic cache paths should be preserved when typed Darwin enforcement is disabled")
+	}
+}
+
+func TestCacheCleanupDarwinDevCachesUsesTypedTargetsWhenEnforced(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	oldBrowser := filepath.Join(home, "Library", "Caches", "ms-playwright", "chromium-1148")
+	newBrowser := filepath.Join(home, "Library", "Caches", "ms-playwright", "chromium-1149")
+	legacyNPM := filepath.Join(home, ".npm", "_cacache", "cache.bin")
+	writeCacheFile(t, home, "Library/Caches/ms-playwright/chromium-1148/browser.bin", "old chromium")
+	writeCacheFile(t, home, "Library/Caches/ms-playwright/chromium-1149/browser.bin", "new chromium")
+	writeFileAt(t, legacyNPM, "npm")
+
+	now := time.Now()
+	mustChtimes(t, oldBrowser, now.Add(-2*time.Hour))
+	mustChtimes(t, newBrowser, now)
+
+	cfg := config.DefaultConfig()
+	cfg.DarwinDevCaches.Enabled = true
+	cfg.DarwinDevCaches.Enforce = true
+	cfg.DarwinDevCaches.Pip.Enabled = false
+	cfg.DarwinDevCaches.JetBrains.Enabled = false
+	cfg.DarwinDevCaches.Bazelisk.Enabled = false
+	cfg.DarwinDevCaches.VSCode.Enabled = false
+	cfg.DarwinDevCaches.Cursor.Enabled = false
+
+	plugin := &CachePlugin{}
+	result := plugin.Cleanup(context.Background(), LevelModerate, cfg, nilLogger())
+	if result.ItemsCleaned != 1 {
+		t.Fatalf("expected one typed Darwin cache target to be deleted, got %#v", result)
+	}
+	if pathExists(oldBrowser) {
+		t.Fatalf("expected old Playwright revision to be deleted by typed enforcement")
+	}
+	if !pathExists(newBrowser) {
+		t.Fatalf("expected newest Playwright revision to remain")
+	}
+	if !pathExists(legacyNPM) {
+		t.Fatalf("legacy generic npm cache should not be deleted by typed Darwin cleanup")
+	}
+}
+
 func TestHomebrewPlanTargetUsesDryRunEstimate(t *testing.T) {
 	target := homebrewPlanTarget(LevelCritical, "/tmp/homebrew-cache", 10, 50, true)
 


### PR DESCRIPTION
## Summary

- make typed `darwin_dev_caches` enforcement the authority for real Darwin `cache` cleanup
- return without mutation when `darwin_dev_caches.enabled=true` but `enforce=false`, preventing legacy generic pip/npm/Go/Cargo cache deletion
- document the real-cleanup gate and add tests for disabled enforcement and typed-only enforcement

## Validation

- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'TestCacheCleanupDarwinDevCachesDisabledEnforcementSkipsLegacyMutation|TestCacheCleanupDarwinDevCachesUsesTypedTargetsWhenEnforced|TestCleanupDarwinDeveloperCacheTargetsDeletesOnlyEligibleTargets|TestDarwinDeveloperCacheTargetsOptInEnforcement'
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
- throwaway-home proof: real critical cache run with `darwin_dev_caches.enforce=false` preserved seeded pip/npm cache files and reported zero bytes/items cleaned
