### PR TITLE
[codex] Add opt-in Home Manager generation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
   retention targets, daemon-contention detection, and opt-in store optimization.
 - Nix real-cleanup host free-space delta accounting around GC and optional store
   optimization, separate from command-reported reclaimed bytes.
+- Opt-in Home Manager generation cleanup via `home-manager remove-generations`,
+  with separate minimum-retention and age-policy settings.
 - Bazel cache and output-base dry-run planning with active-use detection,
   protected workspace symlink detection, and budget metadata.
 - Bazel reclaim candidates now refine byte estimates with a bounded recursive

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ enabling offline compaction.
 Darwin developer cache review is documented in
 [docs/darwin-dev-caches.md](docs/darwin-dev-caches.md).
 
-Nix store and generation cleanup policy is documented in
+Nix store, user-profile generation, and opt-in Home Manager generation cleanup
+policy is documented in
 [docs/nix-cleanup-policy.md](docs/nix-cleanup-policy.md).
 
 Bazel cache and output-base review is documented in

--- a/config/config.go
+++ b/config/config.go
@@ -245,6 +245,8 @@ type BazelConfig struct {
 type NixConfig struct {
 	// MinUserGenerations preserves at least this many user profile generations.
 	MinUserGenerations int `yaml:"min_user_generations"`
+	// MinHomeManagerGenerations preserves at least this many Home Manager generations.
+	MinHomeManagerGenerations int `yaml:"min_home_manager_generations"`
 	// MinSystemGenerations preserves at least this many system/darwin generations when visible.
 	MinSystemGenerations int `yaml:"min_system_generations"`
 	// HostMeasurePath is the filesystem path used for plugin-isolated host free-space deltas.
@@ -253,6 +255,12 @@ type NixConfig struct {
 	DeleteGenerationsOlderThan string `yaml:"delete_generations_older_than"`
 	// CriticalDeleteGenerationsOlderThan is the critical-level generation age policy.
 	CriticalDeleteGenerationsOlderThan string `yaml:"critical_delete_generations_older_than"`
+	// DeleteHomeManagerGenerations enables home-manager remove-generations for selected generations.
+	DeleteHomeManagerGenerations bool `yaml:"delete_home_manager_generations"`
+	// HomeManagerDeleteGenerationsOlderThan is the normal Home Manager generation age policy.
+	HomeManagerDeleteGenerationsOlderThan string `yaml:"home_manager_delete_generations_older_than"`
+	// HomeManagerCriticalDeleteGenerationsOlderThan is the critical-level Home Manager generation age policy.
+	HomeManagerCriticalDeleteGenerationsOlderThan string `yaml:"home_manager_critical_delete_generations_older_than"`
 	// AllowStoreOptimize enables nix-store --optimize at critical level.
 	AllowStoreOptimize bool `yaml:"allow_store_optimize"`
 	// SkipWhenDaemonBusy skips Nix cleanup when active Nix work is detected.
@@ -459,16 +467,20 @@ func DefaultConfig() *Config {
 			AllowDeleteActiveOutputBases: false,
 		},
 		Nix: NixConfig{
-			MinUserGenerations:                 5,
-			MinSystemGenerations:               3,
-			HostMeasurePath:                    "/nix/store",
-			DeleteGenerationsOlderThan:         "14d",
-			CriticalDeleteGenerationsOlderThan: "3d",
-			AllowStoreOptimize:                 false,
-			SkipWhenDaemonBusy:                 true,
-			DaemonBusyBackoff:                  "30m",
-			MaxGCDuration:                      "20m",
-			RootAttributionLimit:               20,
+			MinUserGenerations:                            5,
+			MinHomeManagerGenerations:                     5,
+			MinSystemGenerations:                          3,
+			HostMeasurePath:                               "/nix/store",
+			DeleteGenerationsOlderThan:                    "14d",
+			CriticalDeleteGenerationsOlderThan:            "3d",
+			DeleteHomeManagerGenerations:                  false,
+			HomeManagerDeleteGenerationsOlderThan:         "14d",
+			HomeManagerCriticalDeleteGenerationsOlderThan: "3d",
+			AllowStoreOptimize:                            false,
+			SkipWhenDaemonBusy:                            true,
+			DaemonBusyBackoff:                             "30m",
+			MaxGCDuration:                                 "20m",
+			RootAttributionLimit:                          20,
 		},
 		Lima: LimaConfig{
 			VMNames: []string{"colima", "unified"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -361,6 +361,9 @@ func TestNixPolicyDefaults(t *testing.T) {
 	if cfg.Nix.MinUserGenerations != 5 {
 		t.Errorf("Nix.MinUserGenerations should be 5, got %d", cfg.Nix.MinUserGenerations)
 	}
+	if cfg.Nix.MinHomeManagerGenerations != 5 {
+		t.Errorf("Nix.MinHomeManagerGenerations should be 5, got %d", cfg.Nix.MinHomeManagerGenerations)
+	}
 	if cfg.Nix.MinSystemGenerations != 3 {
 		t.Errorf("Nix.MinSystemGenerations should be 3, got %d", cfg.Nix.MinSystemGenerations)
 	}
@@ -372,6 +375,15 @@ func TestNixPolicyDefaults(t *testing.T) {
 	}
 	if cfg.Nix.CriticalDeleteGenerationsOlderThan != "3d" {
 		t.Errorf("Nix.CriticalDeleteGenerationsOlderThan should be 3d, got %q", cfg.Nix.CriticalDeleteGenerationsOlderThan)
+	}
+	if cfg.Nix.DeleteHomeManagerGenerations {
+		t.Error("Nix.DeleteHomeManagerGenerations should be false by default")
+	}
+	if cfg.Nix.HomeManagerDeleteGenerationsOlderThan != "14d" {
+		t.Errorf("Nix.HomeManagerDeleteGenerationsOlderThan should be 14d, got %q", cfg.Nix.HomeManagerDeleteGenerationsOlderThan)
+	}
+	if cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan != "3d" {
+		t.Errorf("Nix.HomeManagerCriticalDeleteGenerationsOlderThan should be 3d, got %q", cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan)
 	}
 	if cfg.Nix.AllowStoreOptimize {
 		t.Error("Nix.AllowStoreOptimize should be false by default")
@@ -545,10 +557,14 @@ podman:
     - applehv
 nix:
   min_user_generations: 7
+  min_home_manager_generations: 11
   min_system_generations: 4
   host_measure_path: /nix
   delete_generations_older_than: 21d
   critical_delete_generations_older_than: 5d
+  delete_home_manager_generations: true
+  home_manager_delete_generations_older_than: 9d
+  home_manager_critical_delete_generations_older_than: 2d
   allow_store_optimize: true
   skip_when_daemon_busy: false
   daemon_busy_backoff: 45m
@@ -699,6 +715,9 @@ darwin_dev_caches:
 	if cfg.Nix.MinUserGenerations != 7 {
 		t.Errorf("Nix.MinUserGenerations should be 7 per config, got %d", cfg.Nix.MinUserGenerations)
 	}
+	if cfg.Nix.MinHomeManagerGenerations != 11 {
+		t.Errorf("Nix.MinHomeManagerGenerations should be 11 per config, got %d", cfg.Nix.MinHomeManagerGenerations)
+	}
 	if cfg.Nix.MinSystemGenerations != 4 {
 		t.Errorf("Nix.MinSystemGenerations should be 4 per config, got %d", cfg.Nix.MinSystemGenerations)
 	}
@@ -710,6 +729,15 @@ darwin_dev_caches:
 	}
 	if cfg.Nix.CriticalDeleteGenerationsOlderThan != "5d" {
 		t.Errorf("Nix.CriticalDeleteGenerationsOlderThan should be 5d per config, got %q", cfg.Nix.CriticalDeleteGenerationsOlderThan)
+	}
+	if !cfg.Nix.DeleteHomeManagerGenerations {
+		t.Error("Nix.DeleteHomeManagerGenerations should be true per config")
+	}
+	if cfg.Nix.HomeManagerDeleteGenerationsOlderThan != "9d" {
+		t.Errorf("Nix.HomeManagerDeleteGenerationsOlderThan should be 9d per config, got %q", cfg.Nix.HomeManagerDeleteGenerationsOlderThan)
+	}
+	if cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan != "2d" {
+		t.Errorf("Nix.HomeManagerCriticalDeleteGenerationsOlderThan should be 2d per config, got %q", cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan)
 	}
 	if !cfg.Nix.AllowStoreOptimize {
 		t.Error("Nix.AllowStoreOptimize should be true per config")

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -127,6 +127,7 @@ podman:
 nix:
   # Preserve rollback safety even under disk pressure
   min_user_generations: 5
+  min_home_manager_generations: 5
   min_system_generations: 3
   # Filesystem used for plugin-isolated host free-space deltas around real Nix GC.
   host_measure_path: /nix/store
@@ -134,6 +135,14 @@ nix:
   # User generation deletion policy for moderate/aggressive and critical levels
   delete_generations_older_than: 14d
   critical_delete_generations_older_than: 3d
+
+  # Home Manager generations are review-only unless this explicit profile
+  # deletion workflow is enabled. When enabled, cleanup uses
+  # `home-manager remove-generations` for generations selected by the policy
+  # below, while preserving the current generation and minimum count.
+  delete_home_manager_generations: false
+  home_manager_delete_generations_older_than: 14d
+  home_manager_critical_delete_generations_older_than: 3d
 
   # Store optimization can be disruptive; leave it explicitly opt-in
   allow_store_optimize: false

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -25,12 +25,14 @@ The Nix plan includes:
 - `host_measure_path`, the filesystem path used to measure plugin-isolated
   host free-space deltas around real Nix GC and optional store optimization;
 - visible GC roots when dry-run GC reports no reclaimable store space;
-- generation targets with `keep_generation`, `delete_generation`, or
+- generation targets with `keep_generation`, `delete_generation`,
+  `delete_home_manager_generation`, `review_home_manager_generation`, or
   `review_privileged_generation` actions;
 - lock-free Home Manager generation targets discovered from
   `~/.local/state/nix/profiles/home-manager-*-link`, reported as protected
-  `review_home_manager_generation` items when they fall outside policy;
-- configured minimum user and system generation retention;
+  `review_home_manager_generation` items when they fall outside policy unless
+  `delete_home_manager_generations` is explicitly enabled;
+- configured minimum user, Home Manager, and system generation retention;
 - whether critical `nix-store --optimize` is allowed.
 
 Default policy:
@@ -38,10 +40,14 @@ Default policy:
 ```yaml
 nix:
   min_user_generations: 5
+  min_home_manager_generations: 5
   min_system_generations: 3
   host_measure_path: /nix/store
   delete_generations_older_than: 14d
   critical_delete_generations_older_than: 3d
+  delete_home_manager_generations: false
+  home_manager_delete_generations_older_than: 14d
+  home_manager_critical_delete_generations_older_than: 3d
   allow_store_optimize: false
   skip_when_daemon_busy: true
   daemon_busy_backoff: 30m
@@ -54,6 +60,10 @@ Runtime behavior:
 - warning runs plain Nix garbage collection only;
 - moderate and aggressive may delete old user profile generations selected by
   the age policy, while preserving the current generation and the minimum count;
+- Home Manager generations are dry-run review-only by default. If
+  `delete_home_manager_generations: true`, moderate and aggressive cleanup uses
+  `home-manager remove-generations` for selected Home Manager generations while
+  preserving the current generation and `min_home_manager_generations`;
 - critical uses the stricter age policy, then runs plain Nix garbage collection;
 - dry-run GC lock or SQLite contention is treated like active Nix work when
   `skip_when_daemon_busy` is enabled, so the plan is deferred instead of
@@ -76,8 +86,8 @@ Runtime behavior:
 - system or nix-darwin generations are reported for operator review but are not
   deleted by the unprivileged plugin path;
 - Home Manager generations are discovered from profile symlinks without taking a
-  `nix-env` profile lock; stale Home Manager generations are review-only until
-  an explicit profile deletion workflow is implemented;
+  `nix-env` profile lock; stale Home Manager generations use the explicit
+  `home-manager remove-generations` workflow only when configured;
 - user profile generations fall back to the same lock-free profile-link scan
   when `nix-env --list-generations` is unavailable or cannot inspect the
   profile;
@@ -98,10 +108,14 @@ Recommended Rocky or Linux runner defaults:
 ```yaml
 nix:
   min_user_generations: 3
+  min_home_manager_generations: 3
   min_system_generations: 2
   host_measure_path: /nix/store
   delete_generations_older_than: 7d
   critical_delete_generations_older_than: 2d
+  delete_home_manager_generations: false
+  home_manager_delete_generations_older_than: 7d
+  home_manager_critical_delete_generations_older_than: 2d
   allow_store_optimize: false
   skip_when_daemon_busy: true
   daemon_busy_backoff: 15m

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -72,18 +72,23 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 		WouldRun: true,
 		Steps:    nixPlanSteps(level, cfg.Nix),
 		Metadata: map[string]string{
-			"cleanup_level":                             level.String(),
-			"min_user_generations":                      strconv.Itoa(cfg.Nix.MinUserGenerations),
-			"min_system_generations":                    strconv.Itoa(cfg.Nix.MinSystemGenerations),
-			"delete_generations_older_than":             cfg.Nix.DeleteGenerationsOlderThan,
-			"critical_delete_generations_older_than":    cfg.Nix.CriticalDeleteGenerationsOlderThan,
-			"allow_store_optimize":                      strconv.FormatBool(cfg.Nix.AllowStoreOptimize),
-			"skip_when_daemon_busy":                     strconv.FormatBool(cfg.Nix.SkipWhenDaemonBusy),
-			"daemon_busy_backoff":                       cfg.Nix.DaemonBusyBackoff,
-			"max_gc_duration":                           cfg.Nix.MaxGCDuration,
-			"host_measure_path":                         nixHostMeasurePath(cfg.Nix),
-			"root_attribution_limit":                    strconv.Itoa(nixRootAttributionLimit(cfg.Nix)),
-			"generation_policy_delete_older_than_level": nixGenerationPolicyAge(level, cfg.Nix),
+			"cleanup_level":                                          level.String(),
+			"min_user_generations":                                   strconv.Itoa(cfg.Nix.MinUserGenerations),
+			"min_home_manager_generations":                           strconv.Itoa(nixMinHomeManagerGenerations(cfg.Nix)),
+			"min_system_generations":                                 strconv.Itoa(cfg.Nix.MinSystemGenerations),
+			"delete_generations_older_than":                          cfg.Nix.DeleteGenerationsOlderThan,
+			"critical_delete_generations_older_than":                 cfg.Nix.CriticalDeleteGenerationsOlderThan,
+			"delete_home_manager_generations":                        strconv.FormatBool(cfg.Nix.DeleteHomeManagerGenerations),
+			"home_manager_delete_generations_older_than":             cfg.Nix.HomeManagerDeleteGenerationsOlderThan,
+			"home_manager_critical_delete_generations_older_than":    cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan,
+			"allow_store_optimize":                                   strconv.FormatBool(cfg.Nix.AllowStoreOptimize),
+			"skip_when_daemon_busy":                                  strconv.FormatBool(cfg.Nix.SkipWhenDaemonBusy),
+			"daemon_busy_backoff":                                    cfg.Nix.DaemonBusyBackoff,
+			"max_gc_duration":                                        cfg.Nix.MaxGCDuration,
+			"host_measure_path":                                      nixHostMeasurePath(cfg.Nix),
+			"root_attribution_limit":                                 strconv.Itoa(nixRootAttributionLimit(cfg.Nix)),
+			"generation_policy_delete_older_than_level":              nixGenerationPolicyAge(level, cfg.Nix),
+			"home_manager_generation_policy_delete_older_than_level": nixHomeManagerGenerationPolicyAge(level, cfg.Nix),
 		},
 	}
 
@@ -211,6 +216,14 @@ func (p *NixPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *config
 		generationsDeleted = generationResult.ItemsCleaned
 		if generationResult.Error != nil {
 			result.Error = generationResult.Error
+			return result
+		}
+
+		homeManagerGenerationResult := p.deleteHomeManagerGenerationsByPolicy(ctx, level, cfg.Nix, logger)
+		result.ItemsCleaned += homeManagerGenerationResult.ItemsCleaned
+		generationsDeleted += homeManagerGenerationResult.ItemsCleaned
+		if homeManagerGenerationResult.Error != nil {
+			result.Error = homeManagerGenerationResult.Error
 			return result
 		}
 	}
@@ -473,6 +486,70 @@ func (p *NixPlugin) deleteUserGenerationsByPolicy(ctx context.Context, level Cle
 	return result
 }
 
+func (p *NixPlugin) deleteHomeManagerGenerationsByPolicy(ctx context.Context, level CleanupLevel, cfg config.NixConfig, logger *slog.Logger) CleanupResult {
+	result := CleanupResult{Plugin: p.Name(), Level: level}
+
+	if !cfg.DeleteHomeManagerGenerations {
+		return result
+	}
+
+	if _, err := exec.LookPath("home-manager"); err != nil {
+		logger.Debug("home-manager not available, skipping Home Manager generation policy deletion")
+		return result
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		logger.Warn("could not locate user home for Home Manager generation deletion", "error", err)
+		return result
+	}
+
+	stateProfilesDir := filepath.Join(home, ".local", "state", "nix", "profiles")
+	generations, err := discoverNixProfileLinkGenerations(stateProfilesDir, "home-manager", "home-manager")
+	if err != nil {
+		logger.Warn("could not inspect Home Manager profile links", "error", err)
+		return result
+	}
+	if len(generations) == 0 {
+		return result
+	}
+
+	olderThan := parseNixPolicyDuration(nixHomeManagerGenerationPolicyAge(level, cfg), 0)
+	if olderThan <= 0 {
+		return result
+	}
+
+	targets := nixGenerationTargets(generations, time.Now(), nixMinHomeManagerGenerations(cfg), olderThan)
+	var generationNumbers []string
+	for _, target := range targets {
+		if target.Action == "delete_generation" {
+			generationNumbers = append(generationNumbers, target.Version)
+		}
+	}
+	if len(generationNumbers) == 0 {
+		return result
+	}
+
+	args := append([]string{"remove-generations"}, generationNumbers...)
+	deleteCtx, cancel := context.WithTimeout(ctx, nixCommandTimeout(cfg))
+	defer cancel()
+
+	cmd := exec.CommandContext(deleteCtx, "home-manager", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if reason, ok := nixContentionReason(string(output)); ok && cfg.SkipWhenDaemonBusy {
+			logger.Warn("skipping Home Manager generation deletion because store contention was reported", "reason", reason)
+			return result
+		}
+		result.Error = fmt.Errorf("home-manager %s failed: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+		return result
+	}
+
+	result.ItemsCleaned = len(generationNumbers)
+	logger.Info("deleted old Home Manager generations", "generations", strings.Join(generationNumbers, ", "))
+	return result
+}
+
 func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLevel, cfg config.NixConfig, logger *slog.Logger) ([]CleanupTarget, []string) {
 	_ = logger
 
@@ -483,6 +560,13 @@ func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLeve
 
 	var targets []CleanupTarget
 	var warnings []string
+	homeManagerConfig := cfg
+	if cfg.DeleteHomeManagerGenerations {
+		if _, err := exec.LookPath("home-manager"); err != nil {
+			warnings = append(warnings, "home-manager is not available; Home Manager generations will remain review-only")
+			homeManagerConfig.DeleteHomeManagerGenerations = false
+		}
+	}
 
 	_, nixEnvErr := exec.LookPath("nix-env")
 	userGenerationsPlanned := false
@@ -516,11 +600,10 @@ func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLeve
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("could not inspect Home Manager profile links: %v", err))
 		} else if len(homeManagerGenerations) > 0 {
-			homeManagerTargets := nixReviewOnlyGenerationTargets(
-				nixGenerationTargets(homeManagerGenerations, time.Now(), cfg.MinUserGenerations, olderThan),
-				"review_home_manager_generation",
-				"outside retention policy, but Home Manager generation deletion requires an explicit profile workflow",
-				CleanupTierWarm,
+			homeManagerOlderThan := parseNixPolicyDuration(nixHomeManagerGenerationPolicyAge(level, cfg), olderThan)
+			homeManagerTargets := nixHomeManagerGenerationTargets(
+				nixGenerationTargets(homeManagerGenerations, time.Now(), nixMinHomeManagerGenerations(cfg), homeManagerOlderThan),
+				homeManagerConfig,
 			)
 			targets = append(targets, homeManagerTargets...)
 		}
@@ -638,6 +721,27 @@ func nixReviewOnlyGenerationTargets(targets []CleanupTarget, action string, dele
 	return targets
 }
 
+func nixHomeManagerGenerationTargets(targets []CleanupTarget, cfg config.NixConfig) []CleanupTarget {
+	if !cfg.DeleteHomeManagerGenerations {
+		return nixReviewOnlyGenerationTargets(
+			targets,
+			"review_home_manager_generation",
+			"outside retention policy, but Home Manager generation deletion requires delete_home_manager_generations=true",
+			CleanupTierWarm,
+		)
+	}
+
+	for i := range targets {
+		if targets[i].Action != "delete_generation" {
+			continue
+		}
+		targets[i].Action = "delete_home_manager_generation"
+		targets[i].Reason = "outside Home Manager retention policy and eligible for home-manager remove-generations"
+		annotateCleanupTargetPolicy(&targets[i], CleanupTierWarm, CleanupReclaimDeferred)
+	}
+	return targets
+}
+
 func nixActiveWorkTargets(reasons []string, backoff string) []CleanupTarget {
 	targets := make([]CleanupTarget, 0, len(reasons))
 	for _, reason := range reasons {
@@ -676,13 +780,23 @@ func nixPlanSteps(level CleanupLevel, cfg config.NixConfig) []string {
 	case LevelModerate, LevelAggressive:
 		steps = append(steps,
 			fmt.Sprintf("Delete user generations older than %s only when at least %d user generations remain", cfg.DeleteGenerationsOlderThan, cfg.MinUserGenerations),
-			"Run plain Nix GC after selected user generation deletion",
 		)
+		if cfg.DeleteHomeManagerGenerations {
+			steps = append(steps, fmt.Sprintf("Delete Home Manager generations older than %s only when at least %d Home Manager generations remain", nixHomeManagerGenerationPolicyAge(level, cfg), nixMinHomeManagerGenerations(cfg)))
+		} else {
+			steps = append(steps, "Report stale Home Manager generations as review-only because delete_home_manager_generations=false")
+		}
+		steps = append(steps, "Run plain Nix GC after selected generation deletion")
 	case LevelCritical:
 		steps = append(steps,
 			fmt.Sprintf("Delete user generations older than %s only when at least %d user generations remain", cfg.CriticalDeleteGenerationsOlderThan, cfg.MinUserGenerations),
-			"Run plain Nix GC after selected user generation deletion",
 		)
+		if cfg.DeleteHomeManagerGenerations {
+			steps = append(steps, fmt.Sprintf("Delete Home Manager generations older than %s only when at least %d Home Manager generations remain", nixHomeManagerGenerationPolicyAge(level, cfg), nixMinHomeManagerGenerations(cfg)))
+		} else {
+			steps = append(steps, "Report stale Home Manager generations as review-only because delete_home_manager_generations=false")
+		}
+		steps = append(steps, "Run plain Nix GC after selected generation deletion")
 		if cfg.AllowStoreOptimize {
 			steps = append(steps, "Run nix-store --optimize because allow_store_optimize=true")
 		} else {
@@ -703,6 +817,27 @@ func nixGenerationPolicyAge(level CleanupLevel, cfg config.NixConfig) string {
 	default:
 		return ""
 	}
+}
+
+func nixHomeManagerGenerationPolicyAge(level CleanupLevel, cfg config.NixConfig) string {
+	switch level {
+	case LevelCritical:
+		if strings.TrimSpace(cfg.HomeManagerCriticalDeleteGenerationsOlderThan) != "" {
+			return cfg.HomeManagerCriticalDeleteGenerationsOlderThan
+		}
+	case LevelModerate, LevelAggressive:
+		if strings.TrimSpace(cfg.HomeManagerDeleteGenerationsOlderThan) != "" {
+			return cfg.HomeManagerDeleteGenerationsOlderThan
+		}
+	}
+	return nixGenerationPolicyAge(level, cfg)
+}
+
+func nixMinHomeManagerGenerations(cfg config.NixConfig) int {
+	if cfg.MinHomeManagerGenerations > 0 {
+		return cfg.MinHomeManagerGenerations
+	}
+	return cfg.MinUserGenerations
 }
 
 func nixCommandTimeout(cfg config.NixConfig) time.Duration {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -511,6 +511,110 @@ func TestNixReviewOnlyGenerationTargetsProtectsSelectedGenerations(t *testing.T)
 	}
 }
 
+func TestNixHomeManagerGenerationTargetsRequireOptIn(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	generations := []nixGeneration{
+		{Number: 1, CreatedAt: now.Add(-30 * 24 * time.Hour), Scope: "home-manager"},
+		{Number: 2, CreatedAt: now.Add(-1 * 24 * time.Hour), Scope: "home-manager", Current: true},
+	}
+
+	reviewTargets := nixHomeManagerGenerationTargets(
+		nixGenerationTargets(generations, now, 1, 7*24*time.Hour),
+		config.NixConfig{},
+	)
+	reviewActions := map[string]CleanupTarget{}
+	for _, target := range reviewTargets {
+		reviewActions[target.Version] = target
+	}
+	if reviewActions["1"].Action != "review_home_manager_generation" || !reviewActions["1"].Protected {
+		t.Fatalf("Home Manager generation should be review-only without opt-in: %+v", reviewActions["1"])
+	}
+
+	deleteTargets := nixHomeManagerGenerationTargets(
+		nixGenerationTargets(generations, now, 1, 7*24*time.Hour),
+		config.NixConfig{DeleteHomeManagerGenerations: true},
+	)
+	deleteActions := map[string]CleanupTarget{}
+	for _, target := range deleteTargets {
+		deleteActions[target.Version] = target
+	}
+	if deleteActions["1"].Action != "delete_home_manager_generation" || deleteActions["1"].Protected {
+		t.Fatalf("Home Manager generation should be deletable with opt-in: %+v", deleteActions["1"])
+	}
+	if deleteActions["2"].Action != "keep_generation" || !deleteActions["2"].Protected {
+		t.Fatalf("current Home Manager generation should remain kept: %+v", deleteActions["2"])
+	}
+}
+
+func TestNixPluginDeleteHomeManagerGenerationsByPolicyUsesRemoveGenerations(t *testing.T) {
+	tempHome := t.TempDir()
+	profileDir := filepath.Join(tempHome, ".local", "state", "nix", "profiles")
+	if err := os.MkdirAll(profileDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	for _, generation := range []struct {
+		name    string
+		modTime time.Time
+	}{
+		{"home-manager-1-link", now.Add(-72 * time.Hour)},
+		{"home-manager-2-link", now.Add(-48 * time.Hour)},
+		{"home-manager-3-link", now.Add(-1 * time.Hour)},
+	} {
+		path := filepath.Join(profileDir, generation.name)
+		if err := os.WriteFile(path, []byte(generation.name), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, generation.modTime, generation.modTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("home-manager-3-link", filepath.Join(profileDir, "home-manager")); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	argsLog := filepath.Join(t.TempDir(), "home-manager.args")
+	fakeHomeManager := filepath.Join(binDir, "home-manager")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$TINYLAND_HOME_MANAGER_ARGS_LOG\"\n"
+	if err := os.WriteFile(fakeHomeManager, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tempHome)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TINYLAND_HOME_MANAGER_ARGS_LOG", argsLog)
+
+	p := NewNixPlugin()
+	result := p.deleteHomeManagerGenerationsByPolicy(
+		context.Background(),
+		LevelModerate,
+		config.NixConfig{
+			DeleteHomeManagerGenerations:          true,
+			MinHomeManagerGenerations:             1,
+			DeleteGenerationsOlderThan:            "24h",
+			HomeManagerDeleteGenerationsOlderThan: "24h",
+			MaxGCDuration:                         "5s",
+		},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	if result.Error != nil {
+		t.Fatalf("deleteHomeManagerGenerationsByPolicy returned error: %v", result.Error)
+	}
+	if result.ItemsCleaned != 2 {
+		t.Fatalf("deleted %d generations, want 2", result.ItemsCleaned)
+	}
+
+	rawArgs, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.TrimSpace(string(rawArgs)), "remove-generations 1 2"; got != want {
+		t.Fatalf("home-manager args = %q, want %q", got, want)
+	}
+}
+
 func TestNixGenerationTargetsPreserveCurrentAndMinimum(t *testing.T) {
 	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 	generations := []nixGeneration{


### PR DESCRIPTION
## Summary

- add config-gated Home Manager generation cleanup through home-manager remove-generations
- keep Home Manager generations review-only by default unless delete_home_manager_generations is enabled
- document the policy and add config/unit coverage for retention, opt-in behavior, and command invocation

Linear: TIN-1011

## Validation

- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test --symlink_prefix=/tmp/tinyland-cleanup-bazel-link- //...
- nix flake check --no-build
- nix build .#default --no-link --print-build-logs