### PR TITLE
Ignore Nix GC root status lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ All notable changes to this project will be documented in this file.
   generic `unknown_root` noise on developer machines.
 - Nix GC-root attribution now classifies Home Manager current/new generation
   gcroots separately from generic unknown roots.
+- Nix GC-root attribution now ignores `nix-store --gc --print-roots` status
+  messages such as stale-root removal lines instead of reporting them as
+  generic unknown roots.
 - Human-readable `--output text` reports now explain dry-run and cleanup cycles
   with mount status, host free-space accounting, plugin plans, warnings, and
   representative targets.

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -941,7 +941,7 @@ func parseNixGCRoots(output string) []nixGCRoot {
 				storePath = fields[len(fields)-1]
 			}
 		}
-		if root == "" {
+		if root == "" || !looksLikeNixGCRoot(root) {
 			continue
 		}
 
@@ -972,6 +972,10 @@ func parseNixGCRoots(output string) []nixGCRoot {
 		return iRank < jRank
 	})
 	return roots
+}
+
+func looksLikeNixGCRoot(root string) bool {
+	return strings.HasPrefix(root, "/") || strings.HasPrefix(root, "{")
 }
 
 func nixGCRootClassRank(class string) int {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -393,6 +393,8 @@ func TestParseNixGCRoots(t *testing.T) {
 /Users/jess/git/kernel/result -> /nix/store/444-linux-kernel
 /Users/jess/.cache/nix/flake-registry.json -> /nix/store/777-flake-registry.json
 /proc/1234/fd/5 -> /nix/store/111-source
+removing stale link '/nix/var/nix/gcroots/auto/news.json'
+finding garbage collector roots...
 `
 
 	roots := parseNixGCRoots(output)


### PR DESCRIPTION
## Summary
- ignore non-root status/progress lines from nix-store --gc --print-roots
- keep GC-root parsing restricted to absolute-path roots and brace roots such as {lsof}
- add regression coverage for stale-root removal and progress chatter

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test --symlink_prefix=/tmp/tinyland-cleanup-bazel-link- //...
- nix flake check --no-build
- nix build .#default --no-link --print-build-logs
- built binary dry-run on neo with root_attribution_limit=600: no unknown_root in gc_root_attribution_classes