### PR TITLE
[codex] Fix BuildKit prune keep-storage units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,11 @@ All notable changes to this project will be documented in this file.
   `darwin_dev_caches.enabled` is true, avoiding broad `~/Library/Caches`
   sweeps unless the typed policy is disabled.
 
+### Fixed
+
+- Pass BuildKit `--keep-storage` as the numeric MB value expected by `buildctl`
+  during targeted Podman cache pruning.
+
 ## [0.2.0]
 
 ### Added

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -512,11 +512,7 @@ func (p *PodmanPlugin) cleanBuildKitCache(ctx context.Context, cfg *config.Confi
 		"container", podmanBuildKitContainerLabel(plan),
 		"keep_duration", plan.KeepDuration,
 		"keep_storage_mb", plan.KeepStorageMB)
-	output, err := p.runPodmanCommand(ctx,
-		"exec", plan.ContainerID,
-		"buildctl", "prune",
-		"--keep-duration", plan.KeepDuration,
-		"--keep-storage", fmt.Sprintf("%dMB", plan.KeepStorageMB))
+	output, err := p.runPodmanCommand(ctx, podmanBuildKitPruneArgs(plan)...)
 	if err != nil {
 		logger.Warn("BuildKit cache prune failed", "container", podmanBuildKitContainerLabel(plan), "error", err)
 		return result, false
@@ -540,6 +536,15 @@ func (p *PodmanPlugin) cleanBuildKitCache(ctx context.Context, cfg *config.Confi
 	}
 
 	return result, trimRan
+}
+
+func podmanBuildKitPruneArgs(plan podmanBuildKitCachePlan) []string {
+	return []string{
+		"exec", plan.ContainerID,
+		"buildctl", "prune",
+		"--keep-duration", plan.KeepDuration,
+		"--keep-storage", strconv.Itoa(plan.KeepStorageMB),
+	}
 }
 
 func (p *PodmanPlugin) addTrimResult(result *CleanupResult, trim podmanVMDiskTrimResult, logger *slog.Logger) {

--- a/plugins/podman_buildkit_test.go
+++ b/plugins/podman_buildkit_test.go
@@ -1,6 +1,10 @@
 package plugins
 
-import "testing"
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func TestParseBuildKitDUSummary(t *testing.T) {
 	output := `
@@ -68,6 +72,30 @@ func TestBuildPodmanBuildKitCachePlanEligible(t *testing.T) {
 	}
 	if target.Reclaim != CleanupReclaimDeferred || target.HostReclaimsSpace == nil || *target.HostReclaimsSpace {
 		t.Fatalf("BuildKit target should be deferred host reclaim: %#v", target)
+	}
+}
+
+func TestPodmanBuildKitPruneArgsUseNumericKeepStorage(t *testing.T) {
+	plan := podmanBuildKitCachePlan{
+		ContainerID:   "abc123",
+		KeepDuration:  "24h",
+		KeepStorageMB: 8192,
+	}
+
+	args := podmanBuildKitPruneArgs(plan)
+	expected := []string{
+		"exec", "abc123",
+		"buildctl", "prune",
+		"--keep-duration", "24h",
+		"--keep-storage", "8192",
+	}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("unexpected BuildKit prune args: %#v", args)
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, "MB") {
+			t.Fatalf("buildctl keep-storage expects a numeric MB value, got arg %q in %#v", arg, args)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- pass BuildKit `--keep-storage` as a numeric MB value instead of `8192MB`
- add focused coverage for the exact BuildKit prune argv
- record the live dogfood bug in the changelog

Refs #6.
Refs #2.

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test.*BuildKit'`\n- `git diff --check`\n\n## Dogfood note\nWhile exercising the #64 BuildKit path on Darwin, this host buildctl rejected `--keep-storage 8192MB` with a parse error. The accepted form is `--keep-storage 8192`. A corrected manual prune ran successfully afterward, though it reclaimed `0B` under the current 24h / 8 GiB retention guard. Advisory guest `fstrim` then increased host free space from about 6.8 GiB to about 11 GiB.