### PR TITLE
[codex] Fail closed on Nix GC preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ All notable changes to this project will be documented in this file.
 - Darwin cache cleanup now treats the typed `darwin_dev_caches` plan as the
   real-cleanup authority when enabled, so `enforce: false` prevents legacy
   generic cache deletion paths from mutating developer machines.
+- Nix real cleanup now dry-run preflights garbage collection and skips the
+  actual GC command when there are zero reclaimable store paths and no user
+  generation deletion happened, or fails closed when that preflight fails,
+  avoiding pointless store-lock contention and unsafe fallback GC.
 - Dev-artifacts dry-runs now surface large top-level temporary proof/output
   directories as protected review-only targets with active process path
   evidence.

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -61,6 +61,12 @@ Runtime behavior:
 - real generation deletion and GC commands also treat those contention
   signatures as deferred no-op cleanup steps when `skip_when_daemon_busy` is
   enabled;
+- real cleanup runs a dry-run GC preflight before mutation and skips the actual
+  GC command when the preflight reports zero reclaimable store paths and no
+  user generation deletion happened in the same cycle;
+- real cleanup fails closed when the dry-run GC preflight itself fails for an
+  unknown reason, so the plugin does not fall through into a mutating GC command
+  without a successful preflight;
 - system or nix-darwin generations are reported for operator review but are not
   deleted by the unprivileged plugin path;
 - Home Manager generations are discovered from profile symlinks without taking a

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -201,13 +201,31 @@ func (p *NixPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *config
 		}
 	}
 
+	generationsDeleted := 0
 	if level >= LevelModerate {
 		generationResult := p.deleteUserGenerationsByPolicy(ctx, level, cfg.Nix, logger)
 		result.ItemsCleaned += generationResult.ItemsCleaned
+		generationsDeleted = generationResult.ItemsCleaned
 		if generationResult.Error != nil {
 			result.Error = generationResult.Error
 			return result
 		}
+	}
+
+	dryRunOutput, dryRunErr := p.collectGarbageDryRun(ctx, cfg.Nix)
+	if dryRunErr != nil {
+		if reason, ok := nixContentionReason(dryRunOutput); ok && cfg.Nix.SkipWhenDaemonBusy {
+			logger.Warn("skipping Nix garbage collection because dry-run preflight reported store contention", "reason", reason)
+			return result
+		}
+		logger.Warn("skipping Nix garbage collection because dry-run preflight failed",
+			"error", dryRunErr,
+			"output", strings.TrimSpace(dryRunOutput))
+		result.Error = fmt.Errorf("nix garbage collection preflight failed: %w", dryRunErr)
+		return result
+	} else if p.nixDryRunHasNoGCWork(dryRunOutput) && generationsDeleted == 0 && !(level == LevelCritical && cfg.Nix.AllowStoreOptimize) {
+		logger.Info("skipping Nix garbage collection because dry-run reported no reclaimable store paths")
+		return result
 	}
 
 	switch level {
@@ -1070,6 +1088,10 @@ func (p *NixPlugin) parseDryRunStorePaths(output string) int {
 		}
 	}
 	return p.parseDeletedPaths(output)
+}
+
+func (p *NixPlugin) nixDryRunHasNoGCWork(output string) bool {
+	return strings.TrimSpace(output) != "" && p.parseDryRunFreedSpace(output) == 0 && p.parseDryRunStorePaths(output) == 0
 }
 
 func (p *NixPlugin) parseFreedSpace(output string) int64 {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -1,6 +1,9 @@
 package plugins
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,6 +54,72 @@ func TestNixPluginParseDryRunStorePaths(t *testing.T) {
 		if got := p.parseDryRunStorePaths(tt.output); got != tt.expected {
 			t.Fatalf("parseDryRunStorePaths(%q) = %d, want %d", tt.output, got, tt.expected)
 		}
+	}
+}
+
+func TestNixDryRunHasNoGCWork(t *testing.T) {
+	p := NewNixPlugin()
+
+	tests := []struct {
+		name     string
+		output   string
+		expected bool
+	}{
+		{"zero store paths", "0 store paths deleted, 0 B freed", true},
+		{"would delete nothing", "would delete 0 store paths\nwould free 0 B", true},
+		{"empty output", "", false},
+		{"store paths available", "would delete 2 store paths\nwould free 4.0 MiB", false},
+		{"bytes available", "1.0 GiB would be freed", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := p.nixDryRunHasNoGCWork(tt.output); got != tt.expected {
+				t.Fatalf("nixDryRunHasNoGCWork(%q) = %t, want %t", tt.output, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNixCleanupFailsClosedWhenDryRunPreflightFails(t *testing.T) {
+	binDir := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "nix-gc-calls")
+	fakeGC := filepath.Join(binDir, "nix-collect-garbage")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$NIX_GC_CALLS"
+if [ "$1" = "--dry-run" ]; then
+  printf '%s\n' "error: dry-run preflight failed" >&2
+  exit 1
+fi
+printf '%s\n' "mutating GC should not run" >&2
+exit 0
+`
+	if err := os.WriteFile(fakeGC, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("NIX_GC_CALLS", callsPath)
+
+	cfg := config.DefaultConfig()
+	cfg.Nix.SkipWhenDaemonBusy = false
+
+	p := NewNixPlugin()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := p.Cleanup(context.Background(), LevelWarning, cfg, logger)
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "preflight failed") {
+		t.Fatalf("expected dry-run preflight failure, got %+v", result)
+	}
+	if result.ItemsCleaned != 0 || result.BytesFreed != 0 || result.CommandBytesFreed != 0 {
+		t.Fatalf("failed preflight should not report cleanup: %+v", result)
+	}
+
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(calls), "--dry-run\n"; got != want {
+		t.Fatalf("unexpected nix-collect-garbage calls %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a real-cleanup Nix GC dry-run preflight before invoking mutating garbage collection.
- Skip mutating GC when dry-run reports zero reclaimable store paths and no user generations were deleted in the same cycle.
- Fail closed when the preflight itself fails for an unknown reason, and document the operator policy.

## Why
This prevents warning/moderate/aggressive cleanup from falling through into a mutating Nix GC when dry-run cannot prove the store work is safe or useful. It also avoids pointless store-lock contention on active developer machines.

## Local dogfood
- Dry-run on this Darwin lab machine deferred Nix cleanup because active Nix work was detected.
- Real warning-level proof with a temporary state file respected that deferral: `items_cleaned=0`, `bytes_freed=0`, host free-space drift about `-2 MiB`.

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'TestNixCleanupFailsClosedWhenDryRunPreflightFails|TestNixDryRunHasNoGCWork|TestNixPluginParseDryRunFreedSpace|TestNixPluginParseDryRunStorePaths|TestNixContentionReason'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
