### PR TITLE
TIN-1010 Scope Bazel output-base activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Active Bazel client processes no longer globally protect unrelated stale
+  output bases; active clients still protect their own output base, and shared
+  cache-tier cleanup remains deferred while Bazel client work is visible.
 - Pass BuildKit `--keep-storage` as the numeric MB value expected by `buildctl`
   during targeted Podman cache pruning.
 

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -26,7 +26,6 @@ estimates when different, host-reclaim expectation, active-use evidence,
 protected status, the planned action, and a reason. Output bases are protected
 when:
 
-- a Bazel or Bazelisk process is active;
 - an active Bazel process exposes an explicit `--output_base`;
 - an output-base lock or server PID file is visible;
 - a configured protected workspace has `bazel-*` symlinks into that output base;
@@ -72,9 +71,9 @@ Runtime boundary:
 - cache-tier cleanup is skipped while active Bazel or Bazelisk client commands
   are visible;
 - process-visible explicit `--output_base` directories are included in the plan
-  even when they are outside configured output-user roots; idle/server-only
-  output-base visibility protects that output base but does not globally block
-  unrelated cache-tier cleanup;
+  even when they are outside configured output-user roots; active clients and
+  idle/server-only output-base visibility protect only their own output base and
+  do not globally block stale unrelated output-base cleanup;
 - aggressive and critical cleanup may classify stale idle-server-only output
   bases as `stop_idle_server_then_delete_output_base` when
   `allow_stop_idle_servers` is enabled; real cleanup runs

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -595,8 +595,8 @@ func newestBazelOutputBases(candidates []bazelCandidate, keep int) map[string]bo
 }
 
 func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration, now time.Time, protectedByRecent bool, globalActive bool, budgetExceeded bool, level CleanupLevel, cfg config.BazelConfig) CleanupTarget {
-	active := candidate.Active || globalActive
-	idleServerOnly := candidate.IdleServer && !candidate.ActiveClient && !globalActive
+	active := candidate.Active || (candidate.Type != "output_base" && globalActive)
+	idleServerOnly := candidate.Type == "output_base" && candidate.IdleServer && !candidate.ActiveClient
 	stale := !candidate.ModTime.After(now.Add(-staleAfter))
 	idleServerStopEligible := candidate.Type == "output_base" &&
 		idleServerOnly &&

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -278,6 +278,59 @@ func TestBazelPlanTargetsDoesNotUseIdleServerAsGlobalCacheActivity(t *testing.T)
 	}
 }
 
+func TestBazelPlanTargetsDoesNotUseActiveClientAsGlobalOutputBaseActivity(t *testing.T) {
+	now := time.Date(2026, 5, 6, 18, 0, 0, 0, time.UTC)
+	cfg := config.BazelConfig{
+		MaxTotalGB:                   1,
+		StaleAfter:                   "14d",
+		CriticalStaleAfter:           "3d",
+		AllowDeleteActiveOutputBases: false,
+		KeepRecentOutputBases:        0,
+	}
+	candidates := []bazelCandidate{
+		{
+			Type:         "output_base",
+			Name:         "active-client-output-base",
+			Path:         "/private/var/tmp/_bazel_jess/active-client",
+			ModTime:      now.Add(-1 * time.Hour),
+			Physical:     2 * bazelGiB,
+			Active:       true,
+			ActiveClient: true,
+			Reason:       "discovered from active Bazel client --output_base",
+		},
+		{
+			Type:     "output_base",
+			Name:     "stale-inactive-output-base",
+			Path:     "/private/var/tmp/_bazel_jess/stale-inactive",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 4 * bazelGiB,
+		},
+		{
+			Type:     "disk_cache",
+			Name:     "disk_cache",
+			Path:     "/private/var/tmp/_bazel_jess/disk_cache",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+		},
+	}
+
+	targets, _ := bazelPlanTargets(candidates, cfg, LevelCritical, now, true)
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Name] = target
+	}
+
+	if actions["active-client-output-base"].Action != "keep" || !actions["active-client-output-base"].Protected || !actions["active-client-output-base"].Active {
+		t.Fatalf("active client output base should remain protected: %#v", actions["active-client-output-base"])
+	}
+	if actions["stale-inactive-output-base"].Action != "delete_output_base" || actions["stale-inactive-output-base"].Protected || actions["stale-inactive-output-base"].Active {
+		t.Fatalf("unrelated stale output base should remain eligible despite active Bazel client elsewhere: %#v", actions["stale-inactive-output-base"])
+	}
+	if actions["disk_cache"].Action != "keep" || !actions["disk_cache"].Protected || !actions["disk_cache"].Active {
+		t.Fatalf("shared cache tier should stay protected while Bazel client work is active: %#v", actions["disk_cache"])
+	}
+}
+
 func TestBazelPlanTargetsCanStopIdleServerBeforeDeletingStaleOutputBase(t *testing.T) {
 	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 	cfg := config.BazelConfig{


### PR DESCRIPTION
## Summary

- Keep Bazel active-client protection scoped to the active client output base instead of globally protecting every stale output base.
- Continue protecting shared Bazel cache tiers while Bazel client commands are visible.
- Add a neo-shaped regression test and update the Bazel policy docs/changelog.

## Tracker

Linear: TIN-1010
Refs: #2, #3
Greptile: disabled after spend incident

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run TestBazel`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //:all_tests`
- `nix build .#default --no-link --print-build-logs`
- `git diff --check`

Note: Bazel passed all 4 test targets. It warned that convenience symlinks could not be refreshed from this sandboxed session, but the build/test completed successfully.