### PR TITLE
TIN-1010 Refine Bazel reclaim byte estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this project will be documented in this file.
   optimization, separate from command-reported reclaimed bytes.
 - Bazel cache and output-base dry-run planning with active-use detection,
   protected workspace symlink detection, and budget metadata.
+- Bazel reclaim candidates now refine byte estimates with a bounded recursive
+  allocation walk so stale output-base dry-runs do not understate large nested
+  `execroot` and `bazel-out` trees.
 - Top-level dry-run summary fields for planned estimated reclaim, required free
   space, and cleanup target count.
 - Target-free report fields and real-cleanup stop behavior once the configured

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -21,10 +21,11 @@ The Bazel plan includes targets for:
 - `disk_cache`: local action cache entries;
 - `bazelisk`: Bazelisk download cache entries.
 
-Targets include policy tier, bounded physical byte estimates, logical byte
-estimates when different, host-reclaim expectation, active-use evidence,
-protected status, the planned action, and a reason. Output bases are protected
-when:
+Targets include policy tier, physical byte estimates, logical byte estimates
+when different, host-reclaim expectation, active-use evidence, protected status,
+the planned action, and a reason. Reclaimable output-base targets get a bounded
+recursive allocation refinement so nested `execroot` and `bazel-out` bytes are
+visible in dry-run plans. Output bases are protected when:
 
 - an active Bazel process exposes an explicit `--output_base`;
 - an output-base lock or server PID file is visible;
@@ -84,8 +85,10 @@ Runtime boundary:
 - after an output base is deleted, workspace roots are scanned shallowly for
   canonical repo-local `bazel-*` symlinks, and only symlinks whose raw target
   points inside that deleted output base are removed;
-- byte counts use top-level allocation estimates so dry-run remains responsive
-  on very large generated trees;
+- protected/review byte counts use top-level allocation estimates so dry-run
+  remains responsive on very large generated trees; reclaimable output-base
+  targets use a bounded recursive refinement and mark the plan partial if the
+  refinement times out;
 - Bazel output bases, repository caches, and disk caches are `warm` targets
   because they are rebuildable but expensive; Bazelisk downloads are `safe`
   targets;

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -19,6 +19,7 @@ import (
 )
 
 const bazelGiB = int64(1024 * 1024 * 1024)
+const bazelReclaimEstimateTimeout = 30 * time.Second
 
 var bazelCommandPattern = regexp.MustCompile(`\b(bazel|bazelisk)\s+(build|test|run|coverage|query|sync|fetch|clean|mobile-install|aquery|cquery|mod)\b`)
 
@@ -126,6 +127,15 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 	globalActive := len(activeInfo.Reasons) > 0
 	candidates := p.discoverCandidates(home, cfg.Bazel, activeInfo)
 	targets, totalPhysical := bazelPlanTargets(candidates, cfg.Bazel, level, time.Now(), globalActive)
+	targets, refined, refineErr := refineBazelReclaimTargetBytes(ctx, targets)
+	if refined {
+		plan.Metadata["reclaim_size_estimate_refined"] = "true"
+	}
+	if refineErr != nil {
+		plan.Metadata["reclaim_size_estimate_partial"] = "true"
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("Bazel reclaim-byte refinement was partial: %v", refineErr))
+	}
+
 	plan.Targets = targets
 	plan.EstimatedBytesFreed = bazelEstimatedCandidateBytes(targets)
 	plan.Metadata["target_count"] = strconv.Itoa(len(targets))
@@ -136,7 +146,7 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 		plan.Warnings = append(plan.Warnings, "detected Bazel cache footprint exceeds configured review budget")
 	}
 	plan.Warnings = append(plan.Warnings, "Bazel cleanup deletes rebuildable cache tiers only when the total footprint exceeds the configured budget and active-use inspection succeeds")
-	plan.Warnings = append(plan.Warnings, "Bazel byte counts use bounded top-level allocation estimates so dry-run stays responsive on very large output bases")
+	plan.Warnings = append(plan.Warnings, "Bazel protected/review byte counts use bounded top-level allocation estimates; reclaim targets use a bounded recursive refinement")
 
 	return plan, activeErr
 }
@@ -446,6 +456,70 @@ func estimateBazelCandidateBytes(path string) (int64, int64) {
 	}
 
 	return logical, physical
+}
+
+func refineBazelReclaimTargetBytes(ctx context.Context, targets []CleanupTarget) ([]CleanupTarget, bool, error) {
+	estimateCtx, cancel := context.WithTimeout(ctx, bazelReclaimEstimateTimeout)
+	defer cancel()
+
+	refined := false
+	for i := range targets {
+		if !bazelTargetReclaimsHost(targets[i]) {
+			continue
+		}
+		logical, physical, err := estimateBazelCandidateBytesRecursive(estimateCtx, targets[i].Path)
+		if physical > targets[i].Bytes {
+			targets[i].Bytes = physical
+			refined = true
+		}
+		if logical > targets[i].LogicalBytes {
+			targets[i].LogicalBytes = logical
+		}
+		if err != nil {
+			return targets, refined, err
+		}
+	}
+	return targets, refined, nil
+}
+
+func estimateBazelCandidateBytesRecursive(ctx context.Context, path string) (int64, int64, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolved = path
+	}
+	rootDev, err := deviceID(resolved)
+	if err != nil {
+		logical, physical := estimateBazelCandidateBytes(path)
+		return logical, physical, err
+	}
+
+	var logical int64
+	var physical int64
+	walkErr := filepath.Walk(resolved, func(p string, info os.FileInfo, err error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err != nil {
+			return nil
+		}
+		if dev, err := deviceID(p); err == nil && dev != rootDev {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		logical += info.Size()
+		if allocated, err := getFileAllocatedBytes(p); err == nil {
+			physical += allocated
+		} else {
+			physical += info.Size()
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return logical, physical, walkErr
+	}
+	return logical, physical, ctx.Err()
 }
 
 func isBazelOutputBase(path string) bool {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -141,6 +141,55 @@ func TestBazelPlanTargetsProtectsRecentActiveAndWorkspaces(t *testing.T) {
 	}
 }
 
+func TestRefineBazelReclaimTargetBytesUsesRecursiveAllocation(t *testing.T) {
+	outputBase := filepath.Join(t.TempDir(), "output-base")
+	makeBazelOutputBase(t, outputBase)
+	nested := filepath.Join(outputBase, "execroot", "repo", "bazel-out", "darwin-fastbuild", "bin")
+	mustMkdir(t, nested)
+	payload := filepath.Join(nested, "large.o")
+	if err := os.WriteFile(payload, bytesOfSize(2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := []CleanupTarget{
+		{
+			Type:      "output_base",
+			Name:      "output-base",
+			Path:      outputBase,
+			Bytes:     1,
+			Action:    "delete_output_base",
+			Protected: false,
+			Active:    false,
+		},
+		{
+			Type:      "output_base",
+			Name:      "protected",
+			Path:      outputBase,
+			Bytes:     1,
+			Action:    "keep",
+			Protected: true,
+			Active:    false,
+		},
+	}
+
+	refined, changed, err := refineBazelReclaimTargetBytes(context.Background(), targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected reclaim target bytes to be refined")
+	}
+	if refined[0].Bytes < 2*1024*1024 {
+		t.Fatalf("delete target bytes = %d, want at least payload size", refined[0].Bytes)
+	}
+	if refined[0].LogicalBytes < 2*1024*1024 {
+		t.Fatalf("delete target logical bytes = %d, want at least payload size", refined[0].LogicalBytes)
+	}
+	if refined[1].Bytes != 1 {
+		t.Fatalf("protected target should not be recursively measured: %#v", refined[1])
+	}
+}
+
 func TestBazelPlanTargetsDeletesCacheTiersOnlyWhenBudgetExceeded(t *testing.T) {
 	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 	cfg := config.BazelConfig{
@@ -756,4 +805,12 @@ func mustMkdir(t *testing.T, path string) {
 	if err := os.MkdirAll(path, 0755); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func bytesOfSize(size int) []byte {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	return data
 }


### PR DESCRIPTION
## Summary
- refine byte estimates for Bazel targets that are already eligible for host-space reclaim using a bounded recursive allocation walk
- keep protected/review targets on the cheap top-level estimate path and mark dry-runs partial if refinement times out
- document the refined estimate boundary and add a regression test for nested output-base payloads

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test(Bazel|Refine)'
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //:all_tests
- nix build .#default --no-link --print-build-logs
- live neo patched dry-run: 75G Bazel root now reports 39.0 GiB partial reclaim estimate instead of 13.0 MiB