### PR TITLE
Report stopped Podman machine disk plans

### DIFF
--- a/docs/podman-darwin-compaction.md
+++ b/docs/podman-darwin-compaction.md
@@ -29,6 +29,8 @@ tinyland-cleanup --once --dry-run --level critical --output json
 The Podman plan reports:
 
 - provider and running state;
+- stopped-machine VM disk metadata when the Podman CLI is installed but the
+  Podman API socket is unavailable;
 - BuildKit builder cache container, reclaimable bytes, retention policy, and
   protected skip reason when the cache is below threshold or cannot be
   inspected;
@@ -91,6 +93,12 @@ machine directories, `qemu-img` is unavailable, active containers are running,
 the provider is unknown, a rollback backup already exists, or the scratch
 filesystem does not have enough physical free space for the compacted copy and
 any required rollback backup.
+
+When the machine is stopped, online pruning is skipped. Critical dry-run still
+reports the raw VM image path, logical size, physical allocation, scratch
+requirement, and protected offline-compaction target when the local Podman
+machine config can be inspected. That path is evidence only unless offline
+compaction is explicitly enabled and all preflight gates pass.
 
 `compact_scratch_dir` may point at a reviewed scratch directory when the default
 VM disk directory cannot hold the temporary compacted image. Same-filesystem

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -197,6 +197,13 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 		plan.WouldRun = false
 		plan.SkipReason = "podman_machine_not_running"
 		plan.Summary = "Podman machine is not running"
+		plan.Steps = append(plan.Steps, "Skip online Podman pruning because the Podman machine is not running")
+		plan.Warnings = append(plan.Warnings, "online Podman cleanup needs a running machine; offline VM disk inspection remains safe in dry-run")
+		if level == LevelCritical {
+			compaction := p.planOfflineCompaction(ctx, cfg, logger)
+			addPodmanCompactionPlanToCleanupPlan(&plan, compaction)
+			plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
+		}
 		return plan
 	}
 
@@ -256,38 +263,45 @@ func (p *PodmanPlugin) PlanCleanup(ctx context.Context, level CleanupLevel, cfg 
 			}
 
 			compaction := p.planOfflineCompaction(ctx, cfg, logger)
-			plan.RequiredFreeBytes = compaction.RequiredFreeBytes
-			if compaction.CanCompact {
-				plan.EstimatedBytesFreed = compaction.EstimatedReclaimBytes
-			}
-			plan.Warnings = append(plan.Warnings, compaction.Warnings...)
-			plan.Steps = append(plan.Steps, compaction.Steps...)
-			plan.Targets = append(plan.Targets, podmanCompactionTargets(compaction)...)
-			plan.Metadata["offline_compaction_enabled"] = strconv.FormatBool(compaction.ConfigEnabled)
-			plan.Metadata["offline_compaction_can_run"] = strconv.FormatBool(compaction.CanCompact)
-			plan.Metadata["offline_compaction_skip_reason"] = compaction.SkipReason
-			plan.Metadata["offline_compaction_provider"] = compaction.Provider
-			plan.Metadata["offline_compaction_format"] = compaction.DiskFormat
-			plan.Metadata["offline_compaction_disk_path"] = compaction.DiskPath
-			plan.Metadata["offline_compaction_scratch_dir"] = compaction.ScratchDir
-			plan.Metadata["offline_compaction_temp_path"] = compaction.TempPath
-			plan.Metadata["offline_compaction_backup_path"] = compaction.BackupPath
-			plan.Metadata["offline_compaction_qemu_img_path"] = compaction.QemuImgPath
-			plan.Metadata["offline_compaction_logical_bytes"] = strconv.FormatInt(compaction.LogicalBytes, 10)
-			plan.Metadata["offline_compaction_physical_bytes"] = strconv.FormatInt(compaction.PhysicalBytes, 10)
-			plan.Metadata["offline_compaction_free_bytes"] = strconv.FormatInt(compaction.FreeBytes, 10)
-			plan.Metadata["offline_compaction_required_free_bytes"] = strconv.FormatInt(compaction.RequiredFreeBytes, 10)
-			plan.Metadata["offline_compaction_estimated_reclaim_bytes"] = strconv.FormatInt(compaction.EstimatedReclaimBytes, 10)
-			plan.Metadata["offline_compaction_active_containers"] = strconv.FormatBool(compaction.ActiveContainers)
-			plan.Metadata["offline_compaction_scratch_dir_configured"] = strconv.FormatBool(compaction.ScratchDirConfigured)
-			plan.Metadata["offline_compaction_scratch_dir_available"] = strconv.FormatBool(compaction.ScratchDirAvailable)
-			plan.Metadata["offline_compaction_scratch_dir_cross_device"] = strconv.FormatBool(compaction.ScratchDirCrossDevice)
-			plan.Metadata["offline_compaction_cross_device_replacement"] = strconv.FormatBool(compaction.CrossDeviceReplacement)
+			addPodmanCompactionPlanToCleanupPlan(&plan, compaction)
 		}
 		plan.Metadata["target_count"] = strconv.Itoa(len(plan.Targets))
 	}
 
 	return plan
+}
+
+func addPodmanCompactionPlanToCleanupPlan(plan *CleanupPlan, compaction podmanCompactionPlan) {
+	if plan.Metadata == nil {
+		plan.Metadata = map[string]string{}
+	}
+	plan.RequiredFreeBytes = compaction.RequiredFreeBytes
+	if compaction.CanCompact {
+		plan.EstimatedBytesFreed = compaction.EstimatedReclaimBytes
+	}
+	plan.Warnings = append(plan.Warnings, compaction.Warnings...)
+	plan.Steps = append(plan.Steps, compaction.Steps...)
+	plan.Targets = append(plan.Targets, podmanCompactionTargets(compaction)...)
+	plan.Metadata["offline_compaction_enabled"] = strconv.FormatBool(compaction.ConfigEnabled)
+	plan.Metadata["offline_compaction_can_run"] = strconv.FormatBool(compaction.CanCompact)
+	plan.Metadata["offline_compaction_skip_reason"] = compaction.SkipReason
+	plan.Metadata["offline_compaction_provider"] = compaction.Provider
+	plan.Metadata["offline_compaction_format"] = compaction.DiskFormat
+	plan.Metadata["offline_compaction_disk_path"] = compaction.DiskPath
+	plan.Metadata["offline_compaction_scratch_dir"] = compaction.ScratchDir
+	plan.Metadata["offline_compaction_temp_path"] = compaction.TempPath
+	plan.Metadata["offline_compaction_backup_path"] = compaction.BackupPath
+	plan.Metadata["offline_compaction_qemu_img_path"] = compaction.QemuImgPath
+	plan.Metadata["offline_compaction_logical_bytes"] = strconv.FormatInt(compaction.LogicalBytes, 10)
+	plan.Metadata["offline_compaction_physical_bytes"] = strconv.FormatInt(compaction.PhysicalBytes, 10)
+	plan.Metadata["offline_compaction_free_bytes"] = strconv.FormatInt(compaction.FreeBytes, 10)
+	plan.Metadata["offline_compaction_required_free_bytes"] = strconv.FormatInt(compaction.RequiredFreeBytes, 10)
+	plan.Metadata["offline_compaction_estimated_reclaim_bytes"] = strconv.FormatInt(compaction.EstimatedReclaimBytes, 10)
+	plan.Metadata["offline_compaction_active_containers"] = strconv.FormatBool(compaction.ActiveContainers)
+	plan.Metadata["offline_compaction_scratch_dir_configured"] = strconv.FormatBool(compaction.ScratchDirConfigured)
+	plan.Metadata["offline_compaction_scratch_dir_available"] = strconv.FormatBool(compaction.ScratchDirAvailable)
+	plan.Metadata["offline_compaction_scratch_dir_cross_device"] = strconv.FormatBool(compaction.ScratchDirCrossDevice)
+	plan.Metadata["offline_compaction_cross_device_replacement"] = strconv.FormatBool(compaction.CrossDeviceReplacement)
 }
 
 // Cleanup performs Podman cleanup at the specified level.
@@ -905,6 +919,17 @@ func detectPodmanEnvironment() (*PodmanEnvironment, error) {
 		return env, nil
 	}
 
+	if runtime.GOOS == "darwin" {
+		env.Runtime = "podman"
+		env.NeedsVM = true
+		env.VMProvider = detectMachineProvider()
+		env.VMRunning, env.MachineName = detectMachine()
+		if env.VMRunning {
+			env.SocketPath = getPodmanSocket()
+		}
+		return env, nil
+	}
+
 	// Verify podman is functional
 	cmd := exec.Command("podman", "info", "--format", "{{.Version.Version}}")
 	if err := cmd.Run(); err != nil {
@@ -914,13 +939,6 @@ func detectPodmanEnvironment() (*PodmanEnvironment, error) {
 
 	// Platform-specific detection
 	switch runtime.GOOS {
-	case "darwin":
-		env.NeedsVM = true
-		env.VMProvider = detectMachineProvider()
-		env.VMRunning, env.MachineName = detectRunningMachine()
-		if env.VMRunning {
-			env.SocketPath = getPodmanSocket()
-		}
 	case "linux":
 		env.NeedsVM = false
 		home, _ := os.UserHomeDir()
@@ -952,24 +970,46 @@ func detectMachineProvider() string {
 	return "applehv"
 }
 
-// detectRunningMachine detects if a Podman machine is running and returns its name.
-func detectRunningMachine() (bool, string) {
+// detectMachine detects the running machine when available, otherwise a default
+// or first machine that can still be inspected while stopped.
+func detectMachine() (bool, string) {
 	cmd := exec.Command("podman", "machine", "list", "--format", "{{.Name}}\t{{.Running}}")
 	output, err := cmd.Output()
 	if err != nil {
 		return false, ""
 	}
+	return parsePodmanMachineList(string(output))
+}
 
+func parsePodmanMachineList(output string) (bool, string) {
+	var firstMachine string
+	var defaultMachine string
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		parts := strings.Split(line, "\t")
-		if len(parts) >= 2 && strings.ToLower(parts[1]) == "true" {
-			// Strip trailing "*" which marks the default machine
-			name := strings.TrimRight(parts[0], "*")
+		if len(parts) < 2 {
+			continue
+		}
+		rawName := strings.TrimSpace(parts[0])
+		if rawName == "" {
+			continue
+		}
+		isDefault := strings.HasSuffix(rawName, "*")
+		name := strings.TrimRight(rawName, "*")
+		if firstMachine == "" {
+			firstMachine = name
+		}
+		if isDefault {
+			defaultMachine = name
+		}
+		if strings.ToLower(strings.TrimSpace(parts[1])) == "true" {
 			return true, name
 		}
 	}
 
-	return false, ""
+	if defaultMachine != "" {
+		return false, defaultMachine
+	}
+	return false, firstMachine
 }
 
 // getPodmanSocket returns the Podman socket path.
@@ -1170,7 +1210,7 @@ func (p *PodmanPlugin) planOfflineCompaction(ctx context.Context, cfg *config.Co
 		return plan
 	}
 
-	if cfg.Podman.CompactRequireNoActiveContainers {
+	if cfg.Podman.CompactRequireNoActiveContainers && !(p.environment.NeedsVM && !p.environment.VMRunning) {
 		active, err := p.hasActiveContainers(ctx)
 		input.ActiveContainers = active
 		if err != nil {

--- a/plugins/podman_compaction_test.go
+++ b/plugins/podman_compaction_test.go
@@ -1,12 +1,85 @@
 package plugins
 
 import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Jesssullivan/tinyland-cleanup/config"
 )
+
+func TestParsePodmanMachineListSelectsStoppedDefault(t *testing.T) {
+	running, name := parsePodmanMachineList("other-machine\tfalse\npodman-machine-default*\tfalse\n")
+
+	if running {
+		t.Fatal("expected no running machine")
+	}
+	if name != "podman-machine-default" {
+		t.Fatalf("expected stopped default machine name, got %q", name)
+	}
+}
+
+func TestPodmanCriticalPlanReportsStoppedMachineDisk(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+
+	diskDir := filepath.Join(home, ".local/share/containers/podman/machine/applehv")
+	if err := os.MkdirAll(diskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	diskPath := filepath.Join(diskDir, "podman-machine-default-arm64.raw")
+	if err := os.WriteFile(diskPath, []byte("raw disk placeholder"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	configDir := filepath.Join(home, ".config/containers/podman/machine/applehv")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "podman-machine-default.json")
+	configJSON := `{"ImagePath":{"Path":"` + diskPath + `"}}`
+	if err := os.WriteFile(configPath, []byte(configJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Podman.BuildKitPrune = false
+	p := &PodmanPlugin{environment: &PodmanEnvironment{
+		Runtime:     "podman",
+		NeedsVM:     true,
+		VMProvider:  "applehv",
+		VMRunning:   false,
+		MachineName: "podman-machine-default",
+	}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	plan := p.PlanCleanup(context.Background(), LevelCritical, cfg, logger)
+	if plan.SkipReason != "podman_machine_not_running" {
+		t.Fatalf("expected stopped-machine skip reason, got %q", plan.SkipReason)
+	}
+	if plan.Metadata["offline_compaction_disk_path"] != diskPath {
+		t.Fatalf("expected stopped-machine disk path %q, got metadata %#v", diskPath, plan.Metadata)
+	}
+	if plan.Metadata["offline_compaction_provider"] != "applehv" {
+		t.Fatalf("expected applehv provider metadata, got %#v", plan.Metadata)
+	}
+
+	disk := findPodmanTarget(t, plan.Targets, "podman_vm_disk")
+	if disk.Path != diskPath {
+		t.Fatalf("expected VM disk target path %q, got %#v", diskPath, disk)
+	}
+	if disk.Action != "protect_offline_compaction" || !disk.Protected {
+		t.Fatalf("expected protected offline compaction target for stopped-machine dry-run, got %#v", disk)
+	}
+	if !strings.Contains(strings.Join(plan.Steps, "\n"), "Skip online Podman pruning") {
+		t.Fatalf("expected online cleanup skip step, got %#v", plan.Steps)
+	}
+}
 
 func TestPodmanCompactionPlanUsesPhysicalAllocationForAppleHVRaw(t *testing.T) {
 	cfg := testPodmanCompactionConfig()


### PR DESCRIPTION
## Summary
- keep Darwin Podman detectable when the CLI exists but the machine/API socket is stopped
- include protected offline-compaction disk targets in critical dry-run output for stopped machines
- document the stopped-machine evidence path and add regression coverage

Related: #6

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test(ParsePodmanMachineListSelectsStoppedDefault|PodmanCriticalPlanReportsStoppedMachineDisk|PodmanCompaction)'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `git diff --check`
- `bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
- `nix build .#default --no-link --print-build-logs`

## Live Neo proof
- patched dry-run reports the stopped `podman-machine-default` disk path
- logical bytes: `107374182400`
- physical bytes: `13779234816`
- protected target: `podman_vm_disk` with `protect_offline_compaction`
- skip reason remains `compact_disk_offline_disabled` by default