### PR TITLE
[codex] Plan Podman BuildKit cache cleanup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -133,6 +133,7 @@ go_test(
         "plugins/bazel_test.go",
         "plugins/devartifacts_test.go",
         "plugins/nix_test.go",
+        "plugins/podman_buildkit_test.go",
         "plugins/podman_compaction_test.go",
         "plugins/plugin_pbt_test.go",
         "plugins/plugin_test.go",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
   accounting.
 - Podman offline compaction preflight for Darwin VM disks, including physical
   allocation accounting and active-container safety gates.
+- Podman BuildKit cache planning and critical cleanup with retention guards,
+  command-byte reporting, and Darwin host free-space delta accounting after
+  advisory VM trim.
 - Structured dry-run targets for Darwin developer caches such as JetBrains,
   Playwright, Bazelisk, and pip.
 - Nix cleanup preflight plans with dry-run reclaim estimates, generation

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ See [docs/operator-workflow.md](docs/operator-workflow.md) for the current
 dry-run, candidate policy tier, and host free-space accounting workflow.
 
 Podman on macOS needs extra care because `applehv` raw sparse images do not
-shrink from guest `fstrim` alone. See
+prove host reclaim from guest `fstrim` output alone. Critical cleanup can prune
+BuildKit cache inside a running buildx builder and then count only the measured
+host free-space delta after advisory trim. See
 [docs/podman-darwin-compaction.md](docs/podman-darwin-compaction.md) before
 enabling offline compaction.
 

--- a/config/config.go
+++ b/config/config.go
@@ -166,6 +166,14 @@ type PodmanConfig struct {
 	ProtectRunningContainers bool `yaml:"protect_running_containers"`
 	// MachineNames to check for cleanup (Darwin)
 	MachineNames []string `yaml:"machine_names"`
+	// BuildKitPrune enables targeted BuildKit cache pruning at critical level
+	BuildKitPrune bool `yaml:"buildkit_prune"`
+	// BuildKitPruneKeepDuration preserves BuildKit records newer than this duration
+	BuildKitPruneKeepDuration string `yaml:"buildkit_prune_keep_duration"`
+	// BuildKitPruneKeepStorageMB preserves this much BuildKit cache after pruning
+	BuildKitPruneKeepStorageMB int `yaml:"buildkit_prune_keep_storage_mb"`
+	// BuildKitPruneMinReclaimGB skips BuildKit pruning below this reclaimable cache size
+	BuildKitPruneMinReclaimGB int `yaml:"buildkit_prune_min_reclaim_gb"`
 	// CleanInsideVM enables cleanup inside Podman machine VM (Darwin)
 	CleanInsideVM bool `yaml:"clean_inside_vm"`
 	// TrimVMDisk enables fstrim inside VM to reclaim sparse disk space (Darwin)
@@ -398,6 +406,10 @@ func DefaultConfig() *Config {
 			PruneImagesAge:                   "24h",
 			ProtectRunningContainers:         true,
 			MachineNames:                     []string{"podman-machine-default"},
+			BuildKitPrune:                    true,
+			BuildKitPruneKeepDuration:        "24h",
+			BuildKitPruneKeepStorageMB:       8192,
+			BuildKitPruneMinReclaimGB:        4,
 			CleanInsideVM:                    true,
 			TrimVMDisk:                       true,
 			CompactMinReclaimGB:              8,

--- a/config/config_pbt_test.go
+++ b/config/config_pbt_test.go
@@ -183,6 +183,18 @@ func TestPodmanConfigDefaults(t *testing.T) {
 	if cfg.Podman.PruneImagesAge == "" {
 		t.Error("Podman.PruneImagesAge should have a default")
 	}
+	if !cfg.Podman.BuildKitPrune {
+		t.Error("Podman.BuildKitPrune should default to true")
+	}
+	if cfg.Podman.BuildKitPruneKeepDuration == "" {
+		t.Error("Podman.BuildKitPruneKeepDuration should have a default")
+	}
+	if cfg.Podman.BuildKitPruneKeepStorageMB <= 0 {
+		t.Errorf("Podman.BuildKitPruneKeepStorageMB should be positive: %d", cfg.Podman.BuildKitPruneKeepStorageMB)
+	}
+	if cfg.Podman.BuildKitPruneMinReclaimGB < 0 {
+		t.Errorf("Podman.BuildKitPruneMinReclaimGB should be non-negative: %d", cfg.Podman.BuildKitPruneMinReclaimGB)
+	}
 
 	// MachineNames should have at least one entry on Darwin
 	// (but we can't check runtime.GOOS in test, so just verify it's set)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -243,6 +243,18 @@ func TestLimaCompactDefaults(t *testing.T) {
 
 func TestPodmanCompactDefaults(t *testing.T) {
 	cfg := DefaultConfig()
+	if !cfg.Podman.BuildKitPrune {
+		t.Error("Podman.BuildKitPrune should default to true")
+	}
+	if cfg.Podman.BuildKitPruneKeepDuration != "24h" {
+		t.Errorf("Podman.BuildKitPruneKeepDuration should default to 24h, got %q", cfg.Podman.BuildKitPruneKeepDuration)
+	}
+	if cfg.Podman.BuildKitPruneKeepStorageMB != 8192 {
+		t.Errorf("Podman.BuildKitPruneKeepStorageMB should default to 8192, got %d", cfg.Podman.BuildKitPruneKeepStorageMB)
+	}
+	if cfg.Podman.BuildKitPruneMinReclaimGB != 4 {
+		t.Errorf("Podman.BuildKitPruneMinReclaimGB should default to 4, got %d", cfg.Podman.BuildKitPruneMinReclaimGB)
+	}
 	if cfg.Podman.CompactDiskOffline {
 		t.Error("Podman.CompactDiskOffline should be false by default (opt-in)")
 	}
@@ -438,6 +450,10 @@ apfs:
 lima:
   compact_offline: true
 podman:
+  buildkit_prune: false
+  buildkit_prune_keep_duration: 48h
+  buildkit_prune_keep_storage_mb: 4096
+  buildkit_prune_min_reclaim_gb: 12
   compact_disk_offline: true
   compact_min_reclaim_gb: 12
   compact_require_no_active_containers: false
@@ -564,6 +580,18 @@ darwin_dev_caches:
 	}
 	if !cfg.Podman.CompactDiskOffline {
 		t.Error("Podman.CompactDiskOffline should be true per config")
+	}
+	if cfg.Podman.BuildKitPrune {
+		t.Error("Podman.BuildKitPrune should be false per config")
+	}
+	if cfg.Podman.BuildKitPruneKeepDuration != "48h" {
+		t.Errorf("Podman.BuildKitPruneKeepDuration should be 48h per config, got %q", cfg.Podman.BuildKitPruneKeepDuration)
+	}
+	if cfg.Podman.BuildKitPruneKeepStorageMB != 4096 {
+		t.Errorf("Podman.BuildKitPruneKeepStorageMB should be 4096 per config, got %d", cfg.Podman.BuildKitPruneKeepStorageMB)
+	}
+	if cfg.Podman.BuildKitPruneMinReclaimGB != 12 {
+		t.Errorf("Podman.BuildKitPruneMinReclaimGB should be 12 per config, got %d", cfg.Podman.BuildKitPruneMinReclaimGB)
 	}
 	if cfg.Podman.CompactMinReclaimGB != 12 {
 		t.Errorf("Podman.CompactMinReclaimGB should be 12 per config, got %d", cfg.Podman.CompactMinReclaimGB)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -76,6 +76,15 @@ podman:
   protect_running_containers: true
   machine_names:
     - podman-machine-default
+
+  # Critical-level BuildKit cache pruning targets the buildx builder cache
+  # inside a running Podman VM. Guest-reported reclaim is recorded separately;
+  # Darwin host reclaim is counted only from measured host free-space deltas.
+  buildkit_prune: true
+  buildkit_prune_keep_duration: 24h
+  buildkit_prune_keep_storage_mb: 8192
+  buildkit_prune_min_reclaim_gb: 4
+
   clean_inside_vm: true
   trim_vm_disk: true
 
@@ -148,11 +157,14 @@ dev_artifacts:
     - ~/git
     - ~/src
     - ~/projects
+  scan_max_duration: 30s
+  scan_max_entries: 250000
   # Review-only: surface large top-level temp proof/output trees without
   # deleting them automatically. Darwin compiled defaults use /private/tmp.
   temp_artifacts: true
   temp_scan_paths:
     - /private/tmp
+  temp_scan_max_roots: 128
   temp_artifact_min_mb: 256
   temp_artifact_stale_after: 6h
   node_modules: true

--- a/docs/podman-darwin-compaction.md
+++ b/docs/podman-darwin-compaction.md
@@ -6,6 +6,13 @@ trimmed byte counts inside the VM, but that does not prove the host raw image
 released APFS allocation. The daemon therefore does not count `applehv` guest
 `fstrim` output as host bytes freed.
 
+Critical cleanup first handles the online path when a running buildx BuildKit
+container is visible. The daemon inspects `buildctl du`, prunes only when the
+reported reclaimable cache is above the configured floor, keeps recent cache and
+a storage floor, then runs advisory `fstrim`. The BuildKit command total is
+reported as `command_bytes_freed`; host reclaim is reported only from the
+measured host free-space delta after the trim.
+
 ## Review
 
 Use dry-run JSON before enabling offline compaction:
@@ -17,6 +24,9 @@ tinyland-cleanup --once --dry-run --level critical --output json
 The Podman plan reports:
 
 - provider and running state;
+- BuildKit builder cache container, reclaimable bytes, retention policy, and
+  protected skip reason when the cache is below threshold or cannot be
+  inspected;
 - disk format and disk path;
 - scratch directory, temp image path, and rollback backup path;
 - logical image size and physical host allocation;
@@ -34,6 +44,20 @@ can run. Blocked compaction still reports the potential reclaim in
 operator review.
 
 ## Enable
+
+BuildKit cache pruning is enabled by default only for critical Podman cleanup:
+
+```yaml
+podman:
+  buildkit_prune: true
+  buildkit_prune_keep_duration: 24h
+  buildkit_prune_keep_storage_mb: 8192
+  buildkit_prune_min_reclaim_gb: 4
+```
+
+This does not stop the Podman VM or delete the builder volume wholesale. It is
+still warm-cache cleanup: active builds may lose reusable cache, so the daemon
+keeps the newest records and a configured storage floor.
 
 Offline compaction is opt-in because it stops the Podman machine:
 

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -42,6 +42,45 @@ type PodmanEnvironment struct {
 
 const podmanCompactionGiB = int64(1024 * 1024 * 1024)
 
+type podmanBuildKitCachePlan struct {
+	Enabled          bool
+	ContainerID      string
+	ContainerName    string
+	KeepDuration     string
+	KeepStorageMB    int
+	MinReclaimBytes  int64
+	ReclaimableBytes int64
+	TotalBytes       int64
+	CanPrune         bool
+	SkipReason       string
+	InspectionError  string
+	Warnings         []string
+	Steps            []string
+}
+
+type podmanBuildKitCachePlanInput struct {
+	Enabled          bool
+	ContainerID      string
+	ContainerName    string
+	KeepDuration     string
+	KeepStorageMB    int
+	MinReclaimBytes  int64
+	ReclaimableBytes int64
+	TotalBytes       int64
+	InspectionError  string
+}
+
+type podmanBuildKitContainer struct {
+	ID   string
+	Name string
+}
+
+type podmanVMDiskTrimResult struct {
+	TrimmedBytes   int64
+	HostBytesFreed int64
+	MeasurePath    string
+}
+
 type podmanCompactionPlan struct {
 	MachineName               string
 	Provider                  string
@@ -178,19 +217,33 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 			"Prune Podman build containers",
 		)
 		if runtime.GOOS == "darwin" && p.environment.VMRunning && cfg.Podman.TrimVMDisk && !p.fstrimReclaimsHostSpace() {
-			plan.Warnings = append(plan.Warnings, "guest fstrim is not counted as host reclaim for this provider")
+			plan.Warnings = append(plan.Warnings, "guest fstrim output is not counted as host bytes for this provider; measured host free-space delta remains authoritative")
 		}
 	case LevelCritical:
 		plan.Steps = append(plan.Steps,
 			"Run full Podman system prune with volumes",
 			"Prune external Podman storage when supported",
 		)
+		buildKit := p.planBuildKitCache(ctx, cfg, logger)
+		plan.Warnings = append(plan.Warnings, buildKit.Warnings...)
+		plan.Steps = append(plan.Steps, buildKit.Steps...)
+		plan.Targets = append(plan.Targets, podmanBuildKitCacheTargets(buildKit)...)
+		plan.Metadata["buildkit_cache_enabled"] = strconv.FormatBool(buildKit.Enabled)
+		plan.Metadata["buildkit_cache_can_prune"] = strconv.FormatBool(buildKit.CanPrune)
+		plan.Metadata["buildkit_cache_skip_reason"] = buildKit.SkipReason
+		plan.Metadata["buildkit_cache_container"] = buildKit.ContainerName
+		plan.Metadata["buildkit_cache_container_id"] = buildKit.ContainerID
+		plan.Metadata["buildkit_cache_keep_duration"] = buildKit.KeepDuration
+		plan.Metadata["buildkit_cache_keep_storage_mb"] = strconv.Itoa(buildKit.KeepStorageMB)
+		plan.Metadata["buildkit_cache_min_reclaim_bytes"] = strconv.FormatInt(buildKit.MinReclaimBytes, 10)
+		plan.Metadata["buildkit_cache_reclaimable_bytes"] = strconv.FormatInt(buildKit.ReclaimableBytes, 10)
+		plan.Metadata["buildkit_cache_total_bytes"] = strconv.FormatInt(buildKit.TotalBytes, 10)
 		if runtime.GOOS == "darwin" && p.environment.VMRunning {
 			if cfg.Podman.CleanInsideVM {
 				plan.Steps = append(plan.Steps, "Run critical cleanup inside the Podman VM")
 			}
 			if cfg.Podman.TrimVMDisk && !p.fstrimReclaimsHostSpace() {
-				plan.Warnings = append(plan.Warnings, "guest fstrim is not counted as host reclaim for this provider")
+				plan.Warnings = append(plan.Warnings, "guest fstrim output is not counted as host bytes for this provider; measured host free-space delta remains authoritative")
 			}
 
 			compaction := p.planOfflineCompaction(ctx, cfg, logger)
@@ -221,8 +274,8 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 			plan.Metadata["offline_compaction_scratch_dir_available"] = strconv.FormatBool(compaction.ScratchDirAvailable)
 			plan.Metadata["offline_compaction_scratch_dir_cross_device"] = strconv.FormatBool(compaction.ScratchDirCrossDevice)
 			plan.Metadata["offline_compaction_cross_device_replacement"] = strconv.FormatBool(compaction.CrossDeviceReplacement)
-			plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
 		}
+		plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
 	}
 
 	return plan
@@ -356,20 +409,12 @@ func (p *PodmanPlugin) cleanAggressive(ctx context.Context, cfg *config.Config, 
 
 	// On Darwin, run fstrim inside VM to reclaim sparse disk space when the
 	// provider reflects guest discard operations back to the host disk image.
+	// Providers such as applehv still benefit from fstrim after guest cleanup,
+	// but only the measured host free-space delta is counted.
 	if runtime.GOOS == "darwin" && p.environment.VMRunning && cfg.Podman.TrimVMDisk {
-		if !p.fstrimReclaimsHostSpace() {
-			logger.Warn("skipping Podman VM fstrim accounting; provider does not shrink host disk images from guest fstrim",
-				"machine", p.environment.MachineName,
-				"provider", p.environment.VMProvider,
-				"suggestion", "use offline compaction for actual host-side reclamation")
-			return result
-		}
-
 		logger.Debug("running fstrim in Podman VM", "machine", p.environment.MachineName)
-		if trimmed, err := p.trimVMDisk(ctx, logger); err == nil && trimmed > 0 {
-			result.BytesFreed += trimmed
-			result.ItemsCleaned++
-			logger.Info("reclaimed sparse disk space from Podman VM", "freed_mb", trimmed/(1024*1024))
+		if trim, err := p.trimVMDiskWithHostDelta(ctx, logger); err == nil {
+			p.addTrimResult(&result, trim, logger)
 		} else if err != nil {
 			logger.Warn("fstrim in Podman VM failed", "error", err)
 		}
@@ -382,6 +427,17 @@ func (p *PodmanPlugin) cleanAggressive(ctx context.Context, cfg *config.Config, 
 func (p *PodmanPlugin) cleanCritical(ctx context.Context, cfg *config.Config, logger *slog.Logger) CleanupResult {
 	result := CleanupResult{Plugin: p.Name(), Level: LevelCritical}
 
+	buildKitTrimRan := false
+	if cfg.Podman.BuildKitPrune {
+		buildKitResult, trimRan := p.cleanBuildKitCache(ctx, cfg, logger)
+		buildKitTrimRan = trimRan
+		result.BytesFreed += buildKitResult.BytesFreed
+		result.EstimatedBytesFreed += buildKitResult.EstimatedBytesFreed
+		result.CommandBytesFreed += buildKitResult.CommandBytesFreed
+		result.HostBytesFreed += buildKitResult.HostBytesFreed
+		result.ItemsCleaned += buildKitResult.ItemsCleaned
+	}
+
 	// Full system prune with volumes
 	logger.Warn("CRITICAL: running full Podman system prune with volumes")
 	output, err := p.runPodmanCommand(ctx, "system", "prune", "-af", "--volumes")
@@ -390,7 +446,7 @@ func (p *PodmanPlugin) cleanCritical(ctx context.Context, cfg *config.Config, lo
 		result.Error = err
 		return result
 	}
-	result.BytesFreed = p.parseReclaimedSpace(output)
+	result.BytesFreed += p.parseReclaimedSpace(output)
 	result.ItemsCleaned++
 
 	// Clean external/orphaned storage (transient mode)
@@ -414,16 +470,11 @@ func (p *PodmanPlugin) cleanCritical(ctx context.Context, cfg *config.Config, lo
 		}
 
 		// Then fstrim to reclaim space when the provider reports that discard
-		// as host-side sparse image reclamation.
-		if cfg.Podman.TrimVMDisk {
-			if !p.fstrimReclaimsHostSpace() {
-				logger.Warn("skipping Podman VM fstrim accounting; provider does not shrink host disk images from guest fstrim",
-					"machine", p.environment.MachineName,
-					"provider", p.environment.VMProvider,
-					"suggestion", "use offline compaction for actual host-side reclamation")
-			} else if trimmed, err := p.trimVMDisk(ctx, logger); err == nil && trimmed > 0 {
-				result.BytesFreed += trimmed
-				result.ItemsCleaned++
+		// as host-side sparse image reclamation. If BuildKit cleanup already
+		// trimmed the VM, do not trim a second time in the same cycle.
+		if cfg.Podman.TrimVMDisk && !buildKitTrimRan {
+			if trim, err := p.trimVMDiskWithHostDelta(ctx, logger); err == nil {
+				p.addTrimResult(&result, trim, logger)
 			} else if err != nil {
 				logger.Warn("fstrim in Podman VM failed", "error", err)
 			}
@@ -446,6 +497,74 @@ func (p *PodmanPlugin) cleanCritical(ctx context.Context, cfg *config.Config, lo
 	}
 
 	return result
+}
+
+func (p *PodmanPlugin) cleanBuildKitCache(ctx context.Context, cfg *config.Config, logger *slog.Logger) (CleanupResult, bool) {
+	result := CleanupResult{Plugin: p.Name(), Level: LevelCritical}
+
+	plan := p.planBuildKitCache(ctx, cfg, logger)
+	if !plan.CanPrune {
+		logger.Debug("skipping BuildKit cache prune", "reason", plan.SkipReason)
+		return result, false
+	}
+
+	logger.Warn("CRITICAL: pruning BuildKit cache",
+		"container", podmanBuildKitContainerLabel(plan),
+		"keep_duration", plan.KeepDuration,
+		"keep_storage_mb", plan.KeepStorageMB)
+	output, err := p.runPodmanCommand(ctx,
+		"exec", plan.ContainerID,
+		"buildctl", "prune",
+		"--keep-duration", plan.KeepDuration,
+		"--keep-storage", fmt.Sprintf("%dMB", plan.KeepStorageMB))
+	if err != nil {
+		logger.Warn("BuildKit cache prune failed", "container", podmanBuildKitContainerLabel(plan), "error", err)
+		return result, false
+	}
+
+	if commandFreed := parseBuildKitPruneSummary(output); commandFreed > 0 {
+		result.CommandBytesFreed += commandFreed
+		result.ItemsCleaned++
+		logger.Info("BuildKit cache prune completed", "command_freed_mb", commandFreed/(1024*1024))
+	}
+
+	trimRan := false
+	if runtime.GOOS == "darwin" && p.environment.VMRunning && cfg.Podman.TrimVMDisk {
+		logger.Debug("running fstrim after BuildKit cache prune", "machine", p.environment.MachineName)
+		trimRan = true
+		if trim, err := p.trimVMDiskWithHostDelta(ctx, logger); err == nil {
+			p.addTrimResult(&result, trim, logger)
+		} else {
+			logger.Warn("fstrim after BuildKit cache prune failed", "error", err)
+		}
+	}
+
+	return result, trimRan
+}
+
+func (p *PodmanPlugin) addTrimResult(result *CleanupResult, trim podmanVMDiskTrimResult, logger *slog.Logger) {
+	if trim.HostBytesFreed > 0 {
+		result.BytesFreed += trim.HostBytesFreed
+		result.HostBytesFreed += trim.HostBytesFreed
+		result.ItemsCleaned++
+		logger.Info("measured Podman VM host free-space reclaim",
+			"freed_mb", trim.HostBytesFreed/(1024*1024),
+			"measure_path", trim.MeasurePath)
+		return
+	}
+	if p.fstrimReclaimsHostSpace() && trim.TrimmedBytes > 0 {
+		result.BytesFreed += trim.TrimmedBytes
+		result.ItemsCleaned++
+		logger.Info("reclaimed sparse disk space from Podman VM", "freed_mb", trim.TrimmedBytes/(1024*1024))
+		return
+	}
+	if trim.TrimmedBytes > 0 {
+		logger.Warn("Podman VM fstrim reported guest trim bytes without measured host reclaim",
+			"trimmed_mb", trim.TrimmedBytes/(1024*1024),
+			"machine", p.environment.MachineName,
+			"provider", p.environment.VMProvider,
+			"measure_path", trim.MeasurePath)
+	}
 }
 
 // runPodmanCommand executes a podman command with timeout.
@@ -508,6 +627,233 @@ func (p *PodmanPlugin) parseReclaimedSpace(output string) int64 {
 	}
 
 	return 0
+}
+
+func (p *PodmanPlugin) planBuildKitCache(ctx context.Context, cfg *config.Config, logger *slog.Logger) podmanBuildKitCachePlan {
+	input := podmanBuildKitCachePlanInput{
+		Enabled:         cfg.Podman.BuildKitPrune,
+		KeepDuration:    cfg.Podman.BuildKitPruneKeepDuration,
+		KeepStorageMB:   cfg.Podman.BuildKitPruneKeepStorageMB,
+		MinReclaimBytes: int64(cfg.Podman.BuildKitPruneMinReclaimGB) * podmanCompactionGiB,
+	}
+	if !cfg.Podman.BuildKitPrune {
+		return buildPodmanBuildKitCachePlan(input)
+	}
+
+	containers, err := p.listBuildKitContainers(ctx)
+	if err != nil {
+		input.InspectionError = err.Error()
+		return buildPodmanBuildKitCachePlan(input)
+	}
+	if len(containers) == 0 {
+		return buildPodmanBuildKitCachePlan(input)
+	}
+
+	input.ContainerID = containers[0].ID
+	input.ContainerName = containers[0].Name
+	output, err := p.runPodmanCommand(ctx, "exec", input.ContainerID, "buildctl", "du")
+	if err != nil {
+		logger.Debug("BuildKit cache inspection failed", "container", input.ContainerName, "error", err)
+		input.InspectionError = err.Error()
+		return buildPodmanBuildKitCachePlan(input)
+	}
+	input.ReclaimableBytes, input.TotalBytes = parseBuildKitDUSummary(output)
+	return buildPodmanBuildKitCachePlan(input)
+}
+
+func buildPodmanBuildKitCachePlan(input podmanBuildKitCachePlanInput) podmanBuildKitCachePlan {
+	keepDuration := strings.TrimSpace(input.KeepDuration)
+	if keepDuration == "" {
+		keepDuration = "24h"
+	}
+	keepStorageMB := input.KeepStorageMB
+	if keepStorageMB <= 0 {
+		keepStorageMB = 8192
+	}
+
+	plan := podmanBuildKitCachePlan{
+		Enabled:          input.Enabled,
+		ContainerID:      input.ContainerID,
+		ContainerName:    input.ContainerName,
+		KeepDuration:     keepDuration,
+		KeepStorageMB:    keepStorageMB,
+		MinReclaimBytes:  input.MinReclaimBytes,
+		ReclaimableBytes: input.ReclaimableBytes,
+		TotalBytes:       input.TotalBytes,
+		InspectionError:  input.InspectionError,
+	}
+
+	switch {
+	case !input.Enabled:
+		plan.SkipReason = "buildkit_prune_disabled"
+	case input.InspectionError != "":
+		plan.SkipReason = "buildkit_cache_inspection_failed"
+	case input.ContainerID == "":
+		plan.SkipReason = "buildkit_container_not_running"
+	case input.ReclaimableBytes <= 0:
+		plan.SkipReason = "buildkit_cache_reclaimable_unknown"
+	case input.MinReclaimBytes > 0 && input.ReclaimableBytes < input.MinReclaimBytes:
+		plan.SkipReason = "below_minimum_buildkit_reclaim"
+	default:
+		plan.CanPrune = true
+	}
+
+	if input.ContainerID != "" {
+		plan.Steps = append(plan.Steps,
+			fmt.Sprintf("Inspect BuildKit cache in Podman container %q", podmanBuildKitContainerLabel(plan)),
+			fmt.Sprintf("Run buildctl prune with keep-duration %s and keep-storage %dMB", plan.KeepDuration, plan.KeepStorageMB),
+		)
+		if runtime.GOOS == "darwin" {
+			plan.Steps = append(plan.Steps, "Run advisory Podman VM fstrim and measure host free-space delta")
+			plan.Warnings = append(plan.Warnings, "BuildKit cache prune is guest-side reclaim; host bytes are counted only from measured host free-space delta")
+		}
+	}
+	if input.InspectionError != "" {
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("BuildKit cache inspection failed: %s", input.InspectionError))
+	}
+
+	return plan
+}
+
+func podmanBuildKitCacheTargets(plan podmanBuildKitCachePlan) []CleanupTarget {
+	if plan.ContainerID == "" && plan.InspectionError == "" {
+		return nil
+	}
+
+	action := "prune_buildkit_cache"
+	reclaim := CleanupReclaimDeferred
+	reason := fmt.Sprintf("BuildKit reports reclaimable cache; prune keeps records newer than %s and at least %dMB", plan.KeepDuration, plan.KeepStorageMB)
+	protected := false
+	if !plan.CanPrune {
+		action = "protect_buildkit_cache"
+		reclaim = CleanupReclaimNone
+		reason = podmanBuildKitSkipReason(plan.SkipReason)
+		protected = true
+	}
+	if plan.SkipReason == "buildkit_cache_inspection_failed" {
+		action = "protect_buildkit_inspection"
+	}
+
+	target := CleanupTarget{
+		Type:      "podman_buildkit_cache",
+		Tier:      CleanupTierWarm,
+		Name:      podmanBuildKitContainerLabel(plan),
+		Bytes:     plan.ReclaimableBytes,
+		Protected: protected,
+		Action:    action,
+		Reason:    reason,
+	}
+	annotateCleanupTargetPolicy(&target, target.Tier, reclaim)
+	return []CleanupTarget{target}
+}
+
+func podmanBuildKitSkipReason(reason string) string {
+	switch reason {
+	case "":
+		return "BuildKit cache prune is not eligible"
+	case "buildkit_prune_disabled":
+		return "BuildKit cache pruning is disabled by config"
+	case "buildkit_container_not_running":
+		return "no running buildx BuildKit container was detected"
+	case "buildkit_cache_reclaimable_unknown":
+		return "BuildKit did not report reclaimable cache"
+	case "below_minimum_buildkit_reclaim":
+		return "BuildKit reclaimable cache is below the configured prune threshold"
+	case "buildkit_cache_inspection_failed":
+		return "BuildKit cache could not be inspected"
+	default:
+		return "BuildKit cache preflight blocked pruning: " + reason
+	}
+}
+
+func podmanBuildKitContainerLabel(plan podmanBuildKitCachePlan) string {
+	if plan.ContainerName != "" {
+		return plan.ContainerName
+	}
+	if plan.ContainerID != "" {
+		return plan.ContainerID
+	}
+	return "buildkit"
+}
+
+func (p *PodmanPlugin) listBuildKitContainers(ctx context.Context) ([]podmanBuildKitContainer, error) {
+	output, err := p.runPodmanCommand(ctx, "ps", "--filter", "name=buildx_buildkit", "--format", "{{.ID}}\t{{.Names}}")
+	if err != nil {
+		return nil, err
+	}
+
+	var containers []podmanBuildKitContainer
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		container := podmanBuildKitContainer{ID: strings.TrimSpace(parts[0])}
+		if len(parts) > 1 {
+			container.Name = strings.TrimSpace(parts[1])
+		}
+		if container.ID == "" {
+			continue
+		}
+		if container.Name == "" {
+			container.Name = container.ID
+		}
+		containers = append(containers, container)
+	}
+	return containers, nil
+}
+
+func parseBuildKitDUSummary(output string) (int64, int64) {
+	var reclaimable int64
+	var total int64
+	re := regexp.MustCompile(`(?im)^\s*(Reclaimable|Total):\s*([0-9]+(?:\.[0-9]+)?)\s*([KMGT]?i?B|[KMGT]?B|B)\s*$`)
+	for _, match := range re.FindAllStringSubmatch(output, -1) {
+		if len(match) < 4 {
+			continue
+		}
+		value, err := strconv.ParseFloat(match[2], 64)
+		if err != nil {
+			continue
+		}
+		bytes := parsePodmanByteQuantity(value, match[3])
+		switch strings.ToLower(match[1]) {
+		case "reclaimable":
+			reclaimable = bytes
+		case "total":
+			total = bytes
+		}
+	}
+	return reclaimable, total
+}
+
+func parseBuildKitPruneSummary(output string) int64 {
+	re := regexp.MustCompile(`(?im)^\s*Total:\s*([0-9]+(?:\.[0-9]+)?)\s*([KMGT]?i?B|[KMGT]?B|B)\s*$`)
+	match := re.FindStringSubmatch(output)
+	if len(match) < 3 {
+		return 0
+	}
+	value, err := strconv.ParseFloat(match[1], 64)
+	if err != nil {
+		return 0
+	}
+	return parsePodmanByteQuantity(value, match[2])
+}
+
+func parsePodmanByteQuantity(value float64, unit string) int64 {
+	unit = strings.ToUpper(strings.TrimSpace(unit))
+	switch {
+	case strings.HasPrefix(unit, "K"):
+		return int64(value * 1024)
+	case strings.HasPrefix(unit, "M"):
+		return int64(value * 1024 * 1024)
+	case strings.HasPrefix(unit, "G"):
+		return int64(value * 1024 * 1024 * 1024)
+	case strings.HasPrefix(unit, "T"):
+		return int64(value * 1024 * 1024 * 1024 * 1024)
+	default:
+		return int64(value)
+	}
 }
 
 // detectPodmanEnvironment detects the Podman runtime environment.
@@ -633,6 +979,58 @@ func (p *PodmanPlugin) trimVMDisk(ctx context.Context, logger *slog.Logger) (int
 	}
 
 	return parseFstrimOutput(string(output)), nil
+}
+
+func (p *PodmanPlugin) trimVMDiskWithHostDelta(ctx context.Context, logger *slog.Logger) (podmanVMDiskTrimResult, error) {
+	result := podmanVMDiskTrimResult{
+		MeasurePath: p.podmanHostMeasurePath(ctx, logger),
+	}
+
+	var before int64
+	var beforeOK bool
+	if result.MeasurePath != "" {
+		if free, err := getFreeDiskSpace(result.MeasurePath); err == nil {
+			before = int64FromUint64(free)
+			beforeOK = true
+		} else {
+			logger.Debug("Podman host free-space preflight failed", "path", result.MeasurePath, "error", err)
+		}
+	}
+
+	trimmed, err := p.trimVMDisk(ctx, logger)
+	result.TrimmedBytes = trimmed
+	if err != nil {
+		return result, err
+	}
+
+	if beforeOK {
+		if free, err := getFreeDiskSpace(result.MeasurePath); err == nil {
+			after := int64FromUint64(free)
+			if after > before {
+				result.HostBytesFreed = after - before
+			}
+		} else {
+			logger.Debug("Podman host free-space post-trim check failed", "path", result.MeasurePath, "error", err)
+		}
+	}
+
+	return result, nil
+}
+
+func (p *PodmanPlugin) podmanHostMeasurePath(ctx context.Context, logger *slog.Logger) string {
+	if runtime.GOOS == "darwin" {
+		if diskPath, err := p.getMachineDiskPath(ctx); err == nil && diskPath != "" {
+			return filepath.Dir(diskPath)
+		} else if err != nil {
+			logger.Debug("Podman disk path unavailable for host free-space measurement", "error", err)
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		return home
+	}
+	return "."
 }
 
 // parseFstrimOutput extracts bytes trimmed from fstrim output.

--- a/plugins/podman_buildkit_test.go
+++ b/plugins/podman_buildkit_test.go
@@ -1,0 +1,114 @@
+package plugins
+
+import "testing"
+
+func TestParseBuildKitDUSummary(t *testing.T) {
+	output := `
+ID									RECLAIMABLE	SIZE
+example								true		10.1GB
+Reclaimable:	23.60GB
+Total:		24.00GB
+`
+	reclaimable, total := parseBuildKitDUSummary(output)
+
+	expectedReclaimable := buildKitTestBytes(23.60)
+	expectedTotal := buildKitTestBytes(24.00)
+	if reclaimable != expectedReclaimable {
+		t.Fatalf("expected reclaimable %d, got %d", expectedReclaimable, reclaimable)
+	}
+	if total != expectedTotal {
+		t.Fatalf("expected total %d, got %d", expectedTotal, total)
+	}
+}
+
+func TestParseBuildKitPruneSummary(t *testing.T) {
+	output := `
+reclaimed records...
+Total:	12.90GB
+`
+	expected := buildKitTestBytes(12.90)
+	if got := parseBuildKitPruneSummary(output); got != expected {
+		t.Fatalf("expected %d, got %d", expected, got)
+	}
+}
+
+func buildKitTestBytes(value float64) int64 {
+	return int64(value * float64(podmanCompactionGiB))
+}
+
+func TestBuildPodmanBuildKitCachePlanEligible(t *testing.T) {
+	plan := buildPodmanBuildKitCachePlan(podmanBuildKitCachePlanInput{
+		Enabled:          true,
+		ContainerID:      "abc123",
+		ContainerName:    "buildx_buildkit_default",
+		KeepDuration:     "24h",
+		KeepStorageMB:    8192,
+		MinReclaimBytes:  4 * podmanCompactionGiB,
+		ReclaimableBytes: 23 * podmanCompactionGiB,
+		TotalBytes:       24 * podmanCompactionGiB,
+	})
+
+	if !plan.CanPrune {
+		t.Fatalf("expected BuildKit cache plan to be eligible, got %q", plan.SkipReason)
+	}
+	if plan.SkipReason != "" {
+		t.Fatalf("expected empty skip reason, got %q", plan.SkipReason)
+	}
+
+	targets := podmanBuildKitCacheTargets(plan)
+	if len(targets) != 1 {
+		t.Fatalf("expected one target, got %#v", targets)
+	}
+	target := targets[0]
+	if target.Type != "podman_buildkit_cache" || target.Action != "prune_buildkit_cache" {
+		t.Fatalf("unexpected BuildKit target: %#v", target)
+	}
+	if target.Protected {
+		t.Fatalf("eligible BuildKit target should not be protected: %#v", target)
+	}
+	if target.Reclaim != CleanupReclaimDeferred || target.HostReclaimsSpace == nil || *target.HostReclaimsSpace {
+		t.Fatalf("BuildKit target should be deferred host reclaim: %#v", target)
+	}
+}
+
+func TestBuildPodmanBuildKitCachePlanBelowMinimum(t *testing.T) {
+	plan := buildPodmanBuildKitCachePlan(podmanBuildKitCachePlanInput{
+		Enabled:          true,
+		ContainerID:      "abc123",
+		ContainerName:    "buildx_buildkit_default",
+		MinReclaimBytes:  4 * podmanCompactionGiB,
+		ReclaimableBytes: 2 * podmanCompactionGiB,
+	})
+
+	if plan.CanPrune {
+		t.Fatal("expected below-minimum BuildKit cache to be protected")
+	}
+	if plan.SkipReason != "below_minimum_buildkit_reclaim" {
+		t.Fatalf("expected below_minimum_buildkit_reclaim, got %q", plan.SkipReason)
+	}
+	target := podmanBuildKitCacheTargets(plan)[0]
+	if target.Action != "protect_buildkit_cache" || !target.Protected {
+		t.Fatalf("expected protected BuildKit target: %#v", target)
+	}
+	if target.Reclaim != CleanupReclaimNone {
+		t.Fatalf("protected BuildKit target should not count reclaim: %#v", target)
+	}
+}
+
+func TestBuildPodmanBuildKitCachePlanInspectionFailure(t *testing.T) {
+	plan := buildPodmanBuildKitCachePlan(podmanBuildKitCachePlanInput{
+		Enabled:         true,
+		InspectionError: "buildctl missing",
+	})
+
+	if plan.CanPrune {
+		t.Fatal("expected inspection failure to block BuildKit prune")
+	}
+	if plan.SkipReason != "buildkit_cache_inspection_failed" {
+		t.Fatalf("expected buildkit_cache_inspection_failed, got %q", plan.SkipReason)
+	}
+	target := podmanBuildKitCacheTargets(plan)[0]
+	if target.Action != "protect_buildkit_inspection" || !target.Protected {
+		t.Fatalf("expected protected inspection target: %#v", target)
+	}
+}


### PR DESCRIPTION
## Summary

- add a critical-level Podman BuildKit cache plan backed by `buildctl du` evidence
- prune BuildKit cache with keep-duration and keep-storage guards, then run advisory VM trim on Darwin
- report BuildKit command bytes separately from measured host free-space deltas
- document the online BuildKit path and expose the new config defaults in `config/default.yaml`

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `git diff --check`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
- `nix build .#default --no-link --print-build-logs`
- dry-run live probe: `go run . --once --dry-run --level critical --plugins podman --output json`

## Notes

The live dry-run found `buildx_buildkit_default` with about 10.7 GiB of reclaimable BuildKit cache after the earlier manual prune. The target is marked `reclaim: deferred`; Darwin host bytes are counted only from measured free-space delta after trim.
