### PR TITLE
TIN-1562 allow aggressive cleanup cooldown bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ builder and runner machines.
 - Cleanup policy should explain what it plans to remove and why.
 - Host free-space accounting should be measured before and after cleanup.
 - Real cleanup should stop once the configured host free-space target is met.
-- Daemon-triggered non-critical cleanup should honor cooldown state.
+- Daemon-triggered cleanup should honor cooldown state below the configured
+  bypass severity.
 - Privileged actions, offline compaction, and service disruption must remain
   explicit policy choices.
 

--- a/config/config.go
+++ b/config/config.go
@@ -157,6 +157,8 @@ type EnableFlags struct {
 type PolicyConfig struct {
 	// Cooldown skips repeated non-critical daemon-triggered plugin cleanup within this duration.
 	Cooldown string `yaml:"cooldown"`
+	// CooldownBypassLevel is the minimum cleanup level that ignores cooldown.
+	CooldownBypassLevel string `yaml:"cooldown_bypass_level"`
 	// StateFile stores daemon cleanup state such as per-plugin last-run timestamps.
 	StateFile string `yaml:"state_file"`
 }
@@ -422,8 +424,9 @@ func DefaultConfig() *Config {
 		},
 		TargetFree: 70,
 		Policy: PolicyConfig{
-			Cooldown:  "30m",
-			StateFile: stateFile,
+			Cooldown:            "30m",
+			CooldownBypassLevel: "critical",
+			StateFile:           stateFile,
 		},
 		LogFile: logFile,
 		Enable: EnableFlags{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Policy.Cooldown != "30m" {
 		t.Errorf("expected cooldown=30m, got %q", cfg.Policy.Cooldown)
 	}
+	if cfg.Policy.CooldownBypassLevel != "critical" {
+		t.Errorf("expected cooldown_bypass_level=critical, got %q", cfg.Policy.CooldownBypassLevel)
+	}
 	if cfg.Policy.StateFile == "" {
 		t.Error("expected default state file")
 	}
@@ -191,6 +194,9 @@ func TestLoadHomeManagerContract(t *testing.T) {
 	}
 	if cfg.Policy.Cooldown != "30m" {
 		t.Errorf("expected policy.cooldown=30m, got %q", cfg.Policy.Cooldown)
+	}
+	if cfg.Policy.CooldownBypassLevel != "aggressive" {
+		t.Errorf("expected policy.cooldown_bypass_level=aggressive, got %q", cfg.Policy.CooldownBypassLevel)
 	}
 	if !cfg.Enable.GitHubRunner {
 		t.Error("expected github runner cleanup enabled")

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -18,9 +18,12 @@ target_free: 70
 
 # Daemon-level cleanup policy
 policy:
-  # Skip repeated non-critical daemon-triggered plugin cleanup within this window.
-  # Explicit --level runs and critical pressure bypass cooldown.
+  # Skip repeated daemon-triggered plugin cleanup below cooldown_bypass_level.
+  # Explicit --level runs always bypass cooldown.
   cooldown: 30m
+  # Conservative default preserves the historical behavior: only critical
+  # pressure bypasses cooldown. Incident-prone hosts can set "aggressive".
+  cooldown_bypass_level: critical
   state_file: ~/.local/state/tinyland-cleanup/state.json
 
 # Enable/disable specific cleanup plugins

--- a/config/testdata/home-manager-honey.yaml
+++ b/config/testdata/home-manager-honey.yaml
@@ -7,6 +7,7 @@ thresholds:
 target_free: 70
 policy:
   cooldown: 30m
+  cooldown_bypass_level: aggressive
   state_file: /home/jess/.local/state/tinyland-cleanup/state.json
 log_file: /home/jess/.local/log/disk-cleanup.log
 enable:

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -255,7 +255,10 @@ only.
 This is the first stable reporting surface. It now exposes typed targets for
 selected plugins, but not per-file cleanup candidates for every plugin. Real
 cleanup cycles stop remaining plugins after the host reaches the configured
-target. Daemon-triggered non-critical cleanup also honors per-plugin cooldown
-state; explicit `--level` runs and critical pressure bypass cooldown. Treat
-broader active-use evidence and CLI target-free overrides as the next policy
-layer.
+target. Daemon-triggered cleanup honors per-plugin cooldown below
+`policy.cooldown_bypass_level`; explicit `--level` runs always bypass cooldown.
+The default bypass level is `critical`, preserving conservative behavior. Hosts
+with recurring aggressive pressure can set `cooldown_bypass_level: aggressive`
+so the daemon keeps attempting eligible cleanup while still below the critical
+threshold. Treat broader active-use evidence and CLI target-free overrides as
+the next policy layer.

--- a/main.go
+++ b/main.go
@@ -690,8 +690,27 @@ func (d *daemon) loadStateForCycle() (*cleanupState, error) {
 func (d *daemon) shouldApplyCooldown(report cycleReport, level monitor.CleanupLevel) bool {
 	return !d.dryRun &&
 		!report.ForcedLevel &&
-		level != monitor.LevelCritical &&
+		level < d.cooldownBypassLevel() &&
 		d.cleanupCooldown() > 0
+}
+
+func (d *daemon) cooldownBypassLevel() monitor.CleanupLevel {
+	if d.config == nil {
+		return monitor.LevelCritical
+	}
+	switch strings.TrimSpace(strings.ToLower(d.config.Policy.CooldownBypassLevel)) {
+	case "warning":
+		return monitor.LevelWarning
+	case "moderate":
+		return monitor.LevelModerate
+	case "aggressive":
+		return monitor.LevelAggressive
+	case "critical", "":
+		return monitor.LevelCritical
+	default:
+		d.logger.Warn("invalid policy.cooldown_bypass_level, defaulting to critical", "value", d.config.Policy.CooldownBypassLevel)
+		return monitor.LevelCritical
+	}
 }
 
 func (d *daemon) updateHostFreeAfter(report *cycleReport, beforeStats *monitor.DiskStats, beforeErr error) {

--- a/main_test.go
+++ b/main_test.go
@@ -541,6 +541,79 @@ func TestRunOnceCriticalBypassesCooldown(t *testing.T) {
 	}
 }
 
+func TestRunOnceConfiguredAggressiveBypassesCooldown(t *testing.T) {
+	var output bytes.Buffer
+	mock := &reportingPlugin{}
+	daemon := newTestDaemon(t, mock, &output)
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	daemon.now = func() time.Time { return now }
+	daemon.config.Policy.Cooldown = "30m"
+	daemon.config.Policy.CooldownBypassLevel = "aggressive"
+	daemon.config.Policy.StateFile = filepath.Join(t.TempDir(), "state.json")
+	state := newCleanupState()
+	state.recordPluginRun("reporting", plugins.LevelAggressive, now.Add(-10*time.Minute), plugins.CleanupResult{
+		Plugin: "reporting",
+		Level:  plugins.LevelAggressive,
+	})
+	if err := saveCleanupState(daemon.config.Policy.StateFile, state); err != nil {
+		t.Fatal(err)
+	}
+	daemon.diskStats = sequenceDiskStats(t,
+		diskStats(1000, 100, 90),
+		diskStats(1000, 100, 90),
+		diskStats(1000, 100, 90),
+		diskStats(1000, 100, 90),
+	)
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelNone); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	if !mock.called {
+		t.Fatal("configured aggressive cleanup should bypass cooldown")
+	}
+	report := decodeCycleReport(t, output.Bytes())
+	if report.Plugins[0].SkipReason == "cooldown" {
+		t.Fatal("aggressive cleanup should not report cooldown skip when configured as bypass level")
+	}
+}
+
+func TestRunOnceInvalidCooldownBypassLevelDefaultsToCritical(t *testing.T) {
+	var output bytes.Buffer
+	mock := &reportingPlugin{}
+	daemon := newTestDaemon(t, mock, &output)
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	daemon.now = func() time.Time { return now }
+	daemon.config.Policy.Cooldown = "30m"
+	daemon.config.Policy.CooldownBypassLevel = "invalid"
+	daemon.config.Policy.StateFile = filepath.Join(t.TempDir(), "state.json")
+	state := newCleanupState()
+	state.recordPluginRun("reporting", plugins.LevelAggressive, now.Add(-10*time.Minute), plugins.CleanupResult{
+		Plugin: "reporting",
+		Level:  plugins.LevelAggressive,
+	})
+	if err := saveCleanupState(daemon.config.Policy.StateFile, state); err != nil {
+		t.Fatal(err)
+	}
+	daemon.diskStats = sequenceDiskStats(t,
+		diskStats(1000, 100, 90),
+		diskStats(1000, 100, 90),
+		diskStats(1000, 100, 90),
+	)
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelNone); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	if mock.called {
+		t.Fatal("invalid cooldown bypass level should preserve critical-only cooldown behavior")
+	}
+	report := decodeCycleReport(t, output.Bytes())
+	if report.Plugins[0].SkipReason != "cooldown" {
+		t.Fatalf("expected cooldown skip reason, got %q", report.Plugins[0].SkipReason)
+	}
+}
+
 func newTestDaemon(t *testing.T, plugin plugins.Plugin, output io.Writer) *daemon {
 	t.Helper()
 


### PR DESCRIPTION
Linear: TIN-1562

## Summary
- add policy.cooldown_bypass_level with conservative default critical
- allow incident-prone hosts to set aggressive so daemon cycles are not fully suppressed while still above aggressive pressure
- document the cooldown boundary and cover aggressive/invalid values in tests

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
- git diff --check

## Neo evidence
- daemon was alive and repeatedly seeing aggressive pressure
- after a real aggressive pass, all plugins were skipped by 30m cooldown while the host remained aggressive
- this PR keeps default critical-only bypass but lets neo opt into aggressive bypass through HM
