### PR TITLE
Add Serena project bootstrap

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,46 @@
+# The name by which the project can be referenced within Serena.
+project_name: "tinyland-cleanup"
+
+# Keep this focused on the repo's active implementation and operator surfaces.
+languages:
+  - go
+  - nix
+  - bash
+  - yaml
+
+# Text defaults.
+encoding: "utf-8"
+line_ending:
+
+# Use the global backend setting unless a local operator overrides it.
+language_backend:
+
+# Honor repo ignore rules before indexing generated/cache-heavy trees.
+ignore_all_files_in_gitignore: true
+ls_specific_settings: {}
+ignored_paths:
+  - ".direnv"
+  - "bazel-bin"
+  - "bazel-out"
+  - "bazel-testlogs"
+  - "result"
+  - "dist"
+  - "vendor"
+
+read_only: false
+excluded_tools: []
+included_optional_tools: []
+fixed_tools: []
+base_modes:
+default_modes:
+
+initial_prompt: >-
+  tinyland-cleanup is a conservative disk-pressure cleanup daemon for Tinyland
+  developer machines and CI hosts. Prefer dry-run and plan output before
+  destructive cleanup, keep privileged or disruptive cleanup explicitly opt-in,
+  preserve before/after free-space accounting, and validate Go, Nix, and Bazel
+  surfaces through the repo-managed commands in AGENTS.md.
+
+symbol_info_budget:
+read_only_memory_patterns: []
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary
- add a repo-local Serena project config for tinyland-cleanup
- declare the active language surfaces: Go, Nix, Bash, and YAML
- exclude generated/cache-heavy trees such as Bazel outputs, `result`, `dist`, and `vendor`

## Why
Claude Code's global Serena and gstack hooks are healthy, but Serena still needs a per-repo `.serena/project.yml` to activate cleanly in arbitrary repositories. tinyland-cleanup was missing that file.

## Validation
- `git diff --cached --check`
- `just serena-project-status ../tinyland-cleanup --strict`

Linear: none — local agent/bootstrap hygiene only.
