### PR TITLE
Classify Home Manager GC roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ All notable changes to this project will be documented in this file.
   store paths, `{nix-process:<pid>}` roots as active Nix work, direnv flake
   roots as warm review targets, and Nix cache roots separately, reducing
   generic `unknown_root` noise on developer machines.
+- Nix GC-root attribution now classifies Home Manager current/new generation
+  gcroots separately from generic unknown roots.
 - Human-readable `--output text` reports now explain dry-run and cleanup cycles
   with mount status, host free-space accounting, plugin plans, warnings, and
   representative targets.

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -990,7 +990,7 @@ func nixGCRootClassRank(class string) int {
 		return 5
 	case "auto_gcroot", "gcroot":
 		return 6
-	case "profile_root":
+	case "home_manager_gcroot", "profile_root":
 		return 7
 	default:
 		return 8
@@ -1013,6 +1013,8 @@ func classifyNixGCRoot(root string) (string, bool) {
 		strings.Contains(lower, "/.local/state/nix/profiles") ||
 		strings.Contains(lower, "/.nix-profile"):
 		return "profile_root", false
+	case strings.Contains(lower, "/.local/state/home-manager/gcroots/"):
+		return "home_manager_gcroot", false
 	case strings.Contains(lower, "/.direnv/flake-inputs/") ||
 		strings.Contains(lower, "/.direnv/flake-profile-"):
 		return "direnv_root", false
@@ -1087,6 +1089,8 @@ func nixGCRootReviewAction(class string) string {
 		return "review_workspace_result_root"
 	case "nix_cache_root":
 		return "review_nix_cache_gc_root"
+	case "home_manager_gcroot":
+		return "review_home_manager_gc_root"
 	default:
 		return "review_gc_root"
 	}

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -387,6 +387,7 @@ func TestParseNixGCRoots(t *testing.T) {
 {nix-process:4321} -> /nix/store/888-active-derivation.drv
 {lsof} -> /nix/store/555-open-library
 /nix/var/nix/profiles/per-user/jess/profile-42-link -> /nix/store/222-home-manager-generation
+/Users/jess/.local/state/home-manager/gcroots/current-home -> /nix/store/999-home-manager-generation
 /nix/var/nix/gcroots/auto/abc -> /nix/store/333-tool
 /Users/jess/git/kernel/.direnv/flake-profile-a5d5b61aa8a61b7d9d765e1daf971a9a578f1cfa -> /nix/store/666-kernel-env
 /Users/jess/git/kernel/result -> /nix/store/444-linux-kernel
@@ -395,8 +396,8 @@ func TestParseNixGCRoots(t *testing.T) {
 `
 
 	roots := parseNixGCRoots(output)
-	if len(roots) != 8 {
-		t.Fatalf("got %d roots, want 8: %#v", len(roots), roots)
+	if len(roots) != 9 {
+		t.Fatalf("got %d roots, want 9: %#v", len(roots), roots)
 	}
 
 	classes := map[string]int{}
@@ -419,6 +420,9 @@ func TestParseNixGCRoots(t *testing.T) {
 	}
 	if classes["profile_root"] != 1 {
 		t.Fatalf("expected one profile root, classes=%v", classes)
+	}
+	if classes["home_manager_gcroot"] != 1 {
+		t.Fatalf("expected one Home Manager gcroot, classes=%v", classes)
 	}
 	if classes["direnv_root"] != 1 {
 		t.Fatalf("expected one direnv root, classes=%v", classes)
@@ -495,9 +499,14 @@ func TestNixGCRootTargetsUseSpecificReviewActions(t *testing.T) {
 			StorePath: "/nix/store/555-flake-registry.json",
 			Class:     "nix_cache_root",
 		},
+		{
+			Root:      "/Users/jess/.local/state/home-manager/gcroots/current-home",
+			StorePath: "/nix/store/666-home-manager-generation",
+			Class:     "home_manager_gcroot",
+		},
 	}
 
-	targets := nixGCRootTargets(roots, 5)
+	targets := nixGCRootTargets(roots, 6)
 	actions := map[string]CleanupTarget{}
 	for _, target := range targets {
 		actions[target.Path] = target
@@ -526,6 +535,11 @@ func TestNixGCRootTargetsUseSpecificReviewActions(t *testing.T) {
 	nixCache := actions["/Users/jess/.cache/nix/flake-registry.json"]
 	if nixCache.Action != "review_nix_cache_gc_root" || nixCache.Tier != CleanupTierWarm || nixCache.Reclaim != CleanupReclaimDeferred {
 		t.Fatalf("nix cache root target should carry warm deferred review policy: %+v", nixCache)
+	}
+
+	homeManagerGCRoot := actions["/Users/jess/.local/state/home-manager/gcroots/current-home"]
+	if homeManagerGCRoot.Action != "review_home_manager_gc_root" || homeManagerGCRoot.Tier != CleanupTierSafe || homeManagerGCRoot.Reclaim != CleanupReclaimNone {
+		t.Fatalf("Home Manager gcroot target should carry safe protected review policy: %+v", homeManagerGCRoot)
 	}
 }
 


### PR DESCRIPTION
## Summary
- classify Home Manager current/new gcroots as home_manager_gcroot instead of generic unknown roots
- rank them with profile roots and add a protected review action
- cover the class and target policy in Nix plugin tests

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test --symlink_prefix=/tmp/tinyland-cleanup-bazel-link- //...
- nix flake check --no-build
- nix build .#default --no-link --print-build-logs
- built binary dry-run with root_attribution_limit=600 on neo: no unknown_root in gc_root_attribution_classes