### PR TITLE
TIN-1011 collapse repeated Nix GC root targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ All notable changes to this project will be documented in this file.
 - Nix GC-root attribution now ignores `nix-store --gc --print-roots` status
   messages such as stale-root removal lines instead of reporting them as
   generic unknown roots.
+- Nix GC-root attribution dry-runs now collapse repeated roots such as
+  `{lsof}` and `{nix-process:<pid>}` into one protected target per root while
+  retaining raw and unique root-class counts in metadata.
 - Human-readable `--output text` reports now explain dry-run and cleanup cycles
   with mount status, host free-space accounting, plugin plans, warnings, and
   representative targets.

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -32,10 +32,11 @@ type nixGeneration struct {
 }
 
 type nixGCRoot struct {
-	Root      string
-	StorePath string
-	Class     string
-	Active    bool
+	Root           string
+	StorePath      string
+	StorePathCount int
+	Class          string
+	Active         bool
 }
 
 // NewNixPlugin creates a new Nix cleanup plugin.
@@ -311,13 +312,16 @@ func (p *NixPlugin) planGCRootAttribution(ctx context.Context, cfg config.NixCon
 	}
 
 	roots := parseNixGCRoots(output)
+	uniqueRoots := nixUniqueGCRoots(roots)
 	metadata["gc_root_attribution_roots"] = strconv.Itoa(len(roots))
 	metadata["gc_root_attribution_classes"] = nixGCRootClassSummary(roots)
+	metadata["gc_root_attribution_unique_roots"] = strconv.Itoa(len(uniqueRoots))
+	metadata["gc_root_attribution_unique_classes"] = nixGCRootClassSummary(uniqueRoots)
 
 	targets := nixGCRootTargets(roots, limit)
-	if len(targets) < len(roots) {
+	if len(targets) < len(uniqueRoots) {
 		metadata["gc_root_attribution_truncated"] = "true"
-		return targets, metadata, []string{fmt.Sprintf("Nix GC root attribution truncated to %d of %d visible roots", len(targets), len(roots))}
+		return targets, metadata, []string{fmt.Sprintf("Nix GC root attribution truncated to %d of %d visible roots (%d store-path entries)", len(targets), len(uniqueRoots), len(roots))}
 	}
 
 	return targets, metadata, nil
@@ -953,13 +957,19 @@ func parseNixGCRoots(output string) []nixGCRoot {
 
 		class, active := classifyNixGCRoot(root)
 		roots = append(roots, nixGCRoot{
-			Root:      root,
-			StorePath: storePath,
-			Class:     class,
-			Active:    active,
+			Root:           root,
+			StorePath:      storePath,
+			StorePathCount: 1,
+			Class:          class,
+			Active:         active,
 		})
 	}
 
+	sortNixGCRoots(roots)
+	return roots
+}
+
+func sortNixGCRoots(roots []nixGCRoot) {
 	sort.Slice(roots, func(i, j int) bool {
 		iRank := nixGCRootClassRank(roots[i].Class)
 		jRank := nixGCRootClassRank(roots[j].Class)
@@ -971,7 +981,6 @@ func parseNixGCRoots(output string) []nixGCRoot {
 		}
 		return iRank < jRank
 	})
-	return roots
 }
 
 func looksLikeNixGCRoot(root string) bool {
@@ -1042,6 +1051,7 @@ func classifyNixGCRoot(root string) (string, bool) {
 }
 
 func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
+	roots = nixUniqueGCRoots(roots)
 	if limit <= 0 || len(roots) == 0 {
 		return nil
 	}
@@ -1059,8 +1069,21 @@ func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
 			reason = fmt.Sprintf("%s %s", reason, version)
 		}
 		name := fmt.Sprintf("%s %s", root.Class, filepath.Base(root.Root))
+		if root.StorePathCount > 1 {
+			name = fmt.Sprintf("%s (%d store paths)", name, root.StorePathCount)
+			if version != "" {
+				version = fmt.Sprintf("%s (+%d more)", version, root.StorePathCount-1)
+				reason = fmt.Sprintf("visible Nix GC root retaining %d store paths; sample %s", root.StorePathCount, filepath.Base(root.StorePath))
+			} else {
+				reason = fmt.Sprintf("visible Nix GC root retaining %d store paths", root.StorePathCount)
+			}
+		}
 		if root.Active {
-			reason = "active process root; review the owning process before any Nix GC action"
+			if root.StorePathCount > 1 {
+				reason = fmt.Sprintf("active GC root retaining %d store paths; review the owning process before any Nix GC action", root.StorePathCount)
+			} else {
+				reason = "active process root; review the owning process before any Nix GC action"
+			}
 		}
 
 		target := CleanupTarget{
@@ -1077,6 +1100,38 @@ func nixGCRootTargets(roots []nixGCRoot, limit int) []CleanupTarget {
 		targets = append(targets, target)
 	}
 	return targets
+}
+
+func nixUniqueGCRoots(roots []nixGCRoot) []nixGCRoot {
+	if len(roots) == 0 {
+		return nil
+	}
+
+	grouped := make([]nixGCRoot, 0, len(roots))
+	index := map[string]int{}
+	for _, root := range roots {
+		key := strings.Join([]string{
+			root.Root,
+			root.Class,
+			strconv.FormatBool(root.Active),
+		}, "\x00")
+		if idx, ok := index[key]; ok {
+			grouped[idx].StorePathCount += max(root.StorePathCount, 1)
+			if grouped[idx].StorePath == "" && root.StorePath != "" {
+				grouped[idx].StorePath = root.StorePath
+			}
+			continue
+		}
+
+		if root.StorePathCount <= 0 {
+			root.StorePathCount = 1
+		}
+		index[key] = len(grouped)
+		grouped = append(grouped, root)
+	}
+
+	sortNixGCRoots(grouped)
+	return grouped
 }
 
 func nixGCRootReviewAction(class string) string {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -473,6 +473,78 @@ func TestNixGCRootTargetsAreProtectedAndLimited(t *testing.T) {
 	}
 }
 
+func TestNixGCRootTargetsCollapseRepeatedRoots(t *testing.T) {
+	roots := []nixGCRoot{
+		{
+			Root:      "{lsof}",
+			StorePath: "/nix/store/111-open-library",
+			Class:     "lsof_root",
+			Active:    true,
+		},
+		{
+			Root:      "{lsof}",
+			StorePath: "/nix/store/222-open-library",
+			Class:     "lsof_root",
+			Active:    true,
+		},
+		{
+			Root:      "/Users/jess/git/kernel/result",
+			StorePath: "/nix/store/333-kernel",
+			Class:     "workspace_result",
+		},
+	}
+
+	targets := nixGCRootTargets(roots, 10)
+	if len(targets) != 2 {
+		t.Fatalf("got %d targets, want 2: %#v", len(targets), targets)
+	}
+	if targets[0].Path != "{lsof}" || targets[0].Action != "review_lsof_gc_root" {
+		t.Fatalf("first target should be the collapsed lsof root: %+v", targets[0])
+	}
+	if targets[0].Version != "111-open-library (+1 more)" {
+		t.Fatalf("collapsed lsof target version = %q", targets[0].Version)
+	}
+	if !strings.Contains(targets[0].Name, "2 store paths") || !strings.Contains(targets[0].Reason, "2 store paths") {
+		t.Fatalf("collapsed lsof target should explain retained store paths: %+v", targets[0])
+	}
+	if targets[1].Path != "/Users/jess/git/kernel/result" {
+		t.Fatalf("second target should remain the workspace result root: %+v", targets[1])
+	}
+}
+
+func TestNixUniqueGCRootsPreservesClassOrdering(t *testing.T) {
+	roots := []nixGCRoot{
+		{
+			Root:      "/Users/jess/git/kernel/result",
+			StorePath: "/nix/store/333-kernel",
+			Class:     "workspace_result",
+		},
+		{
+			Root:      "{nix-process:1234}",
+			StorePath: "/nix/store/111-builder-input",
+			Class:     "nix_process_root",
+			Active:    true,
+		},
+		{
+			Root:      "{nix-process:1234}",
+			StorePath: "/nix/store/222-builder-input",
+			Class:     "nix_process_root",
+			Active:    true,
+		},
+	}
+
+	unique := nixUniqueGCRoots(roots)
+	if len(unique) != 2 {
+		t.Fatalf("got %d unique roots, want 2: %#v", len(unique), unique)
+	}
+	if unique[0].Class != "nix_process_root" || unique[0].StorePathCount != 2 {
+		t.Fatalf("active process root should remain first and collapsed: %#v", unique)
+	}
+	if unique[1].Class != "workspace_result" || unique[1].StorePathCount != 1 {
+		t.Fatalf("workspace result should remain after active root: %#v", unique)
+	}
+}
+
 func TestNixGCRootTargetsUseSpecificReviewActions(t *testing.T) {
 	roots := []nixGCRoot{
 		{


### PR DESCRIPTION
## Summary
- collapse repeated Nix GC roots such as {lsof} and {nix-process:<pid>} into one protected dry-run target per root
- keep raw root counts and add unique-root counts/classes in metadata
- add regression tests for collapsed root targets and class ordering

Linear: TIN-1011

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test --symlink_prefix=/tmp/tinyland-cleanup-bazel-link- //...
- nix flake check --no-build
- nix build .#default --no-link --print-build-logs
- source-built neo dry-run: raw roots 438, unique roots 269, {lsof} collapsed from 170 store paths to one protected target