### PR TITLE
Add dry-run byte disposition accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ All notable changes to this project will be documented in this file.
 - Dry-run cleanup targets now carry policy tier, logical byte, reclaim kind,
   and host-space reclaim expectation metadata where planner evidence is
   available.
+- Darwin developer-cache and development-artifact dry-runs now summarize
+  target bytes by host-reclaim candidate, deferred reclaim, protected, active
+  protected, and review-only disposition.
 - Review-only sparsebundle targets now report logical size from `Info.plist`
   when available, making APFS bundle physical-vs-logical accounting visible in
   dry-run plans.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ lists `scan_truncated_paths`. Symlink-heavy temporary roots, including Nix
 shell symlink forests, are measured as symlink entries rather than as the store
 paths they point at.
 
+For Darwin developer-cache and development-artifact plans, dry-run metadata and
+text reports separate bytes that are direct host-reclaim candidates from bytes
+that are protected, active-protected, deferred, or review-only. Use that
+accounting when a host is full but the safe reclaim estimate is near zero.
+
 For a one-off run, override the configured maximum used-space target without
 editing the config file:
 

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -85,6 +85,19 @@ Structured plugin targets may include policy metadata:
 
 Use this metadata to separate cheap cache cleanup from expensive rebuilds,
 privileged actions, and review-only evidence before applying a real cleanup.
+For Darwin developer-cache and development-artifact plans, plugin metadata also
+rolls target bytes up by disposition:
+
+- `host_reclaim_candidate_bytes`: unprotected targets expected to free host
+  space directly;
+- `deferred_reclaim_candidate_bytes`: unprotected targets that only enable
+  later host-space reclamation;
+- `protected_physical_bytes`: protected targets that explain pressure but are
+  not cleanup candidates;
+- `active_protected_physical_bytes`: the protected subset blocked by active-use
+  evidence;
+- `review_physical_bytes`: measured review-only targets that require manual
+  operator action.
 
 ## Probe Darwin Volumes
 

--- a/main_test.go
+++ b/main_test.go
@@ -135,6 +135,14 @@ func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
 				},
 			},
 			Warnings: []string{"review before cleanup"},
+			Metadata: map[string]string{
+				"total_physical_bytes":             "1024",
+				"host_reclaim_candidate_bytes":     "0",
+				"deferred_reclaim_candidate_bytes": "0",
+				"protected_physical_bytes":         "1024",
+				"active_protected_physical_bytes":  "0",
+				"review_physical_bytes":            "0",
+			},
 		},
 	}
 	daemon := newTestDaemon(t, mock, &output)
@@ -152,6 +160,7 @@ func TestRunOnceDryRunTextReportExplainsPlan(t *testing.T) {
 		"plan: estimated reclaim 1.0 MiB",
 		"- reporting: would run (dry_run)",
 		"reporting dry-run plan",
+		"accounting: total 1.0 KiB, host reclaim 0 B, deferred 0 B, protected 1.0 KiB, active protected 0 B, review 0 B",
 		"example-cache (/tmp/example-cache) [cache]: review, protected, tier=warm, reclaim=none, 1.0 KiB - operator review required",
 		"review before cleanup",
 	} {

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -928,8 +928,7 @@ func (p *CachePlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *
 
 	plan.Targets = targets
 	plan.EstimatedBytesFreed = estimated
-	plan.Metadata["target_count"] = strconv.Itoa(len(targets))
-	plan.Metadata["total_physical_bytes"] = strconv.FormatInt(total, 10)
+	annotateCleanupPlanTargetAccounting(&plan)
 
 	if cfg.DarwinDevCaches.MaxTotalGB > 0 && total > int64(cfg.DarwinDevCaches.MaxTotalGB)*1024*1024*1024 {
 		plan.Warnings = append(plan.Warnings, "known Darwin developer caches exceed configured review budget")

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -286,17 +286,15 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 		return targets[i].Bytes > targets[j].Bytes
 	})
 
-	var total, estimated int64
+	var estimated int64
 	for _, target := range targets {
-		total += target.Bytes
 		if target.Action == "delete" || target.Action == "clean-cache" {
 			estimated += target.Bytes
 		}
 	}
 	plan.Targets = targets
 	plan.EstimatedBytesFreed = estimated
-	plan.Metadata["target_count"] = strconv.Itoa(len(targets))
-	plan.Metadata["total_physical_bytes"] = strconv.FormatInt(total, 10)
+	annotateCleanupPlanTargetAccounting(&plan)
 	scanBudget.annotatePlan(&plan)
 
 	return plan

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -616,6 +617,17 @@ func TestPlanCleanupModerateClassifiesDevArtifacts(t *testing.T) {
 	if plan.Metadata["mutates"] != "true" {
 		t.Fatalf("expected mutates=true metadata, got %#v", plan.Metadata)
 	}
+	if got := plan.Metadata["host_reclaim_candidate_bytes"]; got != strconv.FormatInt(oldTarget.Bytes, 10) {
+		t.Fatalf("expected stale delete bytes to be host reclaim candidates, got %q metadata=%#v", got, plan.Metadata)
+	}
+	protectedBytes := requirePlanMetadataInt64(t, plan.Metadata, "protected_physical_bytes")
+	if protectedBytes != freshTarget.Bytes+protectedTarget.Bytes {
+		t.Fatalf("expected protected byte accounting for fresh/configured targets, got %d metadata=%#v", protectedBytes, plan.Metadata)
+	}
+	totalBytes := requirePlanMetadataInt64(t, plan.Metadata, "total_physical_bytes")
+	if totalBytes != oldTarget.Bytes+freshTarget.Bytes+protectedTarget.Bytes {
+		t.Fatalf("expected total byte accounting across all targets, got %d metadata=%#v", totalBytes, plan.Metadata)
+	}
 }
 
 func TestPlanNodeModulesProtectsActiveDevelopmentProcess(t *testing.T) {
@@ -645,6 +657,50 @@ func TestPlanNodeModulesProtectsActiveDevelopmentProcess(t *testing.T) {
 	target := findDevArtifactTarget(t, targets, "node_modules", filepath.Join(project, "node_modules"))
 	if target.Action != "protect" || !target.Protected || !target.Active {
 		t.Fatalf("expected active node_modules to be protected, got %#v", target)
+	}
+}
+
+func TestPlanCleanupAccountsActiveProtectedDevArtifacts(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(map[string]string{
+		"node_modules": "Node.js package manager or runtime",
+	})
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	tmpDir := t.TempDir()
+	project := filepath.Join(tmpDir, "active-project")
+	if err := os.MkdirAll(filepath.Join(project, "node_modules", "pkg"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "node_modules", "pkg", "index.js"), []byte("module.exports = {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	packageJSON := filepath.Join(project, "package.json")
+	if err := os.WriteFile(packageJSON, []byte(`{"name":"active"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	if err := os.Chtimes(packageJSON, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.DevArtifacts.ScanPaths = []string{tmpDir}
+	cfg.DevArtifacts.PythonVenvs = false
+	cfg.DevArtifacts.RustTargets = false
+	cfg.DevArtifacts.ZigArtifacts = false
+	cfg.DevArtifacts.GoBuildCache = false
+	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.TempArtifacts = false
+
+	plan := p.PlanCleanup(context.Background(), LevelAggressive, cfg, logger)
+	target := findDevArtifactTarget(t, plan.Targets, "node_modules", filepath.Join(project, "node_modules"))
+	if target.Action != "protect" || !target.Protected || !target.Active {
+		t.Fatalf("expected active node_modules to be protected, got %#v", target)
+	}
+	if got := plan.Metadata["active_protected_physical_bytes"]; got != strconv.FormatInt(target.Bytes, 10) {
+		t.Fatalf("expected active protected bytes to match target size, got %q metadata=%#v", got, plan.Metadata)
+	}
+	if got := plan.Metadata["host_reclaim_candidate_bytes"]; got != "0" {
+		t.Fatalf("active protected artifact should not be a host reclaim candidate, got %q", got)
 	}
 }
 
@@ -1159,4 +1215,17 @@ func newDevArtifactsPluginWithActive(active map[string]string) *DevArtifactsPlug
 			return active, nil
 		},
 	}
+}
+
+func requirePlanMetadataInt64(t *testing.T, metadata map[string]string, key string) int64 {
+	t.Helper()
+	raw, ok := metadata[key]
+	if !ok {
+		t.Fatalf("expected metadata key %q in %#v", key, metadata)
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("metadata key %q should be an int64, got %q: %v", key, raw, err)
+	}
+	return value
 }

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/Jesssullivan/tinyland-cleanup/config"
@@ -174,6 +175,55 @@ func hostReclaimForAction(action string) string {
 	default:
 		return CleanupReclaimNone
 	}
+}
+
+func annotateCleanupPlanTargetAccounting(plan *CleanupPlan) {
+	if plan.Metadata == nil {
+		plan.Metadata = map[string]string{}
+	}
+
+	var totalPhysical int64
+	var hostReclaimCandidate int64
+	var deferredReclaimCandidate int64
+	var protectedPhysical int64
+	var activeProtectedPhysical int64
+	var reviewPhysical int64
+
+	for _, target := range plan.Targets {
+		if target.Bytes <= 0 {
+			continue
+		}
+		totalPhysical += target.Bytes
+
+		if target.Protected {
+			protectedPhysical += target.Bytes
+			if target.Active {
+				activeProtectedPhysical += target.Bytes
+			}
+			continue
+		}
+
+		reclaim := target.Reclaim
+		if reclaim == "" {
+			reclaim = hostReclaimForAction(target.Action)
+		}
+		switch reclaim {
+		case CleanupReclaimHost:
+			hostReclaimCandidate += target.Bytes
+		case CleanupReclaimDeferred:
+			deferredReclaimCandidate += target.Bytes
+		default:
+			reviewPhysical += target.Bytes
+		}
+	}
+
+	plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
+	plan.Metadata["total_physical_bytes"] = strconv.FormatInt(totalPhysical, 10)
+	plan.Metadata["host_reclaim_candidate_bytes"] = strconv.FormatInt(hostReclaimCandidate, 10)
+	plan.Metadata["deferred_reclaim_candidate_bytes"] = strconv.FormatInt(deferredReclaimCandidate, 10)
+	plan.Metadata["protected_physical_bytes"] = strconv.FormatInt(protectedPhysical, 10)
+	plan.Metadata["active_protected_physical_bytes"] = strconv.FormatInt(activeProtectedPhysical, 10)
+	plan.Metadata["review_physical_bytes"] = strconv.FormatInt(reviewPhysical, 10)
 }
 
 // Plugin is the interface that cleanup plugins must implement.

--- a/report_text.go
+++ b/report_text.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/Jesssullivan/tinyland-cleanup/monitor"
@@ -172,6 +173,9 @@ func writeTextPluginReport(w io.Writer, plugin pluginCycleReport) error {
 				return err
 			}
 		}
+		if err := writeTextPlanAccounting(w, plan.Metadata); err != nil {
+			return err
+		}
 		if len(plan.Warnings) > 0 {
 			if err := writeTextList(w, "  warnings:", plan.Warnings, 3); err != nil {
 				return err
@@ -215,6 +219,40 @@ func writeTextPluginReport(w io.Writer, plugin pluginCycleReport) error {
 		}
 	}
 	return nil
+}
+
+func writeTextPlanAccounting(w io.Writer, metadata map[string]string) error {
+	total, ok := planMetadataInt64(metadata, "total_physical_bytes")
+	if !ok || total <= 0 {
+		return nil
+	}
+	hostReclaim, _ := planMetadataInt64(metadata, "host_reclaim_candidate_bytes")
+	deferred, _ := planMetadataInt64(metadata, "deferred_reclaim_candidate_bytes")
+	protected, _ := planMetadataInt64(metadata, "protected_physical_bytes")
+	activeProtected, _ := planMetadataInt64(metadata, "active_protected_physical_bytes")
+	review, _ := planMetadataInt64(metadata, "review_physical_bytes")
+
+	_, err := fmt.Fprintf(w, "  accounting: total %s, host reclaim %s, deferred %s, protected %s, active protected %s, review %s\n",
+		formatByteCount(total),
+		formatByteCount(hostReclaim),
+		formatByteCount(deferred),
+		formatByteCount(protected),
+		formatByteCount(activeProtected),
+		formatByteCount(review),
+	)
+	return err
+}
+
+func planMetadataInt64(metadata map[string]string, key string) (int64, bool) {
+	if len(metadata) == 0 {
+		return 0, false
+	}
+	raw, ok := metadata[key]
+	if !ok {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	return value, err == nil
 }
 
 func writeTextList(w io.Writer, header string, items []string, limit int) error {


### PR DESCRIPTION
## Summary
- Add shared dry-run target byte accounting metadata for Darwin cache and development-artifact plans.
- Show host reclaim, deferred, protected, active-protected, and review-only bytes in text reports.
- Document how to use the accounting when disk pressure is high but safe reclaim is near zero.

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'TestPlanCleanupModerateClassifiesDevArtifacts|TestPlanCleanupAccountsActiveProtectedDevArtifacts'
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test . -run TestRunOnceDryRunTextReportExplainsPlan
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //:all_tests
- nix build .#default --no-link --print-build-logs

Linear: TIN-1011