### PR TITLE
Classify Nix GC roots for Darwin developer hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ All notable changes to this project will be documented in this file.
   Bazelisk, and pip cache targets.
 - Nix low-reclaim dry-runs now emit protected GC-root attribution targets so
   operators can see what is pinning the store before taking action.
+- Nix GC-root attribution now classifies Darwin `{lsof}` roots as active open
+  store paths, `{nix-process:<pid>}` roots as active Nix work, direnv flake
+  roots as warm review targets, and Nix cache roots separately, reducing
+  generic `unknown_root` noise on developer machines.
 - Human-readable `--output text` reports now explain dry-run and cleanup cycles
   with mount status, host free-space accounting, plugin plans, warnings, and
   representative targets.

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -93,9 +93,12 @@ Runtime behavior:
   profile;
 - low-reclaim dry-runs run `nix-store --gc --print-roots` and emit protected
   `nix_gc_root` targets so operators can see whether profiles, gcroots,
-  workspace `result` links, temporary roots, or active processes are pinning the
-  store; active process roots, temporary roots, and workspace result roots are
-  listed before generic unknown roots when attribution output is truncated;
+  direnv profiles, workspace `result` links, Nix cache roots, temporary roots,
+  lsof-discovered open store paths, active Nix process roots, or active
+  processes are pinning the store; active process roots, active Nix process
+  roots, lsof roots, temporary roots, direnv roots, workspace result roots, and
+  Nix cache roots are listed before generic unknown roots when attribution
+  output is truncated;
 - `nix-store --optimize` runs only when `allow_store_optimize: true`.
 
 Recommended Darwin developer-machine defaults are the repo defaults above.

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -976,35 +976,53 @@ func parseNixGCRoots(output string) []nixGCRoot {
 
 func nixGCRootClassRank(class string) int {
 	switch class {
-	case "process_root":
+	case "process_root", "nix_process_root":
 		return 0
-	case "temporary_root":
+	case "lsof_root":
 		return 1
-	case "workspace_result":
+	case "temporary_root":
 		return 2
-	case "auto_gcroot", "gcroot":
+	case "direnv_root":
 		return 3
-	case "profile_root":
+	case "workspace_result":
 		return 4
-	default:
+	case "nix_cache_root":
 		return 5
+	case "auto_gcroot", "gcroot":
+		return 6
+	case "profile_root":
+		return 7
+	default:
+		return 8
 	}
 }
 
 func classifyNixGCRoot(root string) (string, bool) {
+	root = strings.TrimSpace(root)
 	lower := strings.ToLower(root)
 
 	switch {
 	case strings.HasPrefix(root, "/proc/"):
 		return "process_root", true
+	case strings.HasPrefix(root, "{nix-process:"):
+		return "nix_process_root", true
+	case strings.HasPrefix(root, "{lsof}"):
+		return "lsof_root", true
 	case strings.Contains(lower, "/profiles/per-user/") ||
 		strings.Contains(lower, "/nix/var/nix/profiles") ||
 		strings.Contains(lower, "/.local/state/nix/profiles") ||
 		strings.Contains(lower, "/.nix-profile"):
 		return "profile_root", false
+	case strings.Contains(lower, "/.direnv/flake-inputs/") ||
+		strings.Contains(lower, "/.direnv/flake-profile-"):
+		return "direnv_root", false
+	case strings.Contains(lower, "/.cache/nix/"):
+		return "nix_cache_root", false
 	case strings.Contains(lower, "/gcroots/auto/"):
 		return "auto_gcroot", false
 	case strings.Contains(lower, "/gcroots/"):
+		return "gcroot", false
+	case strings.Contains(lower, "/nix-gc-roots/"):
 		return "gcroot", false
 	case strings.HasSuffix(root, "/result") ||
 		strings.Contains(root, "/result-"):
@@ -1057,12 +1075,18 @@ func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
 
 func nixGCRootReviewAction(class string) string {
 	switch class {
-	case "process_root":
+	case "process_root", "nix_process_root":
 		return "review_active_gc_root"
+	case "lsof_root":
+		return "review_lsof_gc_root"
 	case "temporary_root":
 		return "review_temporary_gc_root"
+	case "direnv_root":
+		return "review_direnv_gc_root"
 	case "workspace_result":
 		return "review_workspace_result_root"
+	case "nix_cache_root":
+		return "review_nix_cache_gc_root"
 	default:
 		return "review_gc_root"
 	}
@@ -1070,9 +1094,9 @@ func nixGCRootReviewAction(class string) string {
 
 func nixGCRootTier(class string) string {
 	switch class {
-	case "process_root":
+	case "process_root", "nix_process_root", "lsof_root":
 		return CleanupTierDisruptive
-	case "workspace_result", "gcroot", "auto_gcroot", "unknown_root":
+	case "direnv_root", "workspace_result", "nix_cache_root", "gcroot", "auto_gcroot", "unknown_root":
 		return CleanupTierWarm
 	default:
 		return CleanupTierSafe
@@ -1081,7 +1105,7 @@ func nixGCRootTier(class string) string {
 
 func nixGCRootReclaim(class string) string {
 	switch class {
-	case "temporary_root", "workspace_result", "gcroot", "auto_gcroot":
+	case "temporary_root", "direnv_root", "workspace_result", "nix_cache_root", "gcroot", "auto_gcroot":
 		return CleanupReclaimDeferred
 	default:
 		return CleanupReclaimNone

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -384,15 +384,19 @@ func TestDiscoverNixProfileLinkGenerations(t *testing.T) {
 func TestParseNixGCRoots(t *testing.T) {
 	output := `
 /proc/1234/fd/5 -> /nix/store/111-source
+{nix-process:4321} -> /nix/store/888-active-derivation.drv
+{lsof} -> /nix/store/555-open-library
 /nix/var/nix/profiles/per-user/jess/profile-42-link -> /nix/store/222-home-manager-generation
 /nix/var/nix/gcroots/auto/abc -> /nix/store/333-tool
+/Users/jess/git/kernel/.direnv/flake-profile-a5d5b61aa8a61b7d9d765e1daf971a9a578f1cfa -> /nix/store/666-kernel-env
 /Users/jess/git/kernel/result -> /nix/store/444-linux-kernel
+/Users/jess/.cache/nix/flake-registry.json -> /nix/store/777-flake-registry.json
 /proc/1234/fd/5 -> /nix/store/111-source
 `
 
 	roots := parseNixGCRoots(output)
-	if len(roots) != 4 {
-		t.Fatalf("got %d roots, want 4: %#v", len(roots), roots)
+	if len(roots) != 8 {
+		t.Fatalf("got %d roots, want 8: %#v", len(roots), roots)
 	}
 
 	classes := map[string]int{}
@@ -407,8 +411,17 @@ func TestParseNixGCRoots(t *testing.T) {
 	if classes["process_root"] != 1 {
 		t.Fatalf("expected one process root, classes=%v", classes)
 	}
+	if classes["nix_process_root"] != 1 {
+		t.Fatalf("expected one nix process root, classes=%v", classes)
+	}
+	if classes["lsof_root"] != 1 {
+		t.Fatalf("expected one lsof root, classes=%v", classes)
+	}
 	if classes["profile_root"] != 1 {
 		t.Fatalf("expected one profile root, classes=%v", classes)
+	}
+	if classes["direnv_root"] != 1 {
+		t.Fatalf("expected one direnv root, classes=%v", classes)
 	}
 	if classes["auto_gcroot"] != 1 {
 		t.Fatalf("expected one auto gcroot, classes=%v", classes)
@@ -416,10 +429,13 @@ func TestParseNixGCRoots(t *testing.T) {
 	if classes["workspace_result"] != 1 {
 		t.Fatalf("expected one workspace result root, classes=%v", classes)
 	}
-	if active != 1 {
-		t.Fatalf("expected one active root, got %d", active)
+	if classes["nix_cache_root"] != 1 {
+		t.Fatalf("expected one nix cache root, classes=%v", classes)
 	}
-	if roots[0].Class != "process_root" || roots[1].Class != "workspace_result" {
+	if active != 3 {
+		t.Fatalf("expected three active roots, got %d", active)
+	}
+	if roots[0].Class != "nix_process_root" || roots[1].Class != "process_root" || roots[2].Class != "lsof_root" || roots[3].Class != "direnv_root" {
 		t.Fatalf("roots should be sorted by operator-actionable class, got %#v", roots)
 	}
 }
@@ -454,18 +470,34 @@ func TestNixGCRootTargetsAreProtectedAndLimited(t *testing.T) {
 func TestNixGCRootTargetsUseSpecificReviewActions(t *testing.T) {
 	roots := []nixGCRoot{
 		{
+			Root:      "{lsof}",
+			StorePath: "/nix/store/111-open-library",
+			Class:     "lsof_root",
+			Active:    true,
+		},
+		{
 			Root:      "/tmp/dev-env-profile-1-link",
 			StorePath: "/nix/store/222-dev-env",
 			Class:     "temporary_root",
+		},
+		{
+			Root:      "/Users/jess/git/kernel/.direnv/flake-profile-a5d5b61aa8a61b7d9d765e1daf971a9a578f1cfa",
+			StorePath: "/nix/store/444-kernel-env",
+			Class:     "direnv_root",
 		},
 		{
 			Root:      "/Users/jess/git/kernel/result",
 			StorePath: "/nix/store/333-kernel",
 			Class:     "workspace_result",
 		},
+		{
+			Root:      "/Users/jess/.cache/nix/flake-registry.json",
+			StorePath: "/nix/store/555-flake-registry.json",
+			Class:     "nix_cache_root",
+		},
 	}
 
-	targets := nixGCRootTargets(roots, 2)
+	targets := nixGCRootTargets(roots, 5)
 	actions := map[string]CleanupTarget{}
 	for _, target := range targets {
 		actions[target.Path] = target
@@ -476,9 +508,24 @@ func TestNixGCRootTargetsUseSpecificReviewActions(t *testing.T) {
 		t.Fatalf("temporary root target should carry specific review action and store path evidence: %+v", temporary)
 	}
 
+	lsof := actions["{lsof}"]
+	if lsof.Action != "review_lsof_gc_root" || lsof.Tier != CleanupTierDisruptive || lsof.Reclaim != CleanupReclaimNone || !lsof.Active {
+		t.Fatalf("lsof root target should carry active process review policy: %+v", lsof)
+	}
+
+	direnv := actions["/Users/jess/git/kernel/.direnv/flake-profile-a5d5b61aa8a61b7d9d765e1daf971a9a578f1cfa"]
+	if direnv.Action != "review_direnv_gc_root" || direnv.Tier != CleanupTierWarm || direnv.Reclaim != CleanupReclaimDeferred {
+		t.Fatalf("direnv root target should carry warm deferred review policy: %+v", direnv)
+	}
+
 	workspace := actions["/Users/jess/git/kernel/result"]
 	if workspace.Action != "review_workspace_result_root" || workspace.Tier != CleanupTierWarm || workspace.Reclaim != CleanupReclaimDeferred {
 		t.Fatalf("workspace result target should carry warm deferred review policy: %+v", workspace)
+	}
+
+	nixCache := actions["/Users/jess/.cache/nix/flake-registry.json"]
+	if nixCache.Action != "review_nix_cache_gc_root" || nixCache.Tier != CleanupTierWarm || nixCache.Reclaim != CleanupReclaimDeferred {
+		t.Fatalf("nix cache root target should carry warm deferred review policy: %+v", nixCache)
 	}
 }
 


### PR DESCRIPTION
## Summary
- classify Darwin `{lsof}` and `{nix-process:<pid>}` GC roots as active protected roots
- classify direnv flake roots, Nix cache roots, and user `nix-gc-roots` separately from generic unknown roots
- update Nix cleanup policy docs and tests

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test --symlink_prefix=/tmp/tinyland-cleanup-bazel-link- //...`
- `nix flake check --no-build`
- `nix build .#default --no-link --print-build-logs`

Lab follow-up target: TIN-1011