### PR TITLE
[codex] Gate broad Podman critical prune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@ All notable changes to this project will be documented in this file.
 - Critical Darwin cache cleanup now prefers typed developer-cache targets when
   `darwin_dev_caches.enabled` is true, avoiding broad `~/Library/Caches`
   sweeps unless the typed policy is disabled.
+- Critical Podman cleanup now keeps broad `podman system prune -af --volumes`
+  behind `podman.critical_system_prune`, while targeted BuildKit cache pruning
+  remains enabled by default.
 
 ### Fixed
 

--- a/config/config.go
+++ b/config/config.go
@@ -174,6 +174,8 @@ type PodmanConfig struct {
 	BuildKitPruneKeepStorageMB int `yaml:"buildkit_prune_keep_storage_mb"`
 	// BuildKitPruneMinReclaimGB skips BuildKit pruning below this reclaimable cache size
 	BuildKitPruneMinReclaimGB int `yaml:"buildkit_prune_min_reclaim_gb"`
+	// CriticalSystemPrune enables broad critical system prune with volumes.
+	CriticalSystemPrune bool `yaml:"critical_system_prune"`
 	// CleanInsideVM enables cleanup inside Podman machine VM (Darwin)
 	CleanInsideVM bool `yaml:"clean_inside_vm"`
 	// TrimVMDisk enables fstrim inside VM to reclaim sparse disk space (Darwin)
@@ -412,6 +414,7 @@ func DefaultConfig() *Config {
 			BuildKitPruneKeepDuration:        "24h",
 			BuildKitPruneKeepStorageMB:       8192,
 			BuildKitPruneMinReclaimGB:        4,
+			CriticalSystemPrune:              false,
 			CleanInsideVM:                    true,
 			TrimVMDisk:                       true,
 			CompactMinReclaimGB:              8,

--- a/config/config_pbt_test.go
+++ b/config/config_pbt_test.go
@@ -195,6 +195,9 @@ func TestPodmanConfigDefaults(t *testing.T) {
 	if cfg.Podman.BuildKitPruneMinReclaimGB < 0 {
 		t.Errorf("Podman.BuildKitPruneMinReclaimGB should be non-negative: %d", cfg.Podman.BuildKitPruneMinReclaimGB)
 	}
+	if cfg.Podman.CriticalSystemPrune {
+		t.Error("Podman.CriticalSystemPrune should default to false")
+	}
 
 	// MachineNames should have at least one entry on Darwin
 	// (but we can't check runtime.GOOS in test, so just verify it's set)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -255,6 +255,9 @@ func TestPodmanCompactDefaults(t *testing.T) {
 	if cfg.Podman.BuildKitPruneMinReclaimGB != 4 {
 		t.Errorf("Podman.BuildKitPruneMinReclaimGB should default to 4, got %d", cfg.Podman.BuildKitPruneMinReclaimGB)
 	}
+	if cfg.Podman.CriticalSystemPrune {
+		t.Error("Podman.CriticalSystemPrune should be false by default (opt-in)")
+	}
 	if cfg.Podman.CompactDiskOffline {
 		t.Error("Podman.CompactDiskOffline should be false by default (opt-in)")
 	}
@@ -457,6 +460,7 @@ podman:
   buildkit_prune_keep_duration: 48h
   buildkit_prune_keep_storage_mb: 4096
   buildkit_prune_min_reclaim_gb: 12
+  critical_system_prune: true
   compact_disk_offline: true
   compact_min_reclaim_gb: 12
   compact_require_no_active_containers: false
@@ -596,6 +600,9 @@ darwin_dev_caches:
 	}
 	if cfg.Podman.BuildKitPruneMinReclaimGB != 12 {
 		t.Errorf("Podman.BuildKitPruneMinReclaimGB should be 12 per config, got %d", cfg.Podman.BuildKitPruneMinReclaimGB)
+	}
+	if !cfg.Podman.CriticalSystemPrune {
+		t.Error("Podman.CriticalSystemPrune should be true per config")
 	}
 	if cfg.Podman.CompactMinReclaimGB != 12 {
 		t.Errorf("Podman.CompactMinReclaimGB should be 12 per config, got %d", cfg.Podman.CompactMinReclaimGB)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -85,6 +85,10 @@ podman:
   buildkit_prune_keep_storage_mb: 8192
   buildkit_prune_min_reclaim_gb: 4
 
+  # Broad system prune with volumes can remove stopped-container state and
+  # unused volumes. Keep it explicitly opt-in even under critical pressure.
+  critical_system_prune: false
+
   clean_inside_vm: true
   trim_vm_disk: true
 

--- a/docs/podman-darwin-compaction.md
+++ b/docs/podman-darwin-compaction.md
@@ -13,6 +13,11 @@ a storage floor, then runs advisory `fstrim`. The BuildKit command total is
 reported as `command_bytes_freed`; host reclaim is reported only from the
 measured host free-space delta after the trim.
 
+Broad `podman system prune -af --volumes` is not part of the default critical
+path. It can remove stopped-container state and unused volumes, so it is
+reported as a protected disruptive target unless `podman.critical_system_prune`
+is explicitly enabled.
+
 ## Review
 
 Use dry-run JSON before enabling offline compaction:
@@ -53,11 +58,17 @@ podman:
   buildkit_prune_keep_duration: 24h
   buildkit_prune_keep_storage_mb: 8192
   buildkit_prune_min_reclaim_gb: 4
+  critical_system_prune: false
 ```
 
 This does not stop the Podman VM or delete the builder volume wholesale. It is
 still warm-cache cleanup: active builds may lose reusable cache, so the daemon
 keeps the newest records and a configured storage floor.
+
+Set `critical_system_prune: true` only for an attended emergency pass after
+reviewing stopped containers and unused volumes. This enables broad
+`podman system prune -af --volumes`, external storage pruning when supported,
+and the matching critical VM system-prune path.
 
 Offline compaction is opt-in because it stops the Podman machine:
 

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -220,10 +220,17 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 			plan.Warnings = append(plan.Warnings, "guest fstrim output is not counted as host bytes for this provider; measured host free-space delta remains authoritative")
 		}
 	case LevelCritical:
-		plan.Steps = append(plan.Steps,
-			"Run full Podman system prune with volumes",
-			"Prune external Podman storage when supported",
-		)
+		plan.Metadata["critical_system_prune_enabled"] = strconv.FormatBool(cfg.Podman.CriticalSystemPrune)
+		plan.Targets = append(plan.Targets, podmanCriticalSystemPruneTarget(cfg.Podman.CriticalSystemPrune))
+		if cfg.Podman.CriticalSystemPrune {
+			plan.Steps = append(plan.Steps,
+				"Run full Podman system prune with volumes",
+				"Prune external Podman storage when supported",
+			)
+		} else {
+			plan.Steps = append(plan.Steps, "Skip broad Podman system prune because podman.critical_system_prune=false")
+			plan.Warnings = append(plan.Warnings, "broad Podman system prune with volumes is disabled; enable podman.critical_system_prune only after reviewing stopped containers and unused volumes")
+		}
 		buildKit := p.planBuildKitCache(ctx, cfg, logger)
 		plan.Warnings = append(plan.Warnings, buildKit.Warnings...)
 		plan.Steps = append(plan.Steps, buildKit.Steps...)
@@ -239,8 +246,10 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 		plan.Metadata["buildkit_cache_reclaimable_bytes"] = strconv.FormatInt(buildKit.ReclaimableBytes, 10)
 		plan.Metadata["buildkit_cache_total_bytes"] = strconv.FormatInt(buildKit.TotalBytes, 10)
 		if runtime.GOOS == "darwin" && p.environment.VMRunning {
-			if cfg.Podman.CleanInsideVM {
+			if cfg.Podman.CleanInsideVM && cfg.Podman.CriticalSystemPrune {
 				plan.Steps = append(plan.Steps, "Run critical cleanup inside the Podman VM")
+			} else if cfg.Podman.CleanInsideVM {
+				plan.Steps = append(plan.Steps, "Skip critical Podman VM system prune because podman.critical_system_prune=false")
 			}
 			if cfg.Podman.TrimVMDisk && !p.fstrimReclaimsHostSpace() {
 				plan.Warnings = append(plan.Warnings, "guest fstrim output is not counted as host bytes for this provider; measured host free-space delta remains authoritative")
@@ -438,35 +447,41 @@ func (p *PodmanPlugin) cleanCritical(ctx context.Context, cfg *config.Config, lo
 		result.ItemsCleaned += buildKitResult.ItemsCleaned
 	}
 
-	// Full system prune with volumes
-	logger.Warn("CRITICAL: running full Podman system prune with volumes")
-	output, err := p.runPodmanCommand(ctx, "system", "prune", "-af", "--volumes")
-	if err != nil {
-		logger.Error("full system prune failed", "error", err)
-		result.Error = err
-		return result
-	}
-	result.BytesFreed += p.parseReclaimedSpace(output)
-	result.ItemsCleaned++
-
-	// Clean external/orphaned storage (transient mode)
-	logger.Warn("CRITICAL: cleaning external podman storage")
-	if output, err := p.runPodmanCommand(ctx, "system", "prune", "--external", "-f"); err == nil {
+	if cfg.Podman.CriticalSystemPrune {
+		// Full system prune with volumes.
+		logger.Warn("CRITICAL: running full Podman system prune with volumes")
+		output, err := p.runPodmanCommand(ctx, "system", "prune", "-af", "--volumes")
+		if err != nil {
+			logger.Error("full system prune failed", "error", err)
+			result.Error = err
+			return result
+		}
 		result.BytesFreed += p.parseReclaimedSpace(output)
 		result.ItemsCleaned++
+
+		// Clean external/orphaned storage (transient mode).
+		logger.Warn("CRITICAL: cleaning external podman storage")
+		if output, err := p.runPodmanCommand(ctx, "system", "prune", "--external", "-f"); err == nil {
+			result.BytesFreed += p.parseReclaimedSpace(output)
+			result.ItemsCleaned++
+		} else {
+			// --external might not be supported on older versions
+			logger.Debug("external storage cleanup not available", "error", err)
+		}
 	} else {
-		// --external might not be supported on older versions
-		logger.Debug("external storage cleanup not available", "error", err)
+		logger.Warn("skipping broad Podman system prune with volumes", "reason", "critical_system_prune_disabled")
 	}
 
 	// On Darwin, aggressive VM cleanup
 	if runtime.GOOS == "darwin" && p.environment.VMRunning {
 		// First, clean inside the VM
-		if cfg.Podman.CleanInsideVM {
+		if cfg.Podman.CleanInsideVM && cfg.Podman.CriticalSystemPrune {
 			logger.Warn("CRITICAL: cleaning inside Podman VM")
 			vmResult := p.cleanInsideVM(ctx, LevelCritical, logger)
 			result.BytesFreed += vmResult.BytesFreed
 			result.ItemsCleaned += vmResult.ItemsCleaned
+		} else if cfg.Podman.CleanInsideVM {
+			logger.Warn("skipping critical Podman VM system prune", "reason", "critical_system_prune_disabled")
 		}
 
 		// Then fstrim to reclaim space when the provider reports that discard
@@ -545,6 +560,26 @@ func podmanBuildKitPruneArgs(plan podmanBuildKitCachePlan) []string {
 		"--keep-duration", plan.KeepDuration,
 		"--keep-storage", strconv.Itoa(plan.KeepStorageMB),
 	}
+}
+
+func podmanCriticalSystemPruneTarget(enabled bool) CleanupTarget {
+	target := CleanupTarget{
+		Type:   "podman_system_prune",
+		Name:   "critical Podman system prune",
+		Tier:   CleanupTierDisruptive,
+		Action: "run_system_prune",
+		Reason: "critical level may prune stopped containers, unused images, unused volumes, and external storage",
+	}
+	if enabled {
+		annotateCleanupTargetPolicy(&target, CleanupTierDisruptive, CleanupReclaimDeferred)
+		return target
+	}
+
+	target.Action = "protect_system_prune"
+	target.Protected = true
+	target.Reason = "broad Podman system prune with volumes is disabled by podman.critical_system_prune=false"
+	annotateCleanupTargetPolicy(&target, CleanupTierDisruptive, CleanupReclaimNone)
+	return target
 }
 
 func (p *PodmanPlugin) addTrimResult(result *CleanupResult, trim podmanVMDiskTrimResult, logger *slog.Logger) {

--- a/plugins/podman_buildkit_test.go
+++ b/plugins/podman_buildkit_test.go
@@ -1,9 +1,14 @@
 package plugins
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
 
 func TestParseBuildKitDUSummary(t *testing.T) {
@@ -97,6 +102,64 @@ func TestPodmanBuildKitPruneArgsUseNumericKeepStorage(t *testing.T) {
 			t.Fatalf("buildctl keep-storage expects a numeric MB value, got arg %q in %#v", arg, args)
 		}
 	}
+}
+
+func TestPodmanCriticalPlanProtectsSystemPruneByDefault(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Podman.BuildKitPrune = false
+	p := &PodmanPlugin{environment: &PodmanEnvironment{Runtime: "podman"}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	plan := p.PlanCleanup(context.Background(), LevelCritical, cfg, logger)
+	if plan.Metadata["critical_system_prune_enabled"] != "false" {
+		t.Fatalf("expected critical system prune disabled metadata, got %#v", plan.Metadata)
+	}
+
+	target := findPodmanBuildKitTestTarget(t, plan.Targets, "podman_system_prune")
+	if target.Action != "protect_system_prune" || !target.Protected {
+		t.Fatalf("critical system prune should be protected by default: %#v", target)
+	}
+	if target.Reclaim != CleanupReclaimNone {
+		t.Fatalf("protected system prune should not claim reclaim: %#v", target)
+	}
+	if !strings.Contains(strings.Join(plan.Steps, "\n"), "critical_system_prune=false") {
+		t.Fatalf("plan steps should explain why broad prune is skipped: %#v", plan.Steps)
+	}
+}
+
+func TestPodmanCriticalPlanAllowsOptInSystemPrune(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Podman.BuildKitPrune = false
+	cfg.Podman.CriticalSystemPrune = true
+	p := &PodmanPlugin{environment: &PodmanEnvironment{Runtime: "podman"}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	plan := p.PlanCleanup(context.Background(), LevelCritical, cfg, logger)
+	if plan.Metadata["critical_system_prune_enabled"] != "true" {
+		t.Fatalf("expected critical system prune enabled metadata, got %#v", plan.Metadata)
+	}
+
+	target := findPodmanBuildKitTestTarget(t, plan.Targets, "podman_system_prune")
+	if target.Action != "run_system_prune" || target.Protected {
+		t.Fatalf("critical system prune should be opt-in runnable: %#v", target)
+	}
+	if target.Reclaim != CleanupReclaimDeferred {
+		t.Fatalf("system prune reclaim should stay deferred in dry-run: %#v", target)
+	}
+	if !strings.Contains(strings.Join(plan.Steps, "\n"), "Run full Podman system prune with volumes") {
+		t.Fatalf("plan steps should include broad prune when opted in: %#v", plan.Steps)
+	}
+}
+
+func findPodmanBuildKitTestTarget(t *testing.T, targets []CleanupTarget, targetType string) CleanupTarget {
+	t.Helper()
+	for _, target := range targets {
+		if target.Type == targetType {
+			return target
+		}
+	}
+	t.Fatalf("target %q not found in %#v", targetType, targets)
+	return CleanupTarget{}
 }
 
 func TestBuildPodmanBuildKitCachePlanBelowMinimum(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `podman.critical_system_prune`, defaulting false
- keep targeted critical BuildKit pruning enabled by default
- make broad `podman system prune -af --volumes`, external prune, and critical VM system prune opt-in
- expose a protected `podman_system_prune` dry-run target when broad prune is disabled
- update default config, docs, changelog, and tests

Refs #6.
Refs #2.

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test.*Podman.*(BuildKit|CriticalPlan|Fstrim)|TestBuildPodmanBuildKit|TestParseBuildKit'`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./config -run 'TestPodman|TestLoadConfig'`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`\n- `git diff --check`\n- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go run . --once --dry-run --level critical --plugins podman --output text`\n\n## Dogfood note\nThis came directly from local critical-pressure dogfood. The machine had active fuzzy containers and active lab/Bazel work, so running the existing full Podman critical path would have continued into broad volume prune. Local cleanup stayed targeted: BuildKit-only prune with a tighter attended recency guard, advisory VM fstrim, and exact inactive `/private/tmp` cleanup. Local Bazel/Nix validation was skipped to avoid adding pressure to a host with only a few GiB free.