### PR TITLE
[codex] Measure Nix host cleanup deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
   Playwright, Bazelisk, and pip.
 - Nix cleanup preflight plans with dry-run reclaim estimates, generation
   retention targets, daemon-contention detection, and opt-in store optimization.
+- Nix real-cleanup host free-space delta accounting around GC and optional store
+  optimization, separate from command-reported reclaimed bytes.
 - Bazel cache and output-base dry-run planning with active-use detection,
   protected workspace symlink detection, and budget metadata.
 - Top-level dry-run summary fields for planned estimated reclaim, required free

--- a/config/config.go
+++ b/config/config.go
@@ -224,6 +224,8 @@ type NixConfig struct {
 	MinUserGenerations int `yaml:"min_user_generations"`
 	// MinSystemGenerations preserves at least this many system/darwin generations when visible.
 	MinSystemGenerations int `yaml:"min_system_generations"`
+	// HostMeasurePath is the filesystem path used for plugin-isolated host free-space deltas.
+	HostMeasurePath string `yaml:"host_measure_path"`
 	// DeleteGenerationsOlderThan is the normal generation age policy.
 	DeleteGenerationsOlderThan string `yaml:"delete_generations_older_than"`
 	// CriticalDeleteGenerationsOlderThan is the critical-level generation age policy.
@@ -435,6 +437,7 @@ func DefaultConfig() *Config {
 		Nix: NixConfig{
 			MinUserGenerations:                 5,
 			MinSystemGenerations:               3,
+			HostMeasurePath:                    "/nix/store",
 			DeleteGenerationsOlderThan:         "14d",
 			CriticalDeleteGenerationsOlderThan: "3d",
 			AllowStoreOptimize:                 false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -287,6 +287,9 @@ func TestNixPolicyDefaults(t *testing.T) {
 	if cfg.Nix.MinSystemGenerations != 3 {
 		t.Errorf("Nix.MinSystemGenerations should be 3, got %d", cfg.Nix.MinSystemGenerations)
 	}
+	if cfg.Nix.HostMeasurePath != "/nix/store" {
+		t.Errorf("Nix.HostMeasurePath should be /nix/store, got %q", cfg.Nix.HostMeasurePath)
+	}
 	if cfg.Nix.DeleteGenerationsOlderThan != "14d" {
 		t.Errorf("Nix.DeleteGenerationsOlderThan should be 14d, got %q", cfg.Nix.DeleteGenerationsOlderThan)
 	}
@@ -465,6 +468,7 @@ podman:
 nix:
   min_user_generations: 7
   min_system_generations: 4
+  host_measure_path: /nix
   delete_generations_older_than: 21d
   critical_delete_generations_older_than: 5d
   allow_store_optimize: true
@@ -616,6 +620,9 @@ darwin_dev_caches:
 	}
 	if cfg.Nix.MinSystemGenerations != 4 {
 		t.Errorf("Nix.MinSystemGenerations should be 4 per config, got %d", cfg.Nix.MinSystemGenerations)
+	}
+	if cfg.Nix.HostMeasurePath != "/nix" {
+		t.Errorf("Nix.HostMeasurePath should be /nix per config, got %q", cfg.Nix.HostMeasurePath)
 	}
 	if cfg.Nix.DeleteGenerationsOlderThan != "21d" {
 		t.Errorf("Nix.DeleteGenerationsOlderThan should be 21d per config, got %q", cfg.Nix.DeleteGenerationsOlderThan)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -112,6 +112,8 @@ nix:
   # Preserve rollback safety even under disk pressure
   min_user_generations: 5
   min_system_generations: 3
+  # Filesystem used for plugin-isolated host free-space deltas around real Nix GC.
+  host_measure_path: /nix/store
 
   # User generation deletion policy for moderate/aggressive and critical levels
   delete_generations_older_than: 14d

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -22,6 +22,8 @@ The Nix plan includes:
   distinguish a temporary deferral from a cleanup-policy mismatch;
 - `nix_daemon_contention` deferral when dry-run GC itself reports SQLite or
   store lock contention and `skip_when_daemon_busy` is enabled;
+- `host_measure_path`, the filesystem path used to measure plugin-isolated
+  host free-space deltas around real Nix GC and optional store optimization;
 - visible GC roots when dry-run GC reports no reclaimable store space;
 - generation targets with `keep_generation`, `delete_generation`, or
   `review_privileged_generation` actions;
@@ -37,6 +39,7 @@ Default policy:
 nix:
   min_user_generations: 5
   min_system_generations: 3
+  host_measure_path: /nix/store
   delete_generations_older_than: 14d
   critical_delete_generations_older_than: 3d
   allow_store_optimize: false
@@ -61,6 +64,9 @@ Runtime behavior:
 - real generation deletion and GC commands also treat those contention
   signatures as deferred no-op cleanup steps when `skip_when_daemon_busy` is
   enabled;
+- real GC reports Nix command output in `command_bytes_freed` and separately
+  reports measured filesystem free-space growth from `host_measure_path` in
+  `host_bytes_freed`;
 - real cleanup runs a dry-run GC preflight before mutation and skips the actual
   GC command when the preflight reports zero reclaimable store paths and no
   user generation deletion happened in the same cycle;
@@ -93,6 +99,7 @@ Recommended Rocky or Linux runner defaults:
 nix:
   min_user_generations: 3
   min_system_generations: 2
+  host_measure_path: /nix/store
   delete_generations_older_than: 7d
   critical_delete_generations_older_than: 2d
   allow_store_optimize: false

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -19,7 +19,9 @@ import (
 const nixDefaultCommandTimeout = 20 * time.Minute
 
 // NixPlugin handles Nix garbage collection operations.
-type NixPlugin struct{}
+type NixPlugin struct {
+	freeDiskSpace func(string) (uint64, error)
+}
 
 type nixGeneration struct {
 	Number    int
@@ -38,7 +40,7 @@ type nixGCRoot struct {
 
 // NewNixPlugin creates a new Nix cleanup plugin.
 func NewNixPlugin() *NixPlugin {
-	return &NixPlugin{}
+	return &NixPlugin{freeDiskSpace: getFreeDiskSpace}
 }
 
 // Name returns the plugin identifier.
@@ -79,6 +81,7 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 			"skip_when_daemon_busy":                     strconv.FormatBool(cfg.Nix.SkipWhenDaemonBusy),
 			"daemon_busy_backoff":                       cfg.Nix.DaemonBusyBackoff,
 			"max_gc_duration":                           cfg.Nix.MaxGCDuration,
+			"host_measure_path":                         nixHostMeasurePath(cfg.Nix),
 			"root_attribution_limit":                    strconv.Itoa(nixRootAttributionLimit(cfg.Nix)),
 			"generation_policy_delete_older_than_level": nixGenerationPolicyAge(level, cfg.Nix),
 		},
@@ -233,12 +236,14 @@ func (p *NixPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *config
 		gcResult := p.collectGarbage(ctx, level, nil, cfg.Nix, logger)
 		result.BytesFreed += gcResult.BytesFreed
 		result.CommandBytesFreed += gcResult.CommandBytesFreed
+		result.HostBytesFreed += gcResult.HostBytesFreed
 		result.ItemsCleaned += gcResult.ItemsCleaned
 		result.Error = gcResult.Error
 	case LevelCritical:
 		gcResult := p.collectGarbageCritical(ctx, cfg.Nix, logger)
 		result.BytesFreed += gcResult.BytesFreed
 		result.CommandBytesFreed += gcResult.CommandBytesFreed
+		result.HostBytesFreed += gcResult.HostBytesFreed
 		result.ItemsCleaned += gcResult.ItemsCleaned
 		result.Error = gcResult.Error
 	}
@@ -309,6 +314,8 @@ func (p *NixPlugin) collectGarbage(ctx context.Context, level CleanupLevel, args
 	result := CleanupResult{Plugin: p.Name(), Level: level}
 
 	logger.Debug("running nix-collect-garbage", "args", strings.Join(args, " "))
+	measurePath := nixHostMeasurePath(cfg)
+	before, beforeOK := p.measureFreeDiskSpace(measurePath, logger)
 
 	ctx, cancel := context.WithTimeout(ctx, nixCommandTimeout(cfg))
 	defer cancel()
@@ -327,8 +334,51 @@ func (p *NixPlugin) collectGarbage(ctx context.Context, level CleanupLevel, args
 	result.CommandBytesFreed = p.parseFreedSpace(string(output))
 	result.BytesFreed = result.CommandBytesFreed
 	result.ItemsCleaned = p.parseDeletedPaths(string(output))
+	if beforeOK {
+		result.HostBytesFreed = p.measuredHostDelta(before, measurePath, logger)
+	}
 
 	return result
+}
+
+func nixHostMeasurePath(cfg config.NixConfig) string {
+	path := strings.TrimSpace(cfg.HostMeasurePath)
+	if path == "" {
+		path = "/nix/store"
+	}
+	home, _ := os.UserHomeDir()
+	path = filepath.Clean(expandHome(path, home))
+	if pathExists(path) {
+		return path
+	}
+	if pathExists("/nix") {
+		return "/nix"
+	}
+	if home != "" && pathExists(home) {
+		return home
+	}
+	return "."
+}
+
+func (p *NixPlugin) measureFreeDiskSpace(path string, logger *slog.Logger) (int64, bool) {
+	freeDiskSpace := p.freeDiskSpace
+	if freeDiskSpace == nil {
+		freeDiskSpace = getFreeDiskSpace
+	}
+	free, err := freeDiskSpace(path)
+	if err != nil {
+		logger.Debug("Nix host free-space measurement failed", "path", path, "error", err)
+		return 0, false
+	}
+	return int64FromUint64(free), true
+}
+
+func (p *NixPlugin) measuredHostDelta(before int64, path string, logger *slog.Logger) int64 {
+	after, ok := p.measureFreeDiskSpace(path, logger)
+	if !ok || after <= before {
+		return 0
+	}
+	return after - before
 }
 
 func (p *NixPlugin) collectGarbageCritical(ctx context.Context, cfg config.NixConfig, logger *slog.Logger) CleanupResult {
@@ -338,6 +388,7 @@ func (p *NixPlugin) collectGarbageCritical(ctx context.Context, cfg config.NixCo
 	gcResult := p.collectGarbage(ctx, LevelCritical, nil, cfg, logger)
 	result.BytesFreed = gcResult.BytesFreed
 	result.CommandBytesFreed = gcResult.CommandBytesFreed
+	result.HostBytesFreed = gcResult.HostBytesFreed
 	result.ItemsCleaned = gcResult.ItemsCleaned
 	if gcResult.Error != nil {
 		result.Error = gcResult.Error
@@ -350,6 +401,8 @@ func (p *NixPlugin) collectGarbageCritical(ctx context.Context, cfg config.NixCo
 	}
 
 	logger.Warn("CRITICAL: running nix-store --optimize")
+	measurePath := nixHostMeasurePath(cfg)
+	before, beforeOK := p.measureFreeDiskSpace(measurePath, logger)
 	optimizeCtx, cancel := context.WithTimeout(ctx, nixCommandTimeout(cfg))
 	defer cancel()
 
@@ -363,6 +416,9 @@ func (p *NixPlugin) collectGarbageCritical(ctx context.Context, cfg config.NixCo
 	optimizedBytes := p.parseOptimizedSpace(string(output))
 	result.BytesFreed += optimizedBytes
 	result.CommandBytesFreed += optimizedBytes
+	if beforeOK {
+		result.HostBytesFreed += p.measuredHostDelta(before, measurePath, logger)
+	}
 
 	return result
 }
@@ -634,7 +690,7 @@ func nixPlanSteps(level CleanupLevel, cfg config.NixConfig) []string {
 		}
 	}
 
-	steps = append(steps, "Use cleanup-cycle host free-space accounting for before/after disk deltas")
+	steps = append(steps, "Measure the Nix store filesystem before and after real GC for plugin-isolated host byte deltas")
 	return steps
 }
 

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -120,6 +121,88 @@ exit 0
 	}
 	if got, want := string(calls), "--dry-run\n"; got != want {
 		t.Fatalf("unexpected nix-collect-garbage calls %q, want %q", got, want)
+	}
+}
+
+func TestNixCollectGarbageReportsHostDeltaSeparately(t *testing.T) {
+	binDir := t.TempDir()
+	fakeGC := filepath.Join(binDir, "nix-collect-garbage")
+	script := `#!/bin/sh
+printf '%s\n' "would delete 1 store paths"
+printf '%s\n' "16.0 MiB freed"
+`
+	if err := os.WriteFile(fakeGC, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cfg := config.DefaultConfig().Nix
+	cfg.HostMeasurePath = t.TempDir()
+	p := NewNixPlugin()
+	freeValues := []uint64{1000, 1256}
+	p.freeDiskSpace = func(path string) (uint64, error) {
+		if path != cfg.HostMeasurePath {
+			t.Fatalf("expected measure path %q, got %q", cfg.HostMeasurePath, path)
+		}
+		if len(freeValues) == 0 {
+			t.Fatal("free space measured more times than expected")
+		}
+		value := freeValues[0]
+		freeValues = freeValues[1:]
+		return value, nil
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := p.collectGarbage(context.Background(), LevelWarning, nil, cfg, logger)
+	if result.Error != nil {
+		t.Fatalf("collectGarbage returned error: %v", result.Error)
+	}
+	if result.CommandBytesFreed != 16*1024*1024 || result.BytesFreed != result.CommandBytesFreed {
+		t.Fatalf("command bytes should remain separate command evidence: %+v", result)
+	}
+	if result.HostBytesFreed != 256 {
+		t.Fatalf("expected measured host delta 256, got %+v", result)
+	}
+}
+
+func TestNixCollectGarbageSkipsHostDeltaWhenMeasurementFails(t *testing.T) {
+	binDir := t.TempDir()
+	fakeGC := filepath.Join(binDir, "nix-collect-garbage")
+	if err := os.WriteFile(fakeGC, []byte("#!/bin/sh\nprintf '%s\\n' '8.0 MiB freed'\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cfg := config.DefaultConfig().Nix
+	cfg.HostMeasurePath = t.TempDir()
+	p := NewNixPlugin()
+	p.freeDiskSpace = func(string) (uint64, error) {
+		return 0, errors.New("measurement unavailable")
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := p.collectGarbage(context.Background(), LevelWarning, nil, cfg, logger)
+	if result.Error != nil {
+		t.Fatalf("collectGarbage returned error: %v", result.Error)
+	}
+	if result.CommandBytesFreed != 8*1024*1024 {
+		t.Fatalf("expected command bytes from Nix output, got %+v", result)
+	}
+	if result.HostBytesFreed != 0 {
+		t.Fatalf("failed measurement should not invent host bytes: %+v", result)
+	}
+}
+
+func TestNixHostMeasurePathDefaultsAndFallbacks(t *testing.T) {
+	cfg := config.NixConfig{}
+	if got := nixHostMeasurePath(cfg); got == "" {
+		t.Fatal("expected non-empty default host measure path")
+	}
+
+	measurePath := t.TempDir()
+	cfg.HostMeasurePath = measurePath
+	if got := nixHostMeasurePath(cfg); got != measurePath {
+		t.Fatalf("expected configured measure path %q, got %q", measurePath, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `nix.host_measure_path` with a default of `/nix/store`
- measure host free-space deltas around real Nix GC and optional `nix-store --optimize`
- keep command-reported reclaimed bytes separate from measured `host_bytes_freed`
- document the runtime policy and add focused tests for success and measurement-failure paths

Refs #4.
Refs #2.

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'TestNix|TestParseNix'`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./config -run 'TestNix|TestLoadConfig'`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`\n- `git diff --check`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go run . --once --dry-run --level critical --plugins nix --output json`\n- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`\n- `nix build .#default --no-link --print-build-logs`\n\n## Local cleanup note\nThe local validation roots `/tmp/tinyland-cleanup-bazel` and `/tmp/tinyland-cleanup-gocache` were removed after validation. The Nix-only dry run remained non-mutating and found zero reclaimable store paths on this host.