### PR TITLE
TIN-977 Tighten tinyland-cleanup config contract

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "config/config_pbt_test.go",
         "config/config_test.go",
     ],
+    data = ["config/testdata/home-manager-honey.yaml"],
     embed = [":config"],
     deps = ["@net_pgregory_rapid//:rapid"],
 )
@@ -133,17 +134,17 @@ go_test(
         "plugins/bazel_test.go",
         "plugins/devartifacts_test.go",
         "plugins/nix_test.go",
-        "plugins/podman_buildkit_test.go",
-        "plugins/podman_compaction_test.go",
         "plugins/plugin_pbt_test.go",
         "plugins/plugin_test.go",
+        "plugins/podman_buildkit_test.go",
+        "plugins/podman_compaction_test.go",
         "plugins/sudo_test.go",
     ] + select({
         "@platforms//os:macos": [
             "plugins/apfs_darwin_test.go",
             "plugins/darwin_dev_cache_test.go",
         ],
-        "//conditions:default": [],
+        "//conditions:default": ["plugins/github_runner_linux_test.go"],
     }),
     embed = [":plugins"],
     deps = [
@@ -157,7 +158,7 @@ test_suite(
     tests = [
         ":config_test",
         ":monitor_test",
-        ":tinyland-cleanup_test",
         ":plugins_test",
+        ":tinyland-cleanup_test",
     ],
 )

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -72,6 +73,26 @@ type GitHubRunnerConfig struct {
 	Home string `yaml:"home"`
 	// WorkDir is the work directory (default: <home>/_work)
 	WorkDir string `yaml:"work_dir"`
+	// CacheDir is the cache directory (default: <home>/cache)
+	CacheDir string `yaml:"cache_dir"`
+	// TempDir is the temp directory (default: <home>/tmp)
+	TempDir string `yaml:"temp_dir"`
+	// Instances describes multiple runner homes managed by the same host.
+	Instances []GitHubRunnerInstanceConfig `yaml:"instances"`
+}
+
+// GitHubRunnerInstanceConfig holds cleanup settings for one GitHub Actions runner instance.
+type GitHubRunnerInstanceConfig struct {
+	// Name is a human-readable instance name for logs.
+	Name string `yaml:"name"`
+	// Home directory for this runner.
+	Home string `yaml:"home"`
+	// WorkDir is the work directory (default: <home>/_work)
+	WorkDir string `yaml:"work_dir"`
+	// CacheDir is the cache directory (default: <home>/cache)
+	CacheDir string `yaml:"cache_dir"`
+	// TempDir is the temp directory (default: <home>/tmp)
+	TempDir string `yaml:"temp_dir"`
 }
 
 // MountConfig defines a mount point to monitor with optional custom thresholds.
@@ -563,7 +584,14 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 
-	if err := yaml.Unmarshal(data, config); err != nil {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return config, nil
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(trimmed))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(config); err != nil {
 		return nil, err
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -157,6 +158,79 @@ poll_interval: "not a number"
 	if err == nil {
 		t.Error("expected error for invalid config")
 	}
+}
+
+func TestLoadConfigRejectsUnknownFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `
+poll_interval: 30
+future_only_setting: true
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Fatal("expected unknown field error")
+	}
+	if !strings.Contains(err.Error(), "field future_only_setting not found") {
+		t.Fatalf("expected unknown field error, got %v", err)
+	}
+}
+
+func TestLoadHomeManagerContract(t *testing.T) {
+	cfg, err := LoadConfig(homeManagerContractPath(t))
+	if err != nil {
+		t.Fatalf("home-manager contract fixture should load: %v", err)
+	}
+
+	if cfg.PollInterval != 180 {
+		t.Errorf("expected poll_interval=180, got %d", cfg.PollInterval)
+	}
+	if cfg.Policy.Cooldown != "30m" {
+		t.Errorf("expected policy.cooldown=30m, got %q", cfg.Policy.Cooldown)
+	}
+	if !cfg.Enable.GitHubRunner {
+		t.Error("expected github runner cleanup enabled")
+	}
+	if got := len(cfg.GitHubRunner.Instances); got != 3 {
+		t.Fatalf("expected 3 github runner instances, got %d", got)
+	}
+	if cfg.GitHubRunner.Instances[1].Name != "honey-2" {
+		t.Errorf("unexpected second instance: %#v", cfg.GitHubRunner.Instances[1])
+	}
+	if cfg.GitHubRunner.Instances[2].CacheDir != "/home/github-runner/instances/honey-capped-1/cache" {
+		t.Errorf("expected custom cache_dir to parse, got %q", cfg.GitHubRunner.Instances[2].CacheDir)
+	}
+	if len(cfg.MonitoredMounts) != 4 {
+		t.Errorf("expected 4 monitored mounts, got %d", len(cfg.MonitoredMounts))
+	}
+	if cfg.Nix.HostMeasurePath != "/nix" {
+		t.Errorf("expected nix.host_measure_path=/nix, got %q", cfg.Nix.HostMeasurePath)
+	}
+	if len(cfg.Bazel.WorkspaceRoots) != 2 {
+		t.Errorf("expected 2 bazel workspace roots, got %d", len(cfg.Bazel.WorkspaceRoots))
+	}
+	if !cfg.DarwinDevCaches.JetBrains.KeepActiveVersions {
+		t.Error("expected darwin_dev_caches.jetbrains.keep_active_versions to parse")
+	}
+}
+
+func homeManagerContractPath(t *testing.T) string {
+	t.Helper()
+
+	candidates := []string{
+		filepath.Join("testdata", "home-manager-honey.yaml"),
+		filepath.Join("config", "testdata", "home-manager-honey.yaml"),
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return candidates[0]
 }
 
 func TestDevArtifactsConfigDefaults(t *testing.T) {

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -41,6 +41,18 @@ enable:
 github_runner:
   home: "/home/github-runner"
   work_dir: ""  # Default: <home>/_work
+  cache_dir: "" # Default: <home>/cache
+  temp_dir: ""  # Default: <home>/tmp
+  # For hosts with several runner services, set instances and include the
+  # primary runner here too. When instances is non-empty, instance paths are
+  # authoritative and the top-level home/work_dir pair is treated as legacy
+  # compatibility config.
+  instances: []
+  # - name: honey-2
+  #   home: /home/github-runner/instances/honey-2
+  #   work_dir: /home/github-runner/instances/honey-2/_work
+  #   cache_dir: /home/github-runner/instances/honey-2/cache
+  #   temp_dir: /home/github-runner/instances/honey-2/tmp
 
 # Monitored mount points (multi-volume support)
 # When configured, all listed mounts are checked and the highest cleanup

--- a/config/testdata/home-manager-honey.yaml
+++ b/config/testdata/home-manager-honey.yaml
@@ -1,0 +1,165 @@
+poll_interval: 180
+thresholds:
+  warning: 75
+  moderate: 80
+  aggressive: 85
+  critical: 90
+target_free: 70
+policy:
+  cooldown: 30m
+  state_file: /home/jess/.local/state/tinyland-cleanup/state.json
+log_file: /home/jess/.local/log/disk-cleanup.log
+enable:
+  cache: true
+  nix_gc: true
+  docker: true
+  lima: false
+  homebrew: false
+  ios_simulator: false
+  gitlab_runner: true
+  github_runner: true
+  yum: true
+  podman: true
+  icloud: false
+  photos: false
+  dev_artifacts: true
+  bazel: true
+  apfs_snapshots: false
+dev_artifacts:
+  scan_paths:
+    - ~/git
+    - ~/src
+  scan_max_duration: 30s
+  scan_max_entries: 250000
+  temp_artifacts: true
+  temp_scan_paths:
+    - /tmp
+  temp_scan_max_roots: 128
+  temp_artifact_min_mb: 256
+  temp_artifact_stale_after: 6h
+  node_modules: true
+  python_venvs: true
+  rust_targets: true
+  zig_artifacts: true
+  go_build_cache: true
+  haskell_cache: true
+  lmstudio_models: false
+  large_local_artifacts: true
+  large_local_artifact_min_mb: 1024
+  protect_paths: []
+apfs:
+  thin_enabled: false
+  max_thin_gb: 50
+  keep_recent_days: 1
+  delete_os_updates: false
+docker:
+  socket: unix:///var/run/docker.sock
+  prune_images_age: 24h
+  protect_running_containers: true
+lima:
+  vm_names: []
+  compact_offline: false
+podman:
+  prune_images_age: 24h
+  protect_running_containers: true
+  machine_names: []
+  buildkit_prune: true
+  buildkit_prune_keep_duration: 24h
+  buildkit_prune_keep_storage_mb: 8192
+  buildkit_prune_min_reclaim_gb: 4
+  critical_system_prune: false
+  clean_inside_vm: true
+  trim_vm_disk: true
+  compact_disk_offline: false
+  compact_min_reclaim_gb: 8
+  compact_require_no_active_containers: true
+  compact_keep_backup_until_restart: true
+  compact_provider_allowlist:
+    - qemu
+nix:
+  min_user_generations: 5
+  min_system_generations: 3
+  host_measure_path: /nix
+  delete_generations_older_than: 14d
+  critical_delete_generations_older_than: 3d
+  allow_store_optimize: false
+  skip_when_daemon_busy: true
+  daemon_busy_backoff: 30m
+  max_gc_duration: 20m
+  root_attribution_limit: 20
+bazel:
+  roots:
+    - ~/.cache/bazel
+  workspace_roots:
+    - ~/git
+    - ~/src
+  bazelisk_cache: ~/.cache/bazelisk
+  max_total_gb: 20
+  keep_recent_output_bases: 5
+  stale_after: 14d
+  critical_stale_after: 3d
+  protect_workspaces:
+    - ~/git/lab
+  allow_stop_idle_servers: true
+  allow_delete_active_output_bases: false
+github_runner:
+  home: /home/github-runner
+  work_dir: /home/github-runner/_work
+  instances:
+    - name: honey
+      home: /home/github-runner
+      work_dir: /home/github-runner/_work
+    - name: honey-2
+      home: /home/github-runner/instances/honey-2
+      work_dir: /home/github-runner/instances/honey-2/_work
+    - name: honey-capped-1
+      home: /home/github-runner/instances/honey-capped-1
+      work_dir: /home/github-runner/instances/honey-capped-1/_work
+      cache_dir: /home/github-runner/instances/honey-capped-1/cache
+      temp_dir: /home/github-runner/instances/honey-capped-1/tmp
+darwin_dev_caches:
+  enabled: false
+  enforce: false
+  max_total_gb: 15
+  jetbrains:
+    enabled: true
+    max_gb: 8
+    stale_after_days: 14
+    keep_active_versions: true
+  playwright:
+    enabled: true
+    keep_latest_per_family: true
+  bazelisk:
+    enabled: true
+    keep_latest: 2
+  pip:
+    enabled: true
+    stale_after_days: 14
+  vscode:
+    enabled: true
+    max_gb: 4
+    stale_after_days: 14
+    keep_active_versions: true
+  cursor:
+    enabled: true
+    max_gb: 4
+    stale_after_days: 14
+    keep_active_versions: true
+monitored_mounts:
+  - path: /
+    label: root
+  - path: /var/lib/docker
+    label: docker
+    threshold_warning: 70
+    threshold_critical: 85
+  - path: /nix
+    label: data-home-nix
+    threshold_warning: 70
+    threshold_critical: 85
+  - path: /srv/data-home
+    label: data-home
+    threshold_warning: 70
+    threshold_critical: 85
+notify:
+  enabled: false
+  webhook_url: ""

--- a/plugins/github_runner.go
+++ b/plugins/github_runner.go
@@ -16,6 +16,14 @@ import (
 // GitHubRunnerPlugin handles GitHub Actions runner cleanup operations.
 type GitHubRunnerPlugin struct{}
 
+type githubRunnerTarget struct {
+	name     string
+	home     string
+	workDir  string
+	cacheDir string
+	tempDir  string
+}
+
 // NewGitHubRunnerPlugin creates a new GitHub runner cleanup plugin.
 func NewGitHubRunnerPlugin() *GitHubRunnerPlugin {
 	return &GitHubRunnerPlugin{}
@@ -41,20 +49,58 @@ func (p *GitHubRunnerPlugin) Enabled(cfg *config.Config) bool {
 	return cfg.Enable.GitHubRunner
 }
 
-// githubRunnerPaths returns the set of directories to clean.
+// githubRunnerTargets returns the configured runner directories to clean.
 // Uses config if available, falls back to well-known defaults.
-func (p *GitHubRunnerPlugin) githubRunnerPaths(cfg *config.Config) (runnerHome, workDir, cacheDir, tempDir string) {
-	runnerHome = cfg.GitHubRunner.Home
-	if runnerHome == "" {
-		runnerHome = "/home/github-runner"
+func (p *GitHubRunnerPlugin) githubRunnerTargets(cfg *config.Config) []githubRunnerTarget {
+	if len(cfg.GitHubRunner.Instances) > 0 {
+		targets := make([]githubRunnerTarget, 0, len(cfg.GitHubRunner.Instances))
+		for _, instance := range cfg.GitHubRunner.Instances {
+			targets = append(targets, normalizeGitHubRunnerTarget(
+				instance.Name,
+				instance.Home,
+				instance.WorkDir,
+				instance.CacheDir,
+				instance.TempDir,
+			))
+		}
+		return targets
 	}
-	workDir = cfg.GitHubRunner.WorkDir
+
+	return []githubRunnerTarget{
+		normalizeGitHubRunnerTarget(
+			"default",
+			cfg.GitHubRunner.Home,
+			cfg.GitHubRunner.WorkDir,
+			cfg.GitHubRunner.CacheDir,
+			cfg.GitHubRunner.TempDir,
+		),
+	}
+}
+
+func normalizeGitHubRunnerTarget(name, home, workDir, cacheDir, tempDir string) githubRunnerTarget {
+	if home == "" {
+		home = "/home/github-runner"
+	}
+	if name == "" {
+		name = filepath.Base(home)
+	}
 	if workDir == "" {
-		workDir = filepath.Join(runnerHome, "_work")
+		workDir = filepath.Join(home, "_work")
 	}
-	cacheDir = filepath.Join(runnerHome, "cache")
-	tempDir = filepath.Join(runnerHome, "tmp")
-	return
+	if cacheDir == "" {
+		cacheDir = filepath.Join(home, "cache")
+	}
+	if tempDir == "" {
+		tempDir = filepath.Join(home, "tmp")
+	}
+
+	return githubRunnerTarget{
+		name:     name,
+		home:     home,
+		workDir:  workDir,
+		cacheDir: cacheDir,
+		tempDir:  tempDir,
+	}
 }
 
 // Cleanup performs GitHub runner cleanup at the specified level.
@@ -64,21 +110,29 @@ func (p *GitHubRunnerPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 		Level:  level,
 	}
 
-	runnerHome, workDir, cacheDir, tempDir := p.githubRunnerPaths(cfg)
+	for _, target := range p.githubRunnerTargets(cfg) {
+		result.BytesFreed += p.cleanupTarget(ctx, level, target, logger)
+	}
+
+	return result
+}
+
+func (p *GitHubRunnerPlugin) cleanupTarget(ctx context.Context, level CleanupLevel, target githubRunnerTarget, logger *slog.Logger) int64 {
+	var bytesFreed int64
 
 	// Validate that the runner home actually exists before cleaning
-	if !pathExistsAndIsDir(runnerHome) {
-		logger.Debug("github runner home not found, skipping", "path", runnerHome)
-		return result
+	if !pathExistsAndIsDir(target.home) {
+		logger.Debug("github runner home not found, skipping", "instance", target.name, "path", target.home)
+		return bytesFreed
 	}
 
 	// Warning level: Clean temp directory only
 	if level >= LevelWarning {
-		if pathExistsAndIsDir(tempDir) {
-			freed := deleteOldFilesSameDevice(tempDir, 24*time.Hour)
-			result.BytesFreed += freed
+		if pathExistsAndIsDir(target.tempDir) {
+			freed := deleteOldFilesSameDevice(target.tempDir, 24*time.Hour)
+			bytesFreed += freed
 			if freed > 0 {
-				logger.Debug("cleaned github runner temp", "freed_mb", freed/(1024*1024))
+				logger.Debug("cleaned github runner temp", "instance", target.name, "freed_mb", freed/(1024*1024))
 			}
 		}
 
@@ -94,7 +148,7 @@ func (p *GitHubRunnerPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 				if info, err := os.Stat(path); err == nil && info.ModTime().Before(time.Now().Add(-24*time.Hour)) {
 					size := getDirSizeSameDevice(path)
 					os.RemoveAll(path)
-					result.BytesFreed += size
+					bytesFreed += size
 				}
 			}
 		}
@@ -103,29 +157,29 @@ func (p *GitHubRunnerPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 	// Moderate level: Clean cache and old work directories
 	if level >= LevelModerate {
 		// Clean cache older than 3 days
-		if pathExistsAndIsDir(cacheDir) {
-			sizeBefore := getDirSizeSameDevice(cacheDir)
-			deleteOldFilesSameDevice(cacheDir, 3*24*time.Hour)
-			sizeAfter := getDirSizeSameDevice(cacheDir)
+		if pathExistsAndIsDir(target.cacheDir) {
+			sizeBefore := getDirSizeSameDevice(target.cacheDir)
+			deleteOldFilesSameDevice(target.cacheDir, 3*24*time.Hour)
+			sizeAfter := getDirSizeSameDevice(target.cacheDir)
 			freed := safeBytesDiff(sizeBefore, sizeAfter)
-			result.BytesFreed += freed
+			bytesFreed += freed
 			if freed > 0 {
-				logger.Debug("cleaned github runner cache", "freed_mb", freed/(1024*1024))
+				logger.Debug("cleaned github runner cache", "instance", target.name, "freed_mb", freed/(1024*1024))
 			}
 		}
 
 		// Clean work directories older than 1 day
-		if pathExistsAndIsDir(workDir) {
-			entries, _ := os.ReadDir(workDir)
+		if pathExistsAndIsDir(target.workDir) {
+			entries, _ := os.ReadDir(target.workDir)
 			for _, entry := range entries {
 				if entry.IsDir() {
-					dirPath := filepath.Join(workDir, entry.Name())
+					dirPath := filepath.Join(target.workDir, entry.Name())
 					info, err := entry.Info()
 					if err == nil && info.ModTime().Before(time.Now().Add(-24*time.Hour)) {
 						size := getDirSizeSameDevice(dirPath)
 						os.RemoveAll(dirPath)
-						result.BytesFreed += size
-						logger.Debug("removed old work dir", "dir", entry.Name(), "freed_mb", size/(1024*1024))
+						bytesFreed += size
+						logger.Debug("removed old work dir", "instance", target.name, "dir", entry.Name(), "freed_mb", size/(1024*1024))
 					}
 				}
 			}
@@ -135,13 +189,13 @@ func (p *GitHubRunnerPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 	// Aggressive level: Clean all work directories and Docker resources
 	if level >= LevelAggressive {
 		// Remove all work directories
-		if pathExistsAndIsDir(workDir) {
-			size := getDirSizeSameDevice(workDir)
+		if pathExistsAndIsDir(target.workDir) {
+			size := getDirSizeSameDevice(target.workDir)
 			if size > 0 {
-				os.RemoveAll(workDir)
-				os.MkdirAll(workDir, 0755)
-				result.BytesFreed += size
-				logger.Debug("cleaned all github runner work dirs", "freed_mb", size/(1024*1024))
+				os.RemoveAll(target.workDir)
+				os.MkdirAll(target.workDir, 0755)
+				bytesFreed += size
+				logger.Debug("cleaned all github runner work dirs", "instance", target.name, "freed_mb", size/(1024*1024))
 			}
 		}
 
@@ -156,16 +210,16 @@ func (p *GitHubRunnerPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 	// Critical level: Nuclear cleanup
 	if level >= LevelCritical {
 		// Remove entire cache
-		if pathExistsAndIsDir(cacheDir) {
-			size := getDirSizeSameDevice(cacheDir)
+		if pathExistsAndIsDir(target.cacheDir) {
+			size := getDirSizeSameDevice(target.cacheDir)
 			if size > 0 {
-				os.RemoveAll(cacheDir)
-				os.MkdirAll(cacheDir, 0755)
-				result.BytesFreed += size
-				logger.Debug("removed all github runner cache", "freed_mb", size/(1024*1024))
+				os.RemoveAll(target.cacheDir)
+				os.MkdirAll(target.cacheDir, 0755)
+				bytesFreed += size
+				logger.Debug("removed all github runner cache", "instance", target.name, "freed_mb", size/(1024*1024))
 			}
 		}
 	}
 
-	return result
+	return bytesFreed
 }

--- a/plugins/github_runner_linux_test.go
+++ b/plugins/github_runner_linux_test.go
@@ -1,0 +1,116 @@
+//go:build linux
+
+package plugins
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Jesssullivan/tinyland-cleanup/config"
+)
+
+func TestGitHubRunnerTargetsUseInstances(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.GitHubRunner.Home = "/home/github-runner"
+	cfg.GitHubRunner.WorkDir = "/home/github-runner/_work"
+	cfg.GitHubRunner.Instances = []config.GitHubRunnerInstanceConfig{
+		{
+			Name: "primary",
+			Home: "/runner/primary",
+		},
+		{
+			Name:     "custom",
+			Home:     "/runner/custom",
+			WorkDir:  "/work/custom",
+			CacheDir: "/cache/custom",
+			TempDir:  "/tmp/custom",
+		},
+	}
+
+	targets := NewGitHubRunnerPlugin().githubRunnerTargets(cfg)
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(targets))
+	}
+	if targets[0].workDir != "/runner/primary/_work" {
+		t.Errorf("expected default work dir for primary, got %q", targets[0].workDir)
+	}
+	if targets[0].cacheDir != "/runner/primary/cache" {
+		t.Errorf("expected default cache dir for primary, got %q", targets[0].cacheDir)
+	}
+	if targets[1].workDir != "/work/custom" {
+		t.Errorf("expected custom work dir, got %q", targets[1].workDir)
+	}
+	if targets[1].tempDir != "/tmp/custom" {
+		t.Errorf("expected custom temp dir, got %q", targets[1].tempDir)
+	}
+}
+
+func TestGitHubRunnerCleanupCoversInstances(t *testing.T) {
+	root := t.TempDir()
+	runnerOne := filepath.Join(root, "honey")
+	runnerTwo := filepath.Join(root, "honey-2")
+	makeRunnerTree(t, runnerOne)
+	makeRunnerTree(t, runnerTwo)
+
+	cfg := config.DefaultConfig()
+	cfg.GitHubRunner.Instances = []config.GitHubRunnerInstanceConfig{
+		{Name: "honey", Home: runnerOne},
+		{Name: "honey-2", Home: runnerTwo},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := NewGitHubRunnerPlugin().Cleanup(context.Background(), LevelModerate, cfg, logger)
+	if result.BytesFreed <= 0 {
+		t.Fatalf("expected cleanup to free bytes, got %d", result.BytesFreed)
+	}
+
+	for _, runner := range []string{runnerOne, runnerTwo} {
+		if pathExists(filepath.Join(runner, "tmp", "old.tmp")) {
+			t.Errorf("expected old temp file removed for %s", runner)
+		}
+		if pathExists(filepath.Join(runner, "cache", "old.cache")) {
+			t.Errorf("expected old cache file removed for %s", runner)
+		}
+		if pathExists(filepath.Join(runner, "_work", "old-work")) {
+			t.Errorf("expected old work directory removed for %s", runner)
+		}
+	}
+}
+
+func makeRunnerTree(t *testing.T, home string) {
+	t.Helper()
+
+	oldTime := time.Now().Add(-96 * time.Hour)
+	for _, dir := range []string{
+		filepath.Join(home, "tmp"),
+		filepath.Join(home, "cache"),
+		filepath.Join(home, "_work", "old-work"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	writeOldFile(t, filepath.Join(home, "tmp", "old.tmp"), oldTime)
+	writeOldFile(t, filepath.Join(home, "cache", "old.cache"), oldTime)
+	writeOldFile(t, filepath.Join(home, "_work", "old-work", "artifact"), oldTime)
+	if err := os.Chtimes(filepath.Join(home, "_work", "old-work"), oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes old work dir: %v", err)
+	}
+}
+
+func writeOldFile(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte("old cleanup candidate"), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Reject unknown YAML config keys with `yaml.Decoder.KnownFields(true)` while preserving empty/missing config defaults.
- Add a Home Manager honey-shape contract fixture covering `policy`, `nix`, `bazel`, `darwin_dev_caches`, and multi-runner GitHub Actions config.
- Add real `github_runner.instances` cleanup support, including per-instance `cache_dir` and `temp_dir` overrides.
- Cover the multi-runner path in Go tests and Bazel data/test targets.

## Tracker

Linear: TIN-977
Greptile: not-applicable

## Validation

- `go test ./...`
- `go vet ./...`
- `bazelisk test //:all_tests`
- `nix flake check --no-build`
- `git diff --check`