### PR TITLE
TIN-1011 Skip globally active dev artifact scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ All notable changes to this project will be documented in this file.
   virtualenvs, Rust `target/`, and Zig outputs is now path-scoped when process
   cwd or command-line evidence proves the active project root; missing cwd
   evidence keeps the conservative family-wide protection fallback.
+- Dev-artifact dry-runs now skip expensive workspace scans for generated-output
+  families that are already protected by conservative family-wide active-use
+  evidence, matching real cleanup behavior and preserving scan budget for
+  reclaimable surfaces.
 - Dev-artifact dry-run and cleanup filesystem walkers now observe cancellation,
   and active temporary roots are protected without expensive size walks so
   operator probes do not compete with active lab or Bazel scratch work.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Development-artifact active-process protection is path-scoped when process cwd
 or command-line evidence proves the active project root, and JSON metadata
 includes `active_dev_artifact_roots` for those protected roots. If cwd evidence
 is unavailable, cleanup keeps the conservative family-wide protection fallback.
+When that fallback protects a whole generated-output family, dry-run planning
+skips the expensive workspace scan for that family and records it in
+`global_active_dev_artifact_scan_skips`.
 
 For a one-off run, override the configured maximum used-space target without
 editing the config file:

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -210,9 +210,13 @@ tracked by Git. For `node_modules`, Python virtualenvs, Rust `target/`, and Zig
 outputs, active-process protection is path-scoped when process cwd or
 command-line evidence proves the active project root; JSON metadata reports
 those roots as `active_dev_artifact_roots`. If cwd evidence is unavailable, the
-plan keeps the conservative family-wide protection fallback. Zig `.zig-cache`
-and `zig-out` targets are also preserved when they contain files modified
-within the recent-output grace window, even at critical pressure.
+plan keeps the conservative family-wide protection fallback. When the fallback
+protects a whole generated-output family, dry-run planning skips that expensive
+workspace scan and records the family in
+`global_active_dev_artifact_scan_skips`, matching real cleanup behavior while
+preserving scan budget for surfaces that can still reclaim space. Zig
+`.zig-cache` and `zig-out` targets are also preserved when they contain files
+modified within the recent-output grace window, even at critical pressure.
 Dev-artifact filesystem walking is bounded by
 `dev_artifacts.scan_max_duration`, `dev_artifacts.scan_max_entries`, and
 `dev_artifacts.temp_scan_max_roots`; when a budget is hit, dry-run metadata sets

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -242,6 +242,9 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 		if scoped := active.ScopedRootReasons(); len(scoped) > 0 {
 			plan.Metadata["active_dev_artifact_roots"] = strings.Join(scoped, ", ")
 		}
+		if skipped := activeGlobalGeneratedArtifactScanSkips(active, daCfg); len(skipped) > 0 {
+			plan.Metadata["global_active_dev_artifact_scan_skips"] = strings.Join(devArtifactActivityReasons(skipped), ", ")
+		}
 	}
 
 	tracker := newDevArtifactGitTracker()
@@ -269,16 +272,16 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 		if !pathExistsAndIsDir(expanded) {
 			continue
 		}
-		if daCfg.NodeModules {
+		if daCfg.NodeModules && !active.GlobalFamilyActive("node_modules") {
 			p.planNodeModules(scanCtx, expanded, nodeAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
 		}
-		if daCfg.PythonVenvs {
+		if daCfg.PythonVenvs && !active.GlobalFamilyActive("python-venv") {
 			p.planPythonVenvs(scanCtx, expanded, venvAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
 		}
-		if daCfg.RustTargets {
+		if daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
 			p.planRustTargets(scanCtx, expanded, rustAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
 		}
-		if daCfg.ZigArtifacts {
+		if daCfg.ZigArtifacts && !active.GlobalFamilyActive("zig-artifact") {
 			p.planZigArtifacts(scanCtx, expanded, zigAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
 		}
 		if daCfg.LargeLocalArtifacts {
@@ -562,16 +565,16 @@ func (p *DevArtifactsPlugin) planTemporaryArtifacts(ctx context.Context, scanPat
 func (p *DevArtifactsPlugin) planTemporaryGeneratedArtifacts(ctx context.Context, scanPath string, minBytes int64, staleAfter, nodeAge, venvAge, rustAge, zigAge time.Duration, mutates bool, daCfg config.DevArtifactsConfig, active devArtifactActivity, activeRoots map[string]string, tracker *devArtifactGitTracker, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
 	budget := optionalDevArtifactScanBudget(budgets)
 	p.forEachStaleTemporaryRoot(ctx, scanPath, minBytes, staleAfter, daCfg.ProtectPaths, activeRoots, func(root string) {
-		if daCfg.NodeModules {
+		if daCfg.NodeModules && !active.GlobalFamilyActive("node_modules") {
 			p.planNodeModules(ctx, root, nodeAge, mutates, daCfg.ProtectPaths, active, tracker, targets, budget)
 		}
-		if daCfg.PythonVenvs {
+		if daCfg.PythonVenvs && !active.GlobalFamilyActive("python-venv") {
 			p.planPythonVenvs(ctx, root, venvAge, mutates, daCfg.ProtectPaths, active, tracker, targets, budget)
 		}
-		if daCfg.RustTargets {
+		if daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
 			p.planRustTargets(ctx, root, rustAge, mutates, daCfg.ProtectPaths, active, tracker, targets, budget)
 		}
-		if daCfg.ZigArtifacts {
+		if daCfg.ZigArtifacts && !active.GlobalFamilyActive("zig-artifact") {
 			p.planZigArtifacts(ctx, root, zigAge, mutates, daCfg.ProtectPaths, active, tracker, targets, budget)
 		}
 	}, budget)
@@ -1363,6 +1366,23 @@ func devArtifactGlobalCacheFamily(targetType string) bool {
 	default:
 		return false
 	}
+}
+
+func activeGlobalGeneratedArtifactScanSkips(active devArtifactActivity, daCfg config.DevArtifactsConfig) map[string]string {
+	skipped := map[string]string{}
+	add := func(enabled bool, targetType string) {
+		if !enabled {
+			return
+		}
+		if reason, ok := active.unscopedReasons[targetType]; ok {
+			skipped[targetType] = reason
+		}
+	}
+	add(daCfg.NodeModules, "node_modules")
+	add(daCfg.PythonVenvs, "python-venv")
+	add(daCfg.RustTargets, "rust-target")
+	add(daCfg.ZigArtifacts, "zig-artifact")
+	return skipped
 }
 
 func devArtifactScopedRootsForCandidate(candidate devArtifactProcessCandidate, cwd string, scanPaths []string, home string) []string {

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -697,7 +697,7 @@ func TestPlanNodeModulesScopesActiveProjectProtection(t *testing.T) {
 	}
 }
 
-func TestPlanCleanupAccountsActiveProtectedDevArtifacts(t *testing.T) {
+func TestPlanCleanupSkipsGlobalActiveDevArtifactFamilyScans(t *testing.T) {
 	p := newDevArtifactsPluginWithActive(map[string]string{
 		"node_modules": "Node.js package manager or runtime",
 	})
@@ -727,14 +727,19 @@ func TestPlanCleanupAccountsActiveProtectedDevArtifacts(t *testing.T) {
 	cfg.DevArtifacts.GoBuildCache = false
 	cfg.DevArtifacts.HaskellCache = false
 	cfg.DevArtifacts.TempArtifacts = false
+	cfg.DevArtifacts.LargeLocalArtifacts = false
+	cfg.DevArtifacts.LMStudioModels = false
+	cfg.DevArtifacts.ScanMaxEntries = 1
 
 	plan := p.PlanCleanup(context.Background(), LevelAggressive, cfg, logger)
-	target := findDevArtifactTarget(t, plan.Targets, "node_modules", filepath.Join(project, "node_modules"))
-	if target.Action != "protect" || !target.Protected || !target.Active {
-		t.Fatalf("expected active node_modules to be protected, got %#v", target)
+	if len(plan.Targets) != 0 {
+		t.Fatalf("global active node_modules should skip expensive scan targets, got %#v", plan.Targets)
 	}
-	if got := plan.Metadata["active_protected_physical_bytes"]; got != strconv.FormatInt(target.Bytes, 10) {
-		t.Fatalf("expected active protected bytes to match target size, got %q metadata=%#v", got, plan.Metadata)
+	if got := plan.Metadata["global_active_dev_artifact_scan_skips"]; got != "node_modules: Node.js package manager or runtime" {
+		t.Fatalf("expected global active scan skip metadata, got %q metadata=%#v", got, plan.Metadata)
+	}
+	if got := plan.Metadata["scan_budget_exhausted"]; got == "true" {
+		t.Fatalf("global active family scan should not exhaust scan budget, metadata=%#v", plan.Metadata)
 	}
 	if got := plan.Metadata["host_reclaim_candidate_bytes"]; got != "0" {
 		t.Fatalf("active protected artifact should not be a host reclaim candidate, got %q", got)


### PR DESCRIPTION
## Summary
- Make dev-artifacts dry-run skip generated-output family scans when conservative family-wide active-use protection is already in force.
- Record skipped families in `global_active_dev_artifact_scan_skips` so operators can distinguish fail-closed protection from missing evidence.
- Keep scoped active roots and unprotected families fully planned, so dry-run budget is spent on surfaces that can still reclaim space.

## Neo proof
- Source dry-run against neo config reported `global_active_dev_artifact_scan_skips: node_modules: Node.js package manager or runtime`.
- Target count dropped from the prior node_modules-dominated 41 targets to 4 targets.
- Dry-run surfaced a stale Python venv reclaim candidate at `/Users/jess/git/crs310-8g-2s-in/.venv` around 292 MB.

## Validation
- `git diff --check`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //:all_tests`
- `nix build .#default --no-link --print-build-logs`
- source dry-run against `/Users/jess/.config/tinyland-cleanup/config.yaml`

Linear: TIN-1011
