### PR TITLE
TIN-1011 refine protected Bazel output-base bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project will be documented in this file.
 - Bazel reclaim candidates now refine byte estimates with a bounded recursive
   allocation walk so stale output-base dry-runs do not understate large nested
   `execroot` and `bazel-out` trees.
+- Bazel protected, recent, active, and reclaimable output-base candidates now
+  share the same bounded recursive allocation walk before policy planning, so
+  dry-runs and budget metadata do not understate large protected `execroot` and
+  `bazel-out` trees.
 - Top-level dry-run summary fields for planned estimated reclaim, required free
   space, and cleanup target count.
 - Target-free report fields and real-cleanup stop behavior once the configured

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -23,9 +23,10 @@ The Bazel plan includes targets for:
 
 Targets include policy tier, physical byte estimates, logical byte estimates
 when different, host-reclaim expectation, active-use evidence, protected status,
-the planned action, and a reason. Reclaimable output-base targets get a bounded
-recursive allocation refinement so nested `execroot` and `bazel-out` bytes are
-visible in dry-run plans. Output bases are protected when:
+the planned action, and a reason. Output-base candidates get a bounded
+recursive allocation refinement before policy planning so protected, recent,
+active, and reclaimable `execroot` and `bazel-out` bytes are visible in dry-run
+plans and budget metadata. Output bases are protected when:
 
 - an active Bazel process exposes an explicit `--output_base`;
 - an output-base lock or server PID file is visible;
@@ -85,10 +86,10 @@ Runtime boundary:
 - after an output base is deleted, workspace roots are scanned shallowly for
   canonical repo-local `bazel-*` symlinks, and only symlinks whose raw target
   points inside that deleted output base are removed;
-- protected/review byte counts use top-level allocation estimates so dry-run
-  remains responsive on very large generated trees; reclaimable output-base
-  targets use a bounded recursive refinement and mark the plan partial if the
-  refinement times out;
+- output-base byte counts use a bounded recursive allocation estimate and mark
+  the plan partial if the refinement times out; repository cache, disk cache,
+  and Bazelisk cache-tier byte counts use top-level allocation estimates so
+  dry-run remains responsive on very large cache trees;
 - Bazel output bases, repository caches, and disk caches are `warm` targets
   because they are rebuildable but expensive; Bazelisk downloads are `safe`
   targets;

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -126,15 +126,15 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 
 	globalActive := len(activeInfo.Reasons) > 0
 	candidates := p.discoverCandidates(home, cfg.Bazel, activeInfo)
-	targets, totalPhysical := bazelPlanTargets(candidates, cfg.Bazel, level, time.Now(), globalActive)
-	targets, refined, refineErr := refineBazelReclaimTargetBytes(ctx, targets)
+	candidates, refined, refineErr := refineBazelOutputBaseCandidateBytes(ctx, candidates)
 	if refined {
-		plan.Metadata["reclaim_size_estimate_refined"] = "true"
+		plan.Metadata["output_base_size_estimate_refined"] = "true"
 	}
 	if refineErr != nil {
-		plan.Metadata["reclaim_size_estimate_partial"] = "true"
-		plan.Warnings = append(plan.Warnings, fmt.Sprintf("Bazel reclaim-byte refinement was partial: %v", refineErr))
+		plan.Metadata["output_base_size_estimate_partial"] = "true"
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("Bazel output-base byte refinement was partial: %v", refineErr))
 	}
+	targets, totalPhysical := bazelPlanTargets(candidates, cfg.Bazel, level, time.Now(), globalActive)
 
 	plan.Targets = targets
 	plan.EstimatedBytesFreed = bazelEstimatedCandidateBytes(targets)
@@ -146,7 +146,7 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 		plan.Warnings = append(plan.Warnings, "detected Bazel cache footprint exceeds configured review budget")
 	}
 	plan.Warnings = append(plan.Warnings, "Bazel cleanup deletes rebuildable cache tiers only when the total footprint exceeds the configured budget and active-use inspection succeeds")
-	plan.Warnings = append(plan.Warnings, "Bazel protected/review byte counts use bounded top-level allocation estimates; reclaim targets use a bounded recursive refinement")
+	plan.Warnings = append(plan.Warnings, "Bazel output-base byte counts use a bounded recursive allocation estimate; cache tier counts use bounded top-level allocation estimates")
 
 	return plan, activeErr
 }
@@ -458,28 +458,28 @@ func estimateBazelCandidateBytes(path string) (int64, int64) {
 	return logical, physical
 }
 
-func refineBazelReclaimTargetBytes(ctx context.Context, targets []CleanupTarget) ([]CleanupTarget, bool, error) {
+func refineBazelOutputBaseCandidateBytes(ctx context.Context, candidates []bazelCandidate) ([]bazelCandidate, bool, error) {
 	estimateCtx, cancel := context.WithTimeout(ctx, bazelReclaimEstimateTimeout)
 	defer cancel()
 
 	refined := false
-	for i := range targets {
-		if !bazelTargetReclaimsHost(targets[i]) {
+	for i := range candidates {
+		if candidates[i].Type != "output_base" {
 			continue
 		}
-		logical, physical, err := estimateBazelCandidateBytesRecursive(estimateCtx, targets[i].Path)
-		if physical > targets[i].Bytes {
-			targets[i].Bytes = physical
+		logical, physical, err := estimateBazelCandidateBytesRecursive(estimateCtx, candidates[i].Path)
+		if physical > candidates[i].Physical {
+			candidates[i].Physical = physical
 			refined = true
 		}
-		if logical > targets[i].LogicalBytes {
-			targets[i].LogicalBytes = logical
+		if logical > candidates[i].Logical {
+			candidates[i].Logical = logical
 		}
 		if err != nil {
-			return targets, refined, err
+			return candidates, refined, err
 		}
 	}
-	return targets, refined, nil
+	return candidates, refined, nil
 }
 
 func estimateBazelCandidateBytesRecursive(ctx context.Context, path string) (int64, int64, error) {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -141,7 +141,7 @@ func TestBazelPlanTargetsProtectsRecentActiveAndWorkspaces(t *testing.T) {
 	}
 }
 
-func TestRefineBazelReclaimTargetBytesUsesRecursiveAllocation(t *testing.T) {
+func TestRefineBazelOutputBaseCandidatesUsesRecursiveAllocation(t *testing.T) {
 	outputBase := filepath.Join(t.TempDir(), "output-base")
 	makeBazelOutputBase(t, outputBase)
 	nested := filepath.Join(outputBase, "execroot", "repo", "bazel-out", "darwin-fastbuild", "bin")
@@ -151,42 +151,86 @@ func TestRefineBazelReclaimTargetBytesUsesRecursiveAllocation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targets := []CleanupTarget{
+	candidates := []bazelCandidate{
 		{
-			Type:      "output_base",
-			Name:      "output-base",
-			Path:      outputBase,
-			Bytes:     1,
-			Action:    "delete_output_base",
-			Protected: false,
-			Active:    false,
+			Type:     "output_base",
+			Name:     "output-base",
+			Path:     outputBase,
+			Physical: 1,
+			Logical:  1,
 		},
 		{
 			Type:      "output_base",
 			Name:      "protected",
 			Path:      outputBase,
-			Bytes:     1,
-			Action:    "keep",
+			Physical:  1,
+			Logical:   1,
 			Protected: true,
-			Active:    false,
 		},
 	}
 
-	refined, changed, err := refineBazelReclaimTargetBytes(context.Background(), targets)
+	refined, changed, err := refineBazelOutputBaseCandidateBytes(context.Background(), candidates)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !changed {
-		t.Fatal("expected reclaim target bytes to be refined")
+		t.Fatal("expected output-base candidate bytes to be refined")
 	}
-	if refined[0].Bytes < 2*1024*1024 {
-		t.Fatalf("delete target bytes = %d, want at least payload size", refined[0].Bytes)
+	if refined[0].Physical < 2*1024*1024 {
+		t.Fatalf("delete candidate physical bytes = %d, want at least payload size", refined[0].Physical)
 	}
-	if refined[0].LogicalBytes < 2*1024*1024 {
-		t.Fatalf("delete target logical bytes = %d, want at least payload size", refined[0].LogicalBytes)
+	if refined[0].Logical < 2*1024*1024 {
+		t.Fatalf("delete candidate logical bytes = %d, want at least payload size", refined[0].Logical)
 	}
-	if refined[1].Bytes != 1 {
-		t.Fatalf("protected target should not be recursively measured: %#v", refined[1])
+	if refined[1].Physical < 2*1024*1024 {
+		t.Fatalf("protected candidate should also be recursively measured: %#v", refined[1])
+	}
+}
+
+func TestBazelPlanRefinesProtectedOutputBaseBytes(t *testing.T) {
+	outputUserRoot := filepath.Join(t.TempDir(), "_bazel_jess")
+	outputBase := filepath.Join(outputUserRoot, "recent")
+	makeBazelOutputBase(t, outputBase)
+	nested := filepath.Join(outputBase, "execroot", "repo", "bazel-out", "darwin-fastbuild", "bin")
+	mustMkdir(t, nested)
+	payload := filepath.Join(nested, "large.o")
+	if err := os.WriteFile(payload, bytesOfSize(2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Bazel.Roots = []string{outputUserRoot}
+	cfg.Bazel.KeepRecentOutputBases = 1
+	cfg.Bazel.BazeliskCache = ""
+	resolvedOutputBase, err := filepath.EvalSymlinks(outputBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plan := NewBazelPlugin().PlanCleanup(context.Background(), LevelCritical, cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	var target CleanupTarget
+	found := false
+	for _, candidate := range plan.Targets {
+		if candidate.Path == resolvedOutputBase {
+			target = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected target for %s, got %#v", resolvedOutputBase, plan.Targets)
+	}
+	if !target.Protected || target.Action != "keep" {
+		t.Fatalf("recent output base should remain protected: %#v", target)
+	}
+	if target.Bytes < 2*1024*1024 {
+		t.Fatalf("protected target bytes = %d, want at least payload size", target.Bytes)
+	}
+	if plan.EstimatedBytesFreed != 0 {
+		t.Fatalf("protected output base should not contribute reclaim estimate, got %d", plan.EstimatedBytesFreed)
+	}
+	if plan.Metadata["output_base_size_estimate_refined"] != "true" {
+		t.Fatalf("missing refinement metadata: %#v", plan.Metadata)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move Bazel output-base byte refinement before cleanup policy planning so protected, recent, active, and reclaimable output bases share the bounded recursive allocation walk.
- Keep deletion safety unchanged: protected/recent/active output bases remain `keep` targets and do not contribute to `EstimatedBytesFreed`.
- Update the Bazel cache policy docs and changelog to reflect the new accounting boundary.

## Root Cause

Neo dry-runs were showing MiB-scale planned targets while live Bazel output bases were GiB-scale. The recursive byte refinement only ran after policy planning and only on reclaim targets, so protected/recent/active output-base candidates kept shallow top-level allocation estimates.

## Live Proof

Committed code was run read-only against Neo's cleanup config:

- command shape: `go run . --config ~/.config/tinyland-cleanup/config.yaml --plugins bazel --once --dry-run --level critical --output json`
- result: `planned_targets=18`, `total_bytes_freed=0`, `estimated_bytes_freed=0`
- metadata: `output_base_size_estimate_refined=true`, `output_base_size_estimate_partial=true`, `total_physical_bytes=15905190981`
- top protected output bases now report GiB-scale byte counts, including `/private/var/tmp/_bazel_jess/87c7d86c146861775c979a6e948c7d50` at `2917551268` bytes and `/private/var/tmp/_bazel_jess/4ad2c846921e694de764098b5725703e` at `2794753020` bytes.

## Validation

- `git diff --check`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- Neo read-only Bazel-plugin dry-run described above

Not run locally: `nix build` and Bazelisk validation, because Neo is under active disk pressure with roughly 20 GiB free and this patch is Go/plugin-scoped. CI should cover broader package validation.

Linear: TIN-1011
