### PR TITLE
TIN-1011 Add Nix generation count caps

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -249,6 +249,10 @@ type NixConfig struct {
 	MinHomeManagerGenerations int `yaml:"min_home_manager_generations"`
 	// MinSystemGenerations preserves at least this many system/darwin generations when visible.
 	MinSystemGenerations int `yaml:"min_system_generations"`
+	// MaxUserGenerations caps retained user profile generations when greater than zero.
+	MaxUserGenerations int `yaml:"max_user_generations"`
+	// MaxHomeManagerGenerations caps retained Home Manager generations when greater than zero.
+	MaxHomeManagerGenerations int `yaml:"max_home_manager_generations"`
 	// HostMeasurePath is the filesystem path used for plugin-isolated host free-space deltas.
 	HostMeasurePath string `yaml:"host_measure_path"`
 	// DeleteGenerationsOlderThan is the normal generation age policy.
@@ -470,6 +474,8 @@ func DefaultConfig() *Config {
 			MinUserGenerations:                            5,
 			MinHomeManagerGenerations:                     5,
 			MinSystemGenerations:                          3,
+			MaxUserGenerations:                            0,
+			MaxHomeManagerGenerations:                     0,
 			HostMeasurePath:                               "/nix/store",
 			DeleteGenerationsOlderThan:                    "14d",
 			CriticalDeleteGenerationsOlderThan:            "3d",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -367,6 +367,12 @@ func TestNixPolicyDefaults(t *testing.T) {
 	if cfg.Nix.MinSystemGenerations != 3 {
 		t.Errorf("Nix.MinSystemGenerations should be 3, got %d", cfg.Nix.MinSystemGenerations)
 	}
+	if cfg.Nix.MaxUserGenerations != 0 {
+		t.Errorf("Nix.MaxUserGenerations should default to disabled, got %d", cfg.Nix.MaxUserGenerations)
+	}
+	if cfg.Nix.MaxHomeManagerGenerations != 0 {
+		t.Errorf("Nix.MaxHomeManagerGenerations should default to disabled, got %d", cfg.Nix.MaxHomeManagerGenerations)
+	}
 	if cfg.Nix.HostMeasurePath != "/nix/store" {
 		t.Errorf("Nix.HostMeasurePath should be /nix/store, got %q", cfg.Nix.HostMeasurePath)
 	}
@@ -559,6 +565,8 @@ nix:
   min_user_generations: 7
   min_home_manager_generations: 11
   min_system_generations: 4
+  max_user_generations: 12
+  max_home_manager_generations: 16
   host_measure_path: /nix
   delete_generations_older_than: 21d
   critical_delete_generations_older_than: 5d
@@ -720,6 +728,12 @@ darwin_dev_caches:
 	}
 	if cfg.Nix.MinSystemGenerations != 4 {
 		t.Errorf("Nix.MinSystemGenerations should be 4 per config, got %d", cfg.Nix.MinSystemGenerations)
+	}
+	if cfg.Nix.MaxUserGenerations != 12 {
+		t.Errorf("Nix.MaxUserGenerations should be 12 per config, got %d", cfg.Nix.MaxUserGenerations)
+	}
+	if cfg.Nix.MaxHomeManagerGenerations != 16 {
+		t.Errorf("Nix.MaxHomeManagerGenerations should be 16 per config, got %d", cfg.Nix.MaxHomeManagerGenerations)
 	}
 	if cfg.Nix.HostMeasurePath != "/nix" {
 		t.Errorf("Nix.HostMeasurePath should be /nix per config, got %q", cfg.Nix.HostMeasurePath)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -129,6 +129,11 @@ nix:
   min_user_generations: 5
   min_home_manager_generations: 5
   min_system_generations: 3
+  # Optional generation-count pressure valves. Zero disables count-based
+  # deletion; age policy still applies. Current generations and minimum
+  # rollback counts are always preserved.
+  max_user_generations: 0
+  max_home_manager_generations: 0
   # Filesystem used for plugin-isolated host free-space deltas around real Nix GC.
   host_measure_path: /nix/store
 

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -77,6 +77,8 @@ func (p *NixPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *co
 			"min_user_generations":                                   strconv.Itoa(cfg.Nix.MinUserGenerations),
 			"min_home_manager_generations":                           strconv.Itoa(nixMinHomeManagerGenerations(cfg.Nix)),
 			"min_system_generations":                                 strconv.Itoa(cfg.Nix.MinSystemGenerations),
+			"max_user_generations":                                   strconv.Itoa(cfg.Nix.MaxUserGenerations),
+			"max_home_manager_generations":                           strconv.Itoa(cfg.Nix.MaxHomeManagerGenerations),
 			"delete_generations_older_than":                          cfg.Nix.DeleteGenerationsOlderThan,
 			"critical_delete_generations_older_than":                 cfg.Nix.CriticalDeleteGenerationsOlderThan,
 			"delete_home_manager_generations":                        strconv.FormatBool(cfg.Nix.DeleteHomeManagerGenerations),
@@ -455,11 +457,11 @@ func (p *NixPlugin) deleteUserGenerationsByPolicy(ctx context.Context, level Cle
 	}
 
 	olderThan := parseNixPolicyDuration(nixGenerationPolicyAge(level, cfg), 0)
-	if olderThan <= 0 {
+	if olderThan <= 0 && cfg.MaxUserGenerations <= 0 {
 		return result
 	}
 
-	targets := nixGenerationTargets(generations, time.Now(), cfg.MinUserGenerations, olderThan)
+	targets := nixGenerationTargetsWithMax(generations, time.Now(), cfg.MinUserGenerations, olderThan, cfg.MaxUserGenerations)
 	var generationNumbers []string
 	for _, target := range targets {
 		if target.Action == "delete_generation" {
@@ -519,11 +521,11 @@ func (p *NixPlugin) deleteHomeManagerGenerationsByPolicy(ctx context.Context, le
 	}
 
 	olderThan := parseNixPolicyDuration(nixHomeManagerGenerationPolicyAge(level, cfg), 0)
-	if olderThan <= 0 {
+	if olderThan <= 0 && cfg.MaxHomeManagerGenerations <= 0 {
 		return result
 	}
 
-	targets := nixGenerationTargets(generations, time.Now(), nixMinHomeManagerGenerations(cfg), olderThan)
+	targets := nixGenerationTargetsWithMax(generations, time.Now(), nixMinHomeManagerGenerations(cfg), olderThan, cfg.MaxHomeManagerGenerations)
 	var generationNumbers []string
 	for _, target := range targets {
 		if target.Action == "delete_generation" {
@@ -558,7 +560,7 @@ func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLeve
 	_ = logger
 
 	olderThan := parseNixPolicyDuration(nixGenerationPolicyAge(level, cfg), 0)
-	if olderThan <= 0 {
+	if olderThan <= 0 && cfg.MaxUserGenerations <= 0 && cfg.MaxHomeManagerGenerations <= 0 {
 		return nil, nil
 	}
 
@@ -581,7 +583,7 @@ func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLeve
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("could not inspect user Nix generations with nix-env: %v", err))
 		} else {
-			targets = append(targets, nixGenerationTargets(userGenerations, time.Now(), cfg.MinUserGenerations, olderThan)...)
+			targets = append(targets, nixGenerationTargetsWithMax(userGenerations, time.Now(), cfg.MinUserGenerations, olderThan, cfg.MaxUserGenerations)...)
 			userGenerationsPlanned = true
 		}
 	}
@@ -595,7 +597,7 @@ func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLeve
 			if err != nil {
 				warnings = append(warnings, fmt.Sprintf("could not inspect user Nix profile links: %v", err))
 			} else if len(userLinkGenerations) > 0 {
-				targets = append(targets, nixGenerationTargets(userLinkGenerations, time.Now(), cfg.MinUserGenerations, olderThan)...)
+				targets = append(targets, nixGenerationTargetsWithMax(userLinkGenerations, time.Now(), cfg.MinUserGenerations, olderThan, cfg.MaxUserGenerations)...)
 				warnings = append(warnings, "using lock-free user Nix profile link inspection after nix-env generation inspection was unavailable")
 			}
 		}
@@ -606,7 +608,7 @@ func (p *NixPlugin) planGenerationTargets(ctx context.Context, level CleanupLeve
 		} else if len(homeManagerGenerations) > 0 {
 			homeManagerOlderThan := parseNixPolicyDuration(nixHomeManagerGenerationPolicyAge(level, cfg), olderThan)
 			homeManagerTargets := nixHomeManagerGenerationTargets(
-				nixGenerationTargets(homeManagerGenerations, time.Now(), nixMinHomeManagerGenerations(cfg), homeManagerOlderThan),
+				nixGenerationTargetsWithMax(homeManagerGenerations, time.Now(), nixMinHomeManagerGenerations(cfg), homeManagerOlderThan, cfg.MaxHomeManagerGenerations),
 				homeManagerConfig,
 			)
 			targets = append(targets, homeManagerTargets...)
@@ -785,20 +787,32 @@ func nixPlanSteps(level CleanupLevel, cfg config.NixConfig) []string {
 		steps = append(steps,
 			fmt.Sprintf("Delete user generations older than %s only when at least %d user generations remain", cfg.DeleteGenerationsOlderThan, cfg.MinUserGenerations),
 		)
+		if cfg.MaxUserGenerations > 0 {
+			steps = append(steps, fmt.Sprintf("Cap user generations at %d while preserving the current generation and minimum rollback count", cfg.MaxUserGenerations))
+		}
 		if cfg.DeleteHomeManagerGenerations {
 			steps = append(steps, fmt.Sprintf("Delete Home Manager generations older than %s only when at least %d Home Manager generations remain", nixHomeManagerGenerationPolicyAge(level, cfg), nixMinHomeManagerGenerations(cfg)))
+			if cfg.MaxHomeManagerGenerations > 0 {
+				steps = append(steps, fmt.Sprintf("Cap Home Manager generations at %d while preserving the current generation and minimum rollback count", cfg.MaxHomeManagerGenerations))
+			}
 		} else {
-			steps = append(steps, "Report stale Home Manager generations as review-only because delete_home_manager_generations=false")
+			steps = append(steps, "Report stale or over-cap Home Manager generations as review-only because delete_home_manager_generations=false")
 		}
 		steps = append(steps, "Run plain Nix GC after selected generation deletion")
 	case LevelCritical:
 		steps = append(steps,
 			fmt.Sprintf("Delete user generations older than %s only when at least %d user generations remain", cfg.CriticalDeleteGenerationsOlderThan, cfg.MinUserGenerations),
 		)
+		if cfg.MaxUserGenerations > 0 {
+			steps = append(steps, fmt.Sprintf("Cap user generations at %d while preserving the current generation and minimum rollback count", cfg.MaxUserGenerations))
+		}
 		if cfg.DeleteHomeManagerGenerations {
 			steps = append(steps, fmt.Sprintf("Delete Home Manager generations older than %s only when at least %d Home Manager generations remain", nixHomeManagerGenerationPolicyAge(level, cfg), nixMinHomeManagerGenerations(cfg)))
+			if cfg.MaxHomeManagerGenerations > 0 {
+				steps = append(steps, fmt.Sprintf("Cap Home Manager generations at %d while preserving the current generation and minimum rollback count", cfg.MaxHomeManagerGenerations))
+			}
 		} else {
-			steps = append(steps, "Report stale Home Manager generations as review-only because delete_home_manager_generations=false")
+			steps = append(steps, "Report stale or over-cap Home Manager generations as review-only because delete_home_manager_generations=false")
 		}
 		steps = append(steps, "Run plain Nix GC after selected generation deletion")
 		if cfg.AllowStoreOptimize {
@@ -1199,8 +1213,15 @@ func nixGCRootClassSummary(roots []nixGCRoot) string {
 }
 
 func nixGenerationTargets(generations []nixGeneration, now time.Time, minKeep int, olderThan time.Duration) []CleanupTarget {
+	return nixGenerationTargetsWithMax(generations, now, minKeep, olderThan, 0)
+}
+
+func nixGenerationTargetsWithMax(generations []nixGeneration, now time.Time, minKeep int, olderThan time.Duration, maxKeep int) []CleanupTarget {
 	if minKeep < 1 {
 		minKeep = 1
+	}
+	if maxKeep > 0 && maxKeep < minKeep {
+		maxKeep = minKeep
 	}
 
 	sorted := append([]nixGeneration(nil), generations...)
@@ -1219,10 +1240,20 @@ func nixGenerationTargets(generations []nixGeneration, now time.Time, minKeep in
 		protectedByMinimum[generation.Number] = true
 	}
 
+	protectedByMaximum := map[int]bool{}
+	if maxKeep > 0 {
+		for idx, generation := range sorted {
+			if idx >= maxKeep {
+				break
+			}
+			protectedByMaximum[generation.Number] = true
+		}
+	}
+
+	ageEnabled := olderThan > 0
 	cutoff := now.Add(-olderThan)
 	targets := make([]CleanupTarget, 0, len(sorted))
 	for _, generation := range sorted {
-		protected := generation.Current || protectedByMinimum[generation.Number] || generation.CreatedAt.After(cutoff)
 		action := "keep_generation"
 		reason := "within generation retention policy"
 		switch {
@@ -1230,12 +1261,16 @@ func nixGenerationTargets(generations []nixGeneration, now time.Time, minKeep in
 			reason = "current profile generation"
 		case protectedByMinimum[generation.Number]:
 			reason = fmt.Sprintf("within minimum retained %s generations", generation.Scope)
-		case generation.CreatedAt.After(cutoff):
+		case maxKeep > 0 && !protectedByMaximum[generation.Number]:
+			action = "delete_generation"
+			reason = "exceeds configured maximum generation count and outside retained minimum"
+		case ageEnabled && generation.CreatedAt.After(cutoff):
 			reason = "younger than configured generation age"
-		default:
+		case ageEnabled:
 			action = "delete_generation"
 			reason = "older than configured generation age and outside retained minimum"
 		}
+		protected := action != "delete_generation"
 
 		nameScope := generation.Scope
 		if nameScope == "" {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -750,6 +750,69 @@ func TestNixPluginDeleteHomeManagerGenerationsByPolicyUsesRemoveGenerations(t *t
 	}
 }
 
+func TestNixGenerationTargetsCanCapRecentChurn(t *testing.T) {
+	now := time.Date(2026, 5, 7, 21, 30, 0, 0, time.UTC)
+	var generations []nixGeneration
+	for number := 1; number <= 8; number++ {
+		generations = append(generations, nixGeneration{
+			Number:    number,
+			CreatedAt: now.Add(-time.Duration(8-number) * time.Minute),
+			Scope:     "user",
+			Current:   number == 8,
+		})
+	}
+
+	targets := nixGenerationTargetsWithMax(generations, now, 3, 7*24*time.Hour, 5)
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Version] = target
+	}
+
+	for _, generation := range []string{"1", "2", "3"} {
+		target := actions[generation]
+		if target.Action != "delete_generation" || target.Protected {
+			t.Fatalf("expected generation %s to be deleted by count cap: %+v", generation, target)
+		}
+		if !strings.Contains(target.Reason, "maximum generation count") {
+			t.Fatalf("generation %s reason should mention maximum count: %+v", generation, target)
+		}
+	}
+	for _, generation := range []string{"4", "5", "6", "7", "8"} {
+		target := actions[generation]
+		if target.Action != "keep_generation" || !target.Protected {
+			t.Fatalf("expected generation %s to be retained: %+v", generation, target)
+		}
+	}
+}
+
+func TestNixGenerationTargetsCountCapPreservesCurrentAndMinimum(t *testing.T) {
+	now := time.Date(2026, 5, 7, 21, 30, 0, 0, time.UTC)
+	generations := []nixGeneration{
+		{Number: 1, CreatedAt: now.Add(-8 * time.Minute), Scope: "user", Current: true},
+		{Number: 2, CreatedAt: now.Add(-7 * time.Minute), Scope: "user"},
+		{Number: 3, CreatedAt: now.Add(-6 * time.Minute), Scope: "user"},
+		{Number: 4, CreatedAt: now.Add(-5 * time.Minute), Scope: "user"},
+		{Number: 5, CreatedAt: now.Add(-4 * time.Minute), Scope: "user"},
+	}
+
+	targets := nixGenerationTargetsWithMax(generations, now, 3, 7*24*time.Hour, 2)
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Version] = target
+	}
+
+	for _, generation := range []string{"1", "3", "4", "5"} {
+		target := actions[generation]
+		if target.Action != "keep_generation" || !target.Protected {
+			t.Fatalf("expected generation %s to stay protected: %+v", generation, target)
+		}
+	}
+	target := actions["2"]
+	if target.Action != "delete_generation" || target.Protected {
+		t.Fatalf("expected only generation 2 to be over the normalized cap: %+v", target)
+	}
+}
+
 func TestNixGenerationTargetsPreserveCurrentAndMinimum(t *testing.T) {
 	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 	generations := []nixGeneration{


### PR DESCRIPTION
## Summary
- add disabled-by-default max generation caps for user and Home Manager Nix profiles
- preserve current generations and configured minimum rollback counts before considering count-based cleanup
- expose cap metadata and plan steps, with unit coverage for same-day churn and min/current protection

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test --symlink_prefix=/tmp/tinyland-cleanup-bazel-link- //...
- nix flake check --no-build
- nix build .#default --no-link --print-build-logs

Linear: TIN-1011