### PR TITLE
bazel: ignore shutdown-touched lock after idle stop

### DIFF
--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -837,10 +837,51 @@ func stopIdleBazelServerThenDeleteOutputBase(ctx context.Context, path string, l
 	if err := shutdownBazelOutputBase(ctx, path, logger); err != nil {
 		return err
 	}
-	if activity := bazelOutputBaseActivity(path); activity.Active {
+	if activity := bazelOutputBasePostShutdownActivity(ctx, path); activity.Active {
 		return fmt.Errorf("refusing to delete output base after shutdown because it is still active: %s", activity.Reason)
 	}
 	return deleteBazelOutputBase(path, logger)
+}
+
+func bazelOutputBasePostShutdownActivity(ctx context.Context, path string) bazelOutputBaseActivityInfo {
+	if bazelServerPIDIsAlive(filepath.Join(path, "server", "server.pid")) {
+		return bazelOutputBaseActivityInfo{
+			Active:     true,
+			IdleServer: true,
+			Reason:     "idle Bazel server pid is alive",
+		}
+	}
+
+	info, err := NewBazelPlugin().activeBazelProcessInfo(ctx)
+	if err != nil {
+		return bazelOutputBaseActivityInfo{
+			Active: true,
+			Reason: "could not verify Bazel process activity after shutdown",
+		}
+	}
+
+	switch bazelProcessOutputBaseKinds(info)[filepath.Clean(path)] {
+	case "client":
+		return bazelOutputBaseActivityInfo{
+			Active:       true,
+			ActiveClient: true,
+			Reason:       "active Bazel client still references output base",
+		}
+	case "server":
+		return bazelOutputBaseActivityInfo{
+			Active:        true,
+			IdleServer:    true,
+			ProcessServer: true,
+			Reason:        "idle Bazel server process still references output base",
+		}
+	case "unknown":
+		return bazelOutputBaseActivityInfo{
+			Active: true,
+			Reason: "Bazel process still references output base",
+		}
+	default:
+		return bazelOutputBaseActivityInfo{}
+	}
 }
 
 func shutdownBazelOutputBase(ctx context.Context, path string, logger *slog.Logger) error {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -644,12 +644,19 @@ func TestApplyBazelCleanupTargetsStopsIdleServerBeforeDeletingOutputBase(t *test
 	root := t.TempDir()
 	outputBase := filepath.Join(root, "_bazel_jess", "stale-idle")
 	makeBazelOutputBase(t, outputBase)
+	if err := os.WriteFile(filepath.Join(outputBase, "lock"), []byte("shutdown-touched lock\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	binDir := filepath.Join(root, "bin")
 	mustMkdir(t, binDir)
 	argsPath := filepath.Join(root, "bazel-args")
 	fakeBazel := filepath.Join(binDir, "bazel")
 	if err := os.WriteFile(fakeBazel, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$BAZEL_SHUTDOWN_ARGS\"\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	fakePS := filepath.Join(binDir, "ps")
+	if err := os.WriteFile(fakePS, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("BAZEL_SHUTDOWN_ARGS", argsPath)


### PR DESCRIPTION
## Summary

Fixes the Neo aggressive-cleanup false negative where a stale Bazel output base is planned as `stop_idle_server_then_delete_output_base`, `bazel shutdown` succeeds, but cleanup refuses deletion because the shutdown path leaves a fresh `lock` mtime.

After successful shutdown, cleanup now ignores a recent lock file by itself and rechecks concrete activity instead:

- live `server/server.pid`
- live Bazel client process referencing the output base
- live Bazel server process referencing the output base

If process inspection fails, cleanup remains conservative and refuses deletion.

## Evidence

Neo dry-run and live cleanup showed the stale output base became a shutdown/delete candidate, then deletion was blocked by `recent Bazel output-base lock detected` even though no live process held the output base after shutdown.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `nix build .#default --no-link --print-build-logs --builders ''`

## Related

- Downstream lab PR: https://github.com/tinyland-inc/lab/pull/521
- Linear: none; upstream cleanup-engine follow-up from Neo disk-pressure triage.
