### PR TITLE
Harden tinyland-cleanup package hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,15 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v22
       - name: Test
         run: nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+
+  nix:
+    name: Nix package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+      - name: Flake metadata
+        run: nix flake check --no-build
+      - name: Build package
+        run: nix build .#default --no-link --print-build-logs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -72,7 +72,10 @@ go_test(
         "config/config_pbt_test.go",
         "config/config_test.go",
     ],
-    data = ["config/testdata/home-manager-honey.yaml"],
+    data = [
+        "config/testdata/home-manager-honey.yaml",
+        "packaging/linux/config.yaml",
+    ],
     embed = [":config"],
     deps = ["@net_pgregory_rapid//:rapid"],
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,10 +130,14 @@ All notable changes to this project will be documented in this file.
 - Dev-artifacts planning now has explicit scan budgets for duration, recursive
   entry count, and top-level temporary roots, with dry-run warnings and metadata
   when evidence is partial.
+- APFS snapshot dry-runs now recognize `com.apple.os.update-*` local snapshots
+  as protected review evidence instead of silently ignoring them.
 
 ### Changed
 
 - Go module path moved to `github.com/Jesssullivan/tinyland-cleanup`.
+- Nix package builds now pass version, source revision, and flake timestamp
+  into `--version` output for provenance.
 - Clarified that the legacy `target_free` config key represents the target
   maximum used-space percentage after cleanup.
 - Critical Darwin cache cleanup now prefers typed developer-cache targets when

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -218,12 +218,56 @@ func TestLoadHomeManagerContract(t *testing.T) {
 	}
 }
 
+func TestPackagedLinuxConfigParsesCurrentNixPolicy(t *testing.T) {
+	cfg, err := LoadConfig(packagedLinuxConfigPath(t))
+	if err != nil {
+		t.Fatalf("packaged Linux config should load: %v", err)
+	}
+
+	if cfg.Nix.MinHomeManagerGenerations != 5 {
+		t.Errorf("expected min_home_manager_generations=5, got %d", cfg.Nix.MinHomeManagerGenerations)
+	}
+	if cfg.Nix.MaxUserGenerations != 0 {
+		t.Errorf("expected max_user_generations=0, got %d", cfg.Nix.MaxUserGenerations)
+	}
+	if cfg.Nix.MaxHomeManagerGenerations != 0 {
+		t.Errorf("expected max_home_manager_generations=0, got %d", cfg.Nix.MaxHomeManagerGenerations)
+	}
+	if cfg.Nix.HostMeasurePath != "/nix/store" {
+		t.Errorf("expected host_measure_path=/nix/store, got %q", cfg.Nix.HostMeasurePath)
+	}
+	if cfg.Nix.DeleteHomeManagerGenerations {
+		t.Error("expected delete_home_manager_generations=false")
+	}
+	if cfg.Nix.HomeManagerDeleteGenerationsOlderThan != "14d" {
+		t.Errorf("expected home_manager_delete_generations_older_than=14d, got %q", cfg.Nix.HomeManagerDeleteGenerationsOlderThan)
+	}
+	if cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan != "3d" {
+		t.Errorf("expected home_manager_critical_delete_generations_older_than=3d, got %q", cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan)
+	}
+}
+
 func homeManagerContractPath(t *testing.T) string {
 	t.Helper()
 
 	candidates := []string{
 		filepath.Join("testdata", "home-manager-honey.yaml"),
 		filepath.Join("config", "testdata", "home-manager-honey.yaml"),
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return candidates[0]
+}
+
+func packagedLinuxConfigPath(t *testing.T) string {
+	t.Helper()
+
+	candidates := []string{
+		filepath.Join("..", "packaging", "linux", "config.yaml"),
+		filepath.Join("packaging", "linux", "config.yaml"),
 	}
 	for _, candidate := range candidates {
 		if _, err := os.Stat(candidate); err == nil {

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -42,6 +42,8 @@ nix:
   min_user_generations: 5
   min_home_manager_generations: 5
   min_system_generations: 3
+  max_user_generations: 0
+  max_home_manager_generations: 0
   host_measure_path: /nix/store
   delete_generations_older_than: 14d
   critical_delete_generations_older_than: 3d
@@ -60,6 +62,11 @@ Runtime behavior:
 - warning runs plain Nix garbage collection only;
 - moderate and aggressive may delete old user profile generations selected by
   the age policy, while preserving the current generation and the minimum count;
+- `max_user_generations` and `max_home_manager_generations` are disabled when
+  set to `0`. When set, they act as count-based pressure valves in addition to
+  age policy: older over-cap generations become cleanup candidates while the
+  current generation and configured minimum rollback counts are still
+  preserved;
 - Home Manager generations are dry-run review-only by default. If
   `delete_home_manager_generations: true`, moderate and aggressive cleanup uses
   `home-manager remove-generations` for selected Home Manager generations while
@@ -113,6 +120,8 @@ nix:
   min_user_generations: 3
   min_home_manager_generations: 3
   min_system_generations: 2
+  max_user_generations: 0
+  max_home_manager_generations: 0
   host_measure_path: /nix/store
   delete_generations_older_than: 7d
   critical_delete_generations_older_than: 2d

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -234,11 +234,14 @@ enabled. Reported reclaimable bytes may describe Docker daemon or VM storage
 and may not immediately equal host free-space delta on macOS or VM-backed
 Docker installations.
 
-For APFS snapshots on macOS, the plan reports local snapshot count, newest and
-oldest snapshot dates, requested thinning size, sudo capability, and Time
-Machine backup state. Snapshot sizes are estimates because `tmutil` does not
-report per-snapshot allocation; real cleanup requires passwordless sudo and is
-deferred while a Time Machine backup is active.
+For APFS snapshots on macOS, the plan reports local snapshot count,
+Time Machine and OS-update snapshot counts, newest and oldest snapshot
+identifiers, requested thinning size, sudo capability, and Time Machine backup
+state. Snapshot sizes are estimates because `tmutil` does not report
+per-snapshot allocation; real cleanup requires passwordless sudo and is
+deferred while a Time Machine backup is active. OS-update snapshots are surfaced
+as protected review evidence because automatic deletion requires a date-form
+`tmutil deletelocalsnapshots` token.
 
 For Homebrew, iOS Simulator, and Xcode on macOS, the plan reports package-manager
 cleanup estimates, simulator device/log/runtime targets, and Xcode logs,

--- a/flake.nix
+++ b/flake.nix
@@ -10,18 +10,22 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
 
-      perSystem = { pkgs, self', system, ... }: {
+      perSystem = { pkgs, self', system, ... }: let
+        buildVersion = "0.2.0";
+        buildCommit = inputs.self.rev or "dirty";
+        buildDate = inputs.self.lastModifiedDate or "unknown";
+      in {
         packages.default = pkgs.buildGoModule {
           pname = "tinyland-cleanup";
-          version = "0.2.0";
+          version = buildVersion;
           src = ./.;
           vendorHash = null;
 
           ldflags = [
             "-s" "-w"
-            "-X main.version=0.2.0"
-          ] ++ pkgs.lib.optionals (inputs.self ? rev) [
-            "-X main.commit=${inputs.self.rev}"
+            "-X main.version=${buildVersion}"
+            "-X main.commit=${buildCommit}"
+            "-X main.date=${buildDate}"
           ];
 
           meta = with pkgs.lib; {

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -58,9 +58,16 @@ podman:
 
 nix:
   min_user_generations: 5
+  min_home_manager_generations: 5
   min_system_generations: 3
+  max_user_generations: 0
+  max_home_manager_generations: 0
+  host_measure_path: /nix/store
   delete_generations_older_than: 14d
   critical_delete_generations_older_than: 3d
+  delete_home_manager_generations: false
+  home_manager_delete_generations_older_than: 14d
+  home_manager_critical_delete_generations_older_than: 3d
   allow_store_optimize: false
   skip_when_daemon_busy: true
   daemon_busy_backoff: 30m

--- a/plugins/apfs_darwin.go
+++ b/plugins/apfs_darwin.go
@@ -102,8 +102,11 @@ func (p *APFSPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg *c
 		plan.SkipReason = "no_apfs_snapshots"
 		return plan
 	}
-	plan.Metadata["newest_snapshot"] = snapshots[0].Date
-	plan.Metadata["oldest_snapshot"] = snapshots[len(snapshots)-1].Date
+	timeMachineSnapshots, osUpdateSnapshots := apfsSnapshotCounts(snapshots)
+	plan.Metadata["time_machine_snapshot_count"] = strconv.Itoa(timeMachineSnapshots)
+	plan.Metadata["os_update_snapshot_count"] = strconv.Itoa(osUpdateSnapshots)
+	plan.Metadata["newest_snapshot"] = apfsSnapshotDisplayName(snapshots[0])
+	plan.Metadata["oldest_snapshot"] = apfsSnapshotDisplayName(snapshots[len(snapshots)-1])
 
 	low, high := apfsSnapshotEstimateBytes(snapshots)
 	plan.Metadata["estimated_snapshot_low_bytes"] = strconv.FormatInt(low, 10)
@@ -238,8 +241,11 @@ func (p *APFSPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *confi
 
 // snapshotInfo represents an APFS local snapshot.
 type snapshotInfo struct {
-	Date string // e.g., "2026-01-15-123456"
-	Time time.Time
+	Date       string // e.g., "2026-01-15-123456", or the full identifier for non-date snapshots.
+	Time       time.Time
+	Kind       string
+	Identifier string
+	HasTime    bool
 }
 
 // listSnapshots lists all local APFS snapshots.
@@ -257,7 +263,10 @@ func (p *APFSPlugin) listSnapshots(ctx context.Context) ([]snapshotInfo, error) 
 }
 
 // parseSnapshotList parses tmutil listlocalsnapshots output.
-// Format: "com.apple.TimeMachine.2026-01-15-123456.local" per line
+// Time Machine snapshots are date-form identifiers such as
+// "com.apple.TimeMachine.2026-01-15-123456.local". macOS update snapshots are
+// non-date identifiers such as "com.apple.os.update-..." and must be reported
+// separately because tmutil deletion accepts date-form tokens.
 func parseSnapshotList(output string) []snapshotInfo {
 	var snapshots []snapshotInfo
 	re := regexp.MustCompile(`(\d{4}-\d{2}-\d{2}-\d{6})`)
@@ -265,6 +274,14 @@ func parseSnapshotList(output string) []snapshotInfo {
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "com.apple.os.update-") {
+			snapshots = append(snapshots, snapshotInfo{
+				Date:       line,
+				Kind:       "os-update",
+				Identifier: line,
+			})
 			continue
 		}
 
@@ -281,17 +298,70 @@ func parseSnapshotList(output string) []snapshotInfo {
 		}
 
 		snapshots = append(snapshots, snapshotInfo{
-			Date: dateStr,
-			Time: t,
+			Date:       dateStr,
+			Time:       t,
+			Kind:       "time-machine",
+			Identifier: line,
+			HasTime:    true,
 		})
 	}
 
-	// Sort by time (newest first)
-	sort.Slice(snapshots, func(i, j int) bool {
-		return snapshots[i].Time.After(snapshots[j].Time)
+	// Sort timed snapshots by time (newest first), then keep non-timed
+	// snapshots in tmutil's original order.
+	sort.SliceStable(snapshots, func(i, j int) bool {
+		iHasTime := apfsSnapshotHasTime(snapshots[i])
+		jHasTime := apfsSnapshotHasTime(snapshots[j])
+		switch {
+		case iHasTime && jHasTime:
+			return snapshots[i].Time.After(snapshots[j].Time)
+		case iHasTime != jHasTime:
+			return iHasTime
+		default:
+			return false
+		}
 	})
 
 	return snapshots
+}
+
+func apfsSnapshotKind(snapshot snapshotInfo) string {
+	if snapshot.Kind != "" {
+		return snapshot.Kind
+	}
+	if apfsSnapshotHasTime(snapshot) {
+		return "time-machine"
+	}
+	return "unknown"
+}
+
+func apfsSnapshotHasTime(snapshot snapshotInfo) bool {
+	return snapshot.HasTime || !snapshot.Time.IsZero()
+}
+
+func apfsSnapshotDisplayName(snapshot snapshotInfo) string {
+	if snapshot.Identifier != "" {
+		return snapshot.Identifier
+	}
+	return snapshot.Date
+}
+
+func apfsSnapshotDeleteToken(snapshot snapshotInfo) (string, bool) {
+	if apfsSnapshotHasTime(snapshot) && snapshot.Date != "" {
+		return snapshot.Date, true
+	}
+	return "", false
+}
+
+func apfsSnapshotCounts(snapshots []snapshotInfo) (timeMachine int, osUpdate int) {
+	for _, snapshot := range snapshots {
+		switch apfsSnapshotKind(snapshot) {
+		case "time-machine":
+			timeMachine++
+		case "os-update":
+			osUpdate++
+		}
+	}
+	return timeMachine, osUpdate
 }
 
 // reportSnapshots logs information about existing snapshots.
@@ -305,8 +375,8 @@ func (p *APFSPlugin) reportSnapshots(snapshots []snapshotInfo, logger *slog.Logg
 
 	logger.Info("APFS local snapshots",
 		"count", len(snapshots),
-		"oldest", oldest.Date,
-		"newest", newest.Date,
+		"oldest", apfsSnapshotDisplayName(oldest),
+		"newest", apfsSnapshotDisplayName(newest),
 		"estimated_size_gb", fmt.Sprintf("~%d-%d", len(snapshots)*5, len(snapshots)*15),
 	)
 }
@@ -398,15 +468,20 @@ func apfsPlanTargets(snapshots []snapshotInfo, level CleanupLevel, cfg config.AP
 		target := CleanupTarget{
 			Type:      "apfs-snapshot",
 			Tier:      CleanupTierPrivileged,
-			Name:      snapshot.Date,
+			Name:      apfsSnapshotDisplayName(snapshot),
+			Version:   apfsSnapshotKind(snapshot),
 			Bytes:     5 * apfsGiB,
 			Protected: true,
 			Action:    "keep",
 			Reason:    "local snapshot is preserved by default",
 		}
 		switch {
+		case apfsSnapshotKind(snapshot) == "os-update":
+			target.Reason = "OS-update snapshot is reported for operator review; automatic deletion requires a date-form tmutil deletion token"
 		case i == 0:
 			target.Reason = "newest local snapshot is always preserved"
+		case !apfsSnapshotHasTime(snapshot):
+			target.Reason = "snapshot is missing a date-form tmutil deletion token"
 		case level == LevelCritical && cfg.DeleteOSUpdates && sudoPasswordless && !backupActive && snapshot.Time.Before(cutoff):
 			target.Protected = false
 			target.Action = "delete_old_snapshot"
@@ -491,19 +566,27 @@ func (p *APFSPlugin) deleteOldSnapshots(ctx context.Context, snapshots []snapsho
 		// Never delete the only snapshot
 		return result
 	}
+	if logger == nil {
+		logger = slog.Default()
+	}
 
 	cutoff := time.Now().Add(-time.Duration(keepDays) * 24 * time.Hour)
 
 	// Skip the first snapshot (most recent) - NEVER delete it
 	for _, snap := range snapshots[1:] {
+		deleteToken, ok := apfsSnapshotDeleteToken(snap)
+		if !ok {
+			logger.Debug("skipping APFS snapshot without date-form deletion token", "snapshot", apfsSnapshotDisplayName(snap), "kind", apfsSnapshotKind(snap))
+			continue
+		}
 		if snap.Time.After(cutoff) {
 			continue // Too recent to delete
 		}
 
-		logger.Warn("deleting old APFS snapshot", "date", snap.Date)
-		output, err := RunWithSudo(ctx, "tmutil", "deletelocalsnapshots", snap.Date)
+		logger.Warn("deleting old APFS snapshot", "date", deleteToken)
+		output, err := RunWithSudo(ctx, "tmutil", "deletelocalsnapshots", deleteToken)
 		if err != nil {
-			logger.Debug("failed to delete snapshot", "date", snap.Date, "error", err, "output", string(output))
+			logger.Debug("failed to delete snapshot", "date", deleteToken, "error", err, "output", string(output))
 			continue
 		}
 

--- a/plugins/apfs_darwin_test.go
+++ b/plugins/apfs_darwin_test.go
@@ -72,6 +72,22 @@ com.apple.TimeMachine.2026-01-15-123456.local
 			expected: 1,
 		},
 		{
+			name: "os update snapshots",
+			input: `Snapshots for volume group containing disk /:
+com.apple.os.update-1234567890ABCDEF
+com.apple.os.update-MSUPrepareUpdate
+`,
+			expected: 2,
+		},
+		{
+			name: "time machine and os update snapshots",
+			input: `Snapshots for volume group containing disk /:
+com.apple.TimeMachine.2026-01-15-123456.local
+com.apple.os.update-MSUPrepareUpdate
+`,
+			expected: 2,
+		},
+		{
 			name:     "malformed lines ignored",
 			input:    "not a snapshot\ninvalid-date.local\n",
 			expected: 0,
@@ -110,6 +126,37 @@ com.apple.TimeMachine.2026-01-12-120000.local
 	// Verify newest is 2026-01-15
 	if snapshots[0].Date != "2026-01-15-160000" {
 		t.Errorf("expected newest snapshot date '2026-01-15-160000', got %q", snapshots[0].Date)
+	}
+}
+
+func TestParseSnapshotListClassifiesOSUpdates(t *testing.T) {
+	input := `Snapshots for volume group containing disk /:
+com.apple.os.update-1234567890ABCDEF
+com.apple.TimeMachine.2026-01-15-160000.local
+com.apple.os.update-MSUPrepareUpdate
+`
+	snapshots := parseSnapshotList(input)
+	if len(snapshots) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(snapshots))
+	}
+
+	if snapshots[0].Date != "2026-01-15-160000" {
+		t.Fatalf("expected timed snapshot first, got %#v", snapshots[0])
+	}
+	if got := apfsSnapshotKind(snapshots[0]); got != "time-machine" {
+		t.Fatalf("first snapshot kind = %q, want time-machine", got)
+	}
+	if got := apfsSnapshotKind(snapshots[1]); got != "os-update" {
+		t.Fatalf("second snapshot kind = %q, want os-update", got)
+	}
+	if got := apfsSnapshotDisplayName(snapshots[1]); got != "com.apple.os.update-1234567890ABCDEF" {
+		t.Fatalf("second snapshot display = %q", got)
+	}
+	if token, ok := apfsSnapshotDeleteToken(snapshots[1]); ok || token != "" {
+		t.Fatalf("OS-update snapshot should not have a deletion token, got %q", token)
+	}
+	if got := apfsSnapshotKind(snapshots[2]); got != "os-update" {
+		t.Fatalf("third snapshot kind = %q, want os-update", got)
 	}
 }
 
@@ -200,6 +247,49 @@ func TestAPFSPlanTargetsCriticalDeletesOnlyEligibleOldSnapshots(t *testing.T) {
 	}
 	if got := apfsEstimatedCandidateBytes(targets); got != 20*apfsGiB {
 		t.Fatalf("estimated candidate bytes = %d, want %d", got, 20*apfsGiB)
+	}
+}
+
+func TestAPFSPlanTargetsReportsOSUpdateSnapshotsConservatively(t *testing.T) {
+	now := time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC)
+	snapshots := []snapshotInfo{
+		{
+			Date:       "2026-01-16-100000",
+			Time:       time.Date(2026, 1, 16, 10, 0, 0, 0, time.UTC),
+			Kind:       "time-machine",
+			Identifier: "com.apple.TimeMachine.2026-01-16-100000.local",
+			HasTime:    true,
+		},
+		{
+			Date:       "com.apple.os.update-MSUPrepareUpdate",
+			Kind:       "os-update",
+			Identifier: "com.apple.os.update-MSUPrepareUpdate",
+		},
+	}
+	cfg := config.APFSConfig{
+		ThinEnabled:     true,
+		MaxThinGB:       50,
+		KeepRecentDays:  1,
+		DeleteOSUpdates: true,
+	}
+
+	targets := apfsPlanTargets(snapshots, LevelCritical, cfg, 50, false, true, now)
+	if len(targets) != 3 {
+		t.Fatalf("expected aggregate target plus 2 snapshots, got %d", len(targets))
+	}
+
+	osUpdateTarget := targets[2]
+	if osUpdateTarget.Name != "com.apple.os.update-MSUPrepareUpdate" {
+		t.Fatalf("OS-update target name = %q", osUpdateTarget.Name)
+	}
+	if osUpdateTarget.Version != "os-update" {
+		t.Fatalf("OS-update target version = %q", osUpdateTarget.Version)
+	}
+	if osUpdateTarget.Action != "keep" || !osUpdateTarget.Protected {
+		t.Fatalf("OS-update snapshot should be protected review-only evidence, got %#v", osUpdateTarget)
+	}
+	if got := apfsEstimatedCandidateBytes(targets); got != 10*apfsGiB {
+		t.Fatalf("estimated candidate bytes = %d, want thinning estimate only", got)
 	}
 }
 


### PR DESCRIPTION
Linear: TIN-1049

## Summary
- add a GitHub Actions Nix package job and inject version, source revision, and flake timestamp into Nix builds
- refresh Linux packaged Nix cleanup defaults and add a config contract test for those keys
- recognize com.apple.os.update-* APFS snapshots in dry-run evidence while keeping them protected from automatic deletion
- update operator docs and changelog for the APFS and provenance behavior

## Notes
- The shared-cache wrapper and Bazel cache policy doc already exist in this repository; this PR focuses on the still-open package/provenance/config hygiene work.
- OS-update APFS snapshots are reported as protected review evidence because tmutil deletelocalsnapshots requires date-form deletion tokens.

## Validation
- git diff --check
- env GOCACHE=/private/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/private/tmp/tinyland-cleanup-gocache-vet GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/private/tmp/tinyland-cleanup-gocache-build GOFLAGS=-mod=vendor go build ./...
- bazelisk --output_user_root=/private/tmp/tinyland-cleanup-bazel test --symlink_prefix=/private/tmp/tinyland-cleanup-bazel-link- //:all_tests
- nix flake check --no-build
- nix build .#default --no-link --print-build-logs
- nix flake check --no-build --all-systems
- built binary reports tinyland-cleanup 0.2.0 (dirty) built 20260508014612 from the working tree build