### PR TITLE
TIN-1011 clean stale Nix temp roots

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -305,6 +305,12 @@ type DevArtifactsConfig struct {
 	TempArtifactMinMB int `yaml:"temp_artifact_min_mb"`
 	// TempArtifactStaleAfter is the age after which temp artifacts become review candidates
 	TempArtifactStaleAfter string `yaml:"temp_artifact_stale_after"`
+	// NixTempRoots enables deletion of stale top-level nix-shell/nix-develop temp roots
+	NixTempRoots bool `yaml:"nix_temp_roots"`
+	// NixTempRootMinMB is the minimum physical size for stale Nix temp-root deletion candidates
+	NixTempRootMinMB int `yaml:"nix_temp_root_min_mb"`
+	// NixTempRootStaleAfter is the age after which Nix temp roots become deletion candidates
+	NixTempRootStaleAfter string `yaml:"nix_temp_root_stale_after"`
 	// NodeModules enables node_modules cleanup
 	NodeModules bool `yaml:"node_modules"`
 	// PythonVenvs enables .venv cleanup
@@ -505,6 +511,9 @@ func DefaultConfig() *Config {
 			TempScanMaxRoots:        128,
 			TempArtifactMinMB:       256,
 			TempArtifactStaleAfter:  "6h",
+			NixTempRoots:            true,
+			NixTempRootMinMB:        1,
+			NixTempRootStaleAfter:   "24h",
 			NodeModules:             true,
 			PythonVenvs:             true,
 			RustTargets:             true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -319,6 +319,15 @@ func TestDevArtifactsConfigDefaults(t *testing.T) {
 	if cfg.DevArtifacts.TempScanMaxRoots != 128 {
 		t.Errorf("DevArtifacts.TempScanMaxRoots should default to 128, got %d", cfg.DevArtifacts.TempScanMaxRoots)
 	}
+	if !cfg.DevArtifacts.NixTempRoots {
+		t.Error("DevArtifacts.NixTempRoots should default to true")
+	}
+	if cfg.DevArtifacts.NixTempRootMinMB != 1 {
+		t.Errorf("DevArtifacts.NixTempRootMinMB should default to 1, got %d", cfg.DevArtifacts.NixTempRootMinMB)
+	}
+	if cfg.DevArtifacts.NixTempRootStaleAfter != "24h" {
+		t.Errorf("DevArtifacts.NixTempRootStaleAfter should default to 24h, got %q", cfg.DevArtifacts.NixTempRootStaleAfter)
+	}
 }
 
 func TestAPFSConfigDefaults(t *testing.T) {

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -199,6 +199,12 @@ dev_artifacts:
   temp_scan_max_roots: 128
   temp_artifact_min_mb: 256
   temp_artifact_stale_after: 6h
+  # Stale top-level Nix shell/develop/build scratch roots are rebuildable but
+  # can accumulate quickly under /private/tmp. These are only deleted under
+  # aggressive/critical pressure, never while referenced by active processes.
+  nix_temp_roots: true
+  nix_temp_root_min_mb: 1
+  nix_temp_root_stale_after: 24h
   node_modules: true
   python_venvs: true
   rust_targets: true

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Jesssullivan/tinyland-cleanup/config"
@@ -27,6 +28,7 @@ const devArtifactRecentOutputGrace = 2 * time.Hour
 
 var tempArtifactPathPattern = regexp.MustCompile(`(?:/private)?/tmp/[^\s"'<>]+|/var/tmp/[^\s"'<>]+`)
 var absoluteDevArtifactPathPattern = regexp.MustCompile(`(?:~|/)[^\s"'<>]+`)
+var nixTempRootNamePattern = regexp.MustCompile(`^(?:nix-shell\.[A-Za-z0-9]+|nix-develop-\d+-\d+|nix-\d+-\d+|nix-build-[A-Za-z0-9._+@=-]+-\d+)$`)
 
 var errDevArtifactScanBudgetExceeded = errors.New("dev artifact scan budget exceeded")
 
@@ -263,7 +265,13 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 			if !pathExistsAndIsDir(expanded) {
 				continue
 			}
-			p.planTemporaryArtifacts(scanCtx, expanded, tempMinBytes, tempStaleAfter, daCfg.ProtectPaths, activeTempRoots, &targets, scanBudget)
+			nixTempRootMinBytes := nixTempRootMinBytes(daCfg)
+			nixTempRootStaleAfter := parseNixPolicyDuration(daCfg.NixTempRootStaleAfter, 24*time.Hour)
+			nixTempRootDeletes := level >= LevelAggressive
+			if daCfg.NixTempRoots {
+				p.planNixTemporaryRoots(scanCtx, expanded, nixTempRootMinBytes, nixTempRootStaleAfter, nixTempRootDeletes, daCfg, activeTempRoots, &targets, scanBudget)
+			}
+			p.planTemporaryArtifacts(scanCtx, expanded, tempMinBytes, tempStaleAfter, daCfg, activeTempRoots, &targets, scanBudget)
 			p.planTemporaryGeneratedArtifacts(scanCtx, expanded, tempMinBytes, tempStaleAfter, nodeAge, venvAge, rustAge, zigAge, mutates, daCfg, active, activeTempRoots, tracker, &targets, scanBudget)
 		}
 	}
@@ -352,6 +360,42 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 
 	tracker := newDevArtifactGitTracker()
 
+	// Incident-oriented temp roots are cheap to classify and should run before
+	// deep workspace walks so a large ~/git tree cannot starve /private/tmp cleanup.
+	if daCfg.TempArtifacts {
+		activeTempRoots := activeTempArtifactRoots(ctx, daCfg.TempScanPaths, home)
+		tempMinBytes := tempArtifactMinBytes(daCfg)
+		tempStaleAfter := parseNixPolicyDuration(daCfg.TempArtifactStaleAfter, 6*time.Hour)
+		nixTempRootMinBytes := nixTempRootMinBytes(daCfg)
+		nixTempRootStaleAfter := parseNixPolicyDuration(daCfg.NixTempRootStaleAfter, 24*time.Hour)
+		for _, scanPath := range daCfg.TempScanPaths {
+			expanded := expandHome(scanPath, home)
+			if !pathExistsAndIsDir(expanded) {
+				continue
+			}
+			if daCfg.NixTempRoots && level >= LevelAggressive {
+				freed := p.cleanNixTemporaryRoots(scanCtx, expanded, nixTempRootMinBytes, nixTempRootStaleAfter, daCfg.ProtectPaths, activeTempRoots, logger, scanBudget)
+				result.BytesFreed += freed
+				if freed > 0 {
+					result.ItemsCleaned++
+				}
+			}
+			if scanBudget.exhausted() {
+				logger.Warn("stopping dev artifact cleanup because scan budget was exhausted", "truncated_paths", strings.Join(scanBudget.truncatedDetails(), "; "))
+				return result
+			}
+			freed := p.cleanTemporaryGeneratedArtifacts(scanCtx, expanded, tempMinBytes, tempStaleAfter, nodeAge, venvAge, rustAge, zigAge, daCfg, active, activeTempRoots, tracker, logger, scanBudget)
+			result.BytesFreed += freed
+			if freed > 0 {
+				result.ItemsCleaned++
+			}
+			if scanBudget.exhausted() {
+				logger.Warn("stopping dev artifact cleanup because scan budget was exhausted", "truncated_paths", strings.Join(scanBudget.truncatedDetails(), "; "))
+				return result
+			}
+		}
+	}
+
 	// Scan configured paths for dev artifacts
 	for _, scanPath := range daCfg.ScanPaths {
 		expanded := expandHome(scanPath, home)
@@ -405,27 +449,6 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 		if scanBudget.exhausted() {
 			logger.Warn("stopping dev artifact cleanup because scan budget was exhausted", "truncated_paths", strings.Join(scanBudget.truncatedDetails(), "; "))
 			return result
-		}
-	}
-
-	if daCfg.TempArtifacts {
-		activeTempRoots := activeTempArtifactRoots(ctx, daCfg.TempScanPaths, home)
-		tempMinBytes := tempArtifactMinBytes(daCfg)
-		tempStaleAfter := parseNixPolicyDuration(daCfg.TempArtifactStaleAfter, 6*time.Hour)
-		for _, scanPath := range daCfg.TempScanPaths {
-			expanded := expandHome(scanPath, home)
-			if !pathExistsAndIsDir(expanded) {
-				continue
-			}
-			freed := p.cleanTemporaryGeneratedArtifacts(scanCtx, expanded, tempMinBytes, tempStaleAfter, nodeAge, venvAge, rustAge, zigAge, daCfg, active, activeTempRoots, tracker, logger, scanBudget)
-			result.BytesFreed += freed
-			if freed > 0 {
-				result.ItemsCleaned++
-			}
-			if scanBudget.exhausted() {
-				logger.Warn("stopping dev artifact cleanup because scan budget was exhausted", "truncated_paths", strings.Join(scanBudget.truncatedDetails(), "; "))
-				return result
-			}
 		}
 	}
 
@@ -523,7 +546,7 @@ func (p *DevArtifactsPlugin) planLargeLocalArtifacts(ctx context.Context, scanPa
 	}, budget)
 }
 
-func (p *DevArtifactsPlugin) planTemporaryArtifacts(ctx context.Context, scanPath string, minBytes int64, staleAfter time.Duration, protectPaths []string, activeRoots map[string]string, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
+func (p *DevArtifactsPlugin) planTemporaryArtifacts(ctx context.Context, scanPath string, minBytes int64, staleAfter time.Duration, daCfg config.DevArtifactsConfig, activeRoots map[string]string, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
 	budget := optionalDevArtifactScanBudget(budgets)
 	entries, err := os.ReadDir(scanPath)
 	if err != nil {
@@ -546,8 +569,9 @@ func (p *DevArtifactsPlugin) planTemporaryArtifacts(ctx context.Context, scanPat
 			continue
 		}
 		activeReason := activeRoots[canonicalTempArtifactPath(path)]
+		protected := p.isProtected(path, daCfg.ProtectPaths)
 		if activeReason != "" {
-			*targets = append(*targets, p.temporaryArtifactTarget(path, 0, info.ModTime(), staleAfter, now, p.isProtected(path, protectPaths), activeReason))
+			*targets = append(*targets, p.temporaryArtifactTarget(path, 0, info.ModTime(), staleAfter, now, protected, activeReason))
 			continue
 		}
 		size, err := getDirAllocatedBytesContext(ctx, path)
@@ -558,8 +582,111 @@ func (p *DevArtifactsPlugin) planTemporaryArtifacts(ctx context.Context, scanPat
 		if size < minBytes {
 			continue
 		}
-		*targets = append(*targets, p.temporaryArtifactTarget(path, size, info.ModTime(), staleAfter, now, p.isProtected(path, protectPaths), ""))
+		*targets = append(*targets, p.temporaryArtifactTarget(path, size, info.ModTime(), staleAfter, now, protected, ""))
 	}
+}
+
+func (p *DevArtifactsPlugin) planNixTemporaryRoots(ctx context.Context, scanPath string, minBytes int64, staleAfter time.Duration, canDelete bool, daCfg config.DevArtifactsConfig, activeRoots map[string]string, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
+	budget := optionalDevArtifactScanBudget(budgets)
+	entries, err := os.ReadDir(scanPath)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return
+		}
+		if !entry.IsDir() || !isNixTemporaryRootName(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(scanPath, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if !canManageDevTempRoot(info) {
+			continue
+		}
+		activeReason := activeRoots[canonicalTempArtifactPath(path)]
+		protected := p.isProtected(path, daCfg.ProtectPaths)
+		target := p.nixTemporaryRootTarget(path, 0, info.ModTime(), staleAfter, now, protected, activeReason, canDelete)
+		if target.Action != "delete" {
+			if err := budget.checkTempRoot(ctx, path); err != nil {
+				return
+			}
+			*targets = append(*targets, target)
+			continue
+		}
+		size, err := getDirAllocatedBytesContext(ctx, path)
+		if err != nil {
+			budget.markContextError(ctx, path)
+			return
+		}
+		if size < minBytes {
+			continue
+		}
+		if err := budget.checkTempRoot(ctx, path); err != nil {
+			return
+		}
+		target.Bytes = size
+		*targets = append(*targets, target)
+	}
+}
+
+func (p *DevArtifactsPlugin) cleanNixTemporaryRoots(ctx context.Context, scanPath string, minBytes int64, staleAfter time.Duration, protectPaths []string, activeRoots map[string]string, logger *slog.Logger, budgets ...*devArtifactScanBudget) int64 {
+	budget := optionalDevArtifactScanBudget(budgets)
+	entries, err := os.ReadDir(scanPath)
+	if err != nil {
+		return 0
+	}
+	now := time.Now()
+	var totalFreed int64
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return totalFreed
+		}
+		if !entry.IsDir() || !isNixTemporaryRootName(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(scanPath, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if !canManageDevTempRoot(info) {
+			continue
+		}
+		activeReason := activeRoots[canonicalTempArtifactPath(path)]
+		target := p.nixTemporaryRootTarget(path, 0, info.ModTime(), staleAfter, now, p.isProtected(path, protectPaths), activeReason, true)
+		if target.Action != "delete" {
+			if err := budget.checkTempRoot(ctx, path); err != nil {
+				return totalFreed
+			}
+			continue
+		}
+		size, err := getDirAllocatedBytesContext(ctx, path)
+		if err != nil {
+			budget.markContextError(ctx, path)
+			return totalFreed
+		}
+		if size < minBytes {
+			continue
+		}
+		if err := budget.checkTempRoot(ctx, path); err != nil {
+			return totalFreed
+		}
+		logger.Debug("removing stale Nix temporary root", "path", path, "size_mb", size/(1024*1024))
+		if err := os.RemoveAll(path); err != nil {
+			logger.Debug("failed to remove stale Nix temporary root", "path", path, "error", err)
+			continue
+		}
+		totalFreed += size
+	}
+	if totalFreed > 0 {
+		logger.Info("cleaned stale Nix temporary roots", "freed_mb", totalFreed/(1024*1024))
+	}
+	return totalFreed
 }
 
 func (p *DevArtifactsPlugin) planTemporaryGeneratedArtifacts(ctx context.Context, scanPath string, minBytes int64, staleAfter, nodeAge, venvAge, rustAge, zigAge time.Duration, mutates bool, daCfg config.DevArtifactsConfig, active devArtifactActivity, activeRoots map[string]string, tracker *devArtifactGitTracker, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
@@ -676,11 +803,67 @@ func (p *DevArtifactsPlugin) temporaryArtifactTarget(path string, physicalBytes 
 	return target
 }
 
+func (p *DevArtifactsPlugin) nixTemporaryRootTarget(path string, physicalBytes int64, modTime time.Time, staleAfter time.Duration, now time.Time, protected bool, activeReason string, canDelete bool) CleanupTarget {
+	action := "delete"
+	reason := fmt.Sprintf("stale Nix temporary root is older than %s", formatDevArtifactAge(staleAfter))
+	active := activeReason != ""
+	isProtected := false
+	switch {
+	case active:
+		action = "protect"
+		reason = "active process references this temporary path: " + activeReason
+		isProtected = true
+	case protected:
+		action = "protect"
+		reason = "path is covered by dev_artifacts.protect_paths"
+		isProtected = true
+	case staleAfter > 0 && modTime.After(now.Add(-staleAfter)):
+		action = "protect"
+		reason = fmt.Sprintf("Nix temporary root is newer than %s", formatDevArtifactAge(staleAfter))
+		isProtected = true
+	case !canDelete:
+		action = "report"
+		reason = "Nix temporary root deletion requires aggressive or critical cleanup level"
+		isProtected = true
+	}
+	target := CleanupTarget{
+		Type:      "nix-temp-root",
+		Name:      filepath.Base(path),
+		Path:      path,
+		Bytes:     physicalBytes,
+		Active:    active,
+		Protected: isProtected,
+		Action:    action,
+		Reason:    reason,
+	}
+	annotateCleanupTargetPolicy(&target, CleanupTierWarm, hostReclaimForAction(target.Action))
+	return target
+}
+
 func tempArtifactMinBytes(cfg config.DevArtifactsConfig) int64 {
 	if cfg.TempArtifactMinMB <= 0 {
 		return 256 * 1024 * 1024
 	}
 	return int64(cfg.TempArtifactMinMB) * 1024 * 1024
+}
+
+func nixTempRootMinBytes(cfg config.DevArtifactsConfig) int64 {
+	if cfg.NixTempRootMinMB <= 0 {
+		return 1024 * 1024
+	}
+	return int64(cfg.NixTempRootMinMB) * 1024 * 1024
+}
+
+func isNixTemporaryRootName(name string) bool {
+	return nixTempRootNamePattern.MatchString(name)
+}
+
+func canManageDevTempRoot(info os.FileInfo) bool {
+	if os.Geteuid() == 0 {
+		return true
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && int(stat.Uid) == os.Geteuid()
 }
 
 func (p *DevArtifactsPlugin) findLargeLocalArtifacts(ctx context.Context, scanPath string, minBytes int64, protectPaths []string, mountedImages map[string]string, callback func(CleanupTarget), budgets ...*devArtifactScanBudget) {

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -908,7 +908,9 @@ func TestPlanTemporaryArtifactsReportsReviewOnlyTargets(t *testing.T) {
 	}
 
 	var targets []CleanupTarget
-	p.planTemporaryArtifacts(context.Background(), tmpDir, 1, 6*time.Hour, nil, map[string]string{
+	cfg := config.DefaultConfig().DevArtifacts
+	cfg.NixTempRoots = false
+	p.planTemporaryArtifacts(context.Background(), tmpDir, 1, 6*time.Hour, cfg, map[string]string{
 		canonicalTempArtifactPath(activePath): "bazel",
 	}, &targets)
 
@@ -957,7 +959,9 @@ func TestPlanTemporaryArtifactsDoesNotChargeSymlinkTargets(t *testing.T) {
 	}
 
 	var targets []CleanupTarget
-	p.planTemporaryArtifacts(context.Background(), tmpDir, 1024*1024, 6*time.Hour, nil, nil, &targets)
+	cfg := config.DefaultConfig().DevArtifacts
+	cfg.NixTempRoots = false
+	p.planTemporaryArtifacts(context.Background(), tmpDir, 1024*1024, 6*time.Hour, cfg, nil, &targets)
 
 	for _, target := range targets {
 		if target.Path == root {
@@ -1042,6 +1046,105 @@ func TestCleanupPrunesGeneratedArtifactsInsideStaleTemporaryRoots(t *testing.T) 
 	}
 }
 
+func TestPlanCleanupDeletesStaleNixTemporaryRoots(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "nix-shell.Abc123")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "scratch"), make([]byte, 2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(root, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := nixTempRootConfig(tmpDir)
+	plan := p.PlanCleanup(context.Background(), LevelCritical, cfg, slog.Default())
+
+	target := findDevArtifactTarget(t, plan.Targets, "nix-temp-root", root)
+	if target.Action != "delete" || target.Protected {
+		t.Fatalf("expected stale Nix temp root to be deletable, got %#v", target)
+	}
+	if plan.EstimatedBytesFreed <= 0 {
+		t.Fatal("expected stale Nix temp root to contribute to reclaim estimate")
+	}
+}
+
+func TestCleanupPrunesNixTemporaryRootsBeforeWorkspaceScanBudget(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "nix-develop-1234-5678")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "scratch"), make([]byte, 2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(root, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "project", "node_modules", "pkg"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "project", "package.json"), []byte(`{"name":"budget"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := nixTempRootConfig(tmpDir)
+	cfg.DevArtifacts.ScanPaths = []string{workspace}
+	cfg.DevArtifacts.ScanMaxEntries = 1
+	cfg.DevArtifacts.NodeModules = true
+
+	result := p.Cleanup(context.Background(), LevelCritical, cfg, logger)
+	if pathExists(root) {
+		t.Fatal("expected stale Nix temp root to be removed before workspace scan budget is exhausted")
+	}
+	if result.BytesFreed <= 0 {
+		t.Fatalf("expected cleanup to report freed bytes, got %#v", result)
+	}
+}
+
+func TestPlanCleanupProtectsActiveNixTemporaryRoots(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "nix-1234-0")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "scratch"), make([]byte, 2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(root, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	p.planNixTemporaryRoots(
+		context.Background(),
+		tmpDir,
+		1024*1024,
+		24*time.Hour,
+		true,
+		nixTempRootConfig(tmpDir).DevArtifacts,
+		map[string]string{canonicalTempArtifactPath(root): "nix-daemon"},
+		&targets,
+		newDevArtifactScanBudget(config.DefaultConfig().DevArtifacts),
+	)
+
+	target := findDevArtifactTarget(t, targets, "nix-temp-root", root)
+	if target.Action != "protect" || !target.Active || !target.Protected {
+		t.Fatalf("expected active Nix temp root to be protected, got %#v", target)
+	}
+}
+
 func tempGeneratedArtifactConfig(tmpDir string) *config.Config {
 	cfg := config.DefaultConfig()
 	cfg.DevArtifacts.ScanPaths = nil
@@ -1051,6 +1154,27 @@ func tempGeneratedArtifactConfig(tmpDir string) *config.Config {
 	cfg.DevArtifacts.NodeModules = false
 	cfg.DevArtifacts.PythonVenvs = false
 	cfg.DevArtifacts.RustTargets = true
+	cfg.DevArtifacts.ZigArtifacts = false
+	cfg.DevArtifacts.GoBuildCache = false
+	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.LargeLocalArtifacts = false
+	cfg.DevArtifacts.LMStudioModels = false
+	return cfg
+}
+
+func nixTempRootConfig(tmpDir string) *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.DevArtifacts.ScanPaths = nil
+	cfg.DevArtifacts.TempScanPaths = []string{tmpDir}
+	cfg.DevArtifacts.TempScanMaxRoots = 20
+	cfg.DevArtifacts.TempArtifactMinMB = 256
+	cfg.DevArtifacts.TempArtifactStaleAfter = "6h"
+	cfg.DevArtifacts.NixTempRoots = true
+	cfg.DevArtifacts.NixTempRootMinMB = 1
+	cfg.DevArtifacts.NixTempRootStaleAfter = "24h"
+	cfg.DevArtifacts.NodeModules = false
+	cfg.DevArtifacts.PythonVenvs = false
+	cfg.DevArtifacts.RustTargets = false
 	cfg.DevArtifacts.ZigArtifacts = false
 	cfg.DevArtifacts.GoBuildCache = false
 	cfg.DevArtifacts.HaskellCache = false


### PR DESCRIPTION
## Summary

- add typed `nix-temp-root` cleanup under `dev-artifacts` for stale top-level Nix shell/develop/build scratch roots
- run temp-root cleanup before deep workspace scans so `~/git` scan-budget exhaustion cannot starve `/private/tmp`
- keep active/protected/recent roots protected, and skip non-owned roots for non-root runs while allowing root/HM daemon runs to consider them

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./config ./plugins -run 'TestDevArtifactPolicyDefaults|TestPlanCleanupDeletesStaleNixTemporaryRoots|TestCleanupPrunesNixTemporaryRootsBeforeWorkspaceScanBudget|TestPlanCleanupProtectsActiveNixTemporaryRoots|TestPlanTemporaryArtifactsReportsReviewOnlyTargets|TestPlanTemporaryArtifactsDoesNotChargeSymlinkTargets'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- live Neo patched dry-run identified 128 stale `nix-temp-root` targets in `/private/tmp` without active-process evidence
- live Neo patched apply reclaimed 913,432,576 bytes estimated across three bounded `dev-artifacts` passes; host free-space delta was 856,219,648 bytes

## Notes

`go test ./...` did not complete in the Go driver in this local environment after package output began; package-scoped tests and build completed successfully.
