### PR TITLE
TIN-1011 Avoid symlink target allocation accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,10 @@ All notable changes to this project will be documented in this file.
   cache-tier cleanup remains deferred while Bazel client work is visible.
 - Pass BuildKit `--keep-storage` as the numeric MB value expected by `buildctl`
   during targeted Podman cache pruning.
+- Filesystem allocation walks now account for symlink entries with `lstat`, so
+  temporary symlink forests such as Nix shell roots are not reported as
+  multi-GiB reclaim candidates by charging their `/nix/store` targets to the
+  containing temp directory.
 
 ## [0.2.0]
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ Large top-level temp roots remain review-only, but stale inactive roots may
 also expose narrower generated-output targets such as Rust `target/`
 directories for safe pruning without deleting the worktree. If scan budgets are
 hit, dry-run output marks the evidence partial with `scan_budget_exhausted` and
-lists `scan_truncated_paths`.
+lists `scan_truncated_paths`. Symlink-heavy temporary roots, including Nix
+shell symlink forests, are measured as symlink entries rather than as the store
+paths they point at.
 
 For a one-off run, override the configured maximum used-space target without
 editing the config file:

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -199,7 +199,10 @@ critical pressure. Dev-artifact filesystem walking is bounded by
 `dev_artifacts.scan_max_duration`, `dev_artifacts.scan_max_entries`, and
 `dev_artifacts.temp_scan_max_roots`; when a budget is hit, dry-run metadata sets
 `scan_budget_exhausted: true`, reports `scan_truncated_paths`, and treats the
-omitted evidence as non-actionable.
+omitted evidence as non-actionable. Symlink-heavy temporary roots, including Nix
+shell symlink forests, are measured as symlink entries rather than as the
+`/nix/store` paths they point at, so dry-run byte counts do not attribute store
+closures to temporary proof directories.
 
 For Docker, the plan reports Docker daemon disk-usage rows from `docker system
 df`, including images, stopped containers, local volumes, and build cache when

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -836,6 +836,38 @@ func TestPlanTemporaryArtifactsReportsReviewOnlyTargets(t *testing.T) {
 	}
 }
 
+func TestPlanTemporaryArtifactsDoesNotChargeSymlinkTargets(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "nix-shell.symlink-forest")
+	targetDir := filepath.Join(tmpDir, "store-target")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "large-store-file"), bytesOfSize(2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(targetDir, "large-store-file"), filepath.Join(root, "tool")); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	oldTime := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(root, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	p.planTemporaryArtifacts(context.Background(), tmpDir, 1024*1024, 6*time.Hour, nil, nil, &targets)
+
+	for _, target := range targets {
+		if target.Path == root {
+			t.Fatalf("symlink forest should not be reported as large temp artifact, got %#v", target)
+		}
+	}
+}
+
 func TestPlanCleanupReportsGeneratedArtifactsInsideStaleTemporaryRoots(t *testing.T) {
 	p := newDevArtifactsPluginWithActive(nil)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/plugins/fs.go
+++ b/plugins/fs.go
@@ -149,10 +149,12 @@ func getFreeDiskSpace(path string) (uint64, error) {
 	return stat.Bavail * uint64(stat.Bsize), nil
 }
 
-// getFileAllocatedBytes returns physical blocks allocated on disk for a file.
+// getFileAllocatedBytes returns physical blocks allocated on disk for a file or
+// symlink. It intentionally uses lstat so symlink forests do not charge the
+// allocation of their /nix/store targets to the directory that contains them.
 // It falls back to apparent size if the filesystem does not report blocks.
 func getFileAllocatedBytes(path string) (int64, error) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Linear: TIN-1011

## What changed
- Measure file allocation with lstat so symlink forests are charged as symlinks, not as their targets.
- Add a regression test for Nix-shell-style temporary symlink forests.
- Document the dry-run accounting behavior in the README, operator workflow, and changelog.

## Why
Neo dry-runs were attributing /nix/store target allocation to /private/tmp/nix-* symlink forests, producing phantom multi-GiB dev-artifact candidates.

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //:all_tests
- live patched dry-run: dev-artifacts reports 0 B reclaim and no /private/tmp/nix-* phantom targets