### PR TITLE
bazel: stop idle servers without bazelisk bootstrap

### DIFF
--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -878,12 +878,27 @@ func shutdownBazelOutputBase(ctx context.Context, path string, logger *slog.Logg
 	pid, err := bazelServerPID(filepath.Join(path, "server", "server.pid"))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Info("Bazel output base has no server pid file; deleting without shutdown", "output_base", path)
+			pids, lookupErr := bazelServerPIDsForOutputBase(ctx, path)
+			if lookupErr != nil {
+				return fmt.Errorf("cannot find idle Bazel server pid for %s after missing pid file: %w", path, lookupErr)
+			}
+			if len(pids) == 0 {
+				logger.Info("Bazel output base has no server pid file and no matching idle server process", "output_base", path)
+				return nil
+			}
+			for _, pid := range pids {
+				if err := shutdownBazelServerPID(ctx, path, pid, logger); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
 		return err
 	}
+	return shutdownBazelServerPID(ctx, path, pid, logger)
+}
 
+func shutdownBazelServerPID(ctx context.Context, path string, pid int, logger *slog.Logger) error {
 	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
@@ -920,6 +935,68 @@ func shutdownBazelOutputBase(ctx context.Context, path string, logger *slog.Logg
 		return nil
 	}
 	return fmt.Errorf("idle Bazel server pid %d still appears active after signal escalation for %s", pid, path)
+}
+
+func bazelServerPIDsForOutputBase(ctx context.Context, path string) ([]int, error) {
+	psCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(psCtx, "ps", "-axo", "pid=,comm=,args=")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return bazelServerPIDsForOutputBaseFromPS(string(output), path), nil
+}
+
+func bazelServerPIDsForOutputBaseFromPS(output, path string) []int {
+	want := filepath.Clean(path)
+	seen := map[int]bool{}
+	var pids []int
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		originalFields := fields[1:]
+		if !bazelProcessLineHasBazel(originalFields) {
+			continue
+		}
+		lineOutputBases := bazelOutputBaseArgs(originalFields)
+		matchesOutputBase := false
+		for _, outputBase := range lineOutputBases {
+			if filepath.Clean(outputBase) == want {
+				matchesOutputBase = true
+				break
+			}
+		}
+		if !matchesOutputBase {
+			continue
+		}
+		lowerFields := make([]string, 0, len(originalFields))
+		for _, field := range originalFields {
+			lowerFields = append(lowerFields, strings.ToLower(field))
+		}
+		command := filepath.Base(lowerFields[0])
+		arg0 := filepath.Base(lowerFields[1])
+		if !bazelCommandName(command) && !bazelCommandName(arg0) {
+			continue
+		}
+		normalized := strings.Join(lowerFields[1:], " ")
+		if matches := bazelCommandPattern.FindStringSubmatch(normalized); len(matches) >= 3 {
+			continue
+		}
+		if !seen[pid] {
+			seen[pid] = true
+			pids = append(pids, pid)
+		}
+	}
+	sort.Ints(pids)
+	return pids
 }
 
 func bazelServerPID(path string) (int, error) {

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -876,6 +877,10 @@ func bazelOutputBasePostShutdownActivity(ctx context.Context, path string) bazel
 func shutdownBazelOutputBase(ctx context.Context, path string, logger *slog.Logger) error {
 	pid, err := bazelServerPID(filepath.Join(path, "server", "server.pid"))
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			logger.Info("Bazel output base has no server pid file; deleting without shutdown", "output_base", path)
+			return nil
+		}
 		return err
 	}
 

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -560,22 +560,11 @@ func bazelOutputBaseActivity(path string) bazelOutputBaseActivityInfo {
 }
 
 func bazelServerPIDIsAlive(path string) bool {
-	data, err := os.ReadFile(path)
+	pid, err := bazelServerPID(path)
 	if err != nil {
 		return false
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || pid <= 0 {
-		return false
-	}
-	err = syscall.Kill(pid, 0)
-	if err == nil {
-		return true
-	}
-	if err == syscall.EPERM {
-		return true
-	}
-	return false
+	return bazelProcessPIDIsActive(pid)
 }
 
 func outputBasesProtectedByWorkspaces(workspaces []string, home string) map[string]bool {
@@ -692,7 +681,7 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 	case idleServerStopEligible:
 		action = "stop_idle_server_then_delete_output_base"
 		protected = false
-		reason = "stale output base has only an idle Bazel server; allow_stop_idle_servers permits shutdown before deletion"
+		reason = "stale output base has only an idle Bazel server; allow_stop_idle_servers permits PID-file signaling before deletion"
 	case active && !cfg.AllowDeleteActiveOutputBases:
 		action = "keep"
 		if candidate.Reason != "" {
@@ -885,24 +874,100 @@ func bazelOutputBasePostShutdownActivity(ctx context.Context, path string) bazel
 }
 
 func shutdownBazelOutputBase(ctx context.Context, path string, logger *slog.Logger) error {
-	bin, err := exec.LookPath("bazel")
+	pid, err := bazelServerPID(filepath.Join(path, "server", "server.pid"))
 	if err != nil {
-		bin, err = exec.LookPath("bazelisk")
-	}
-	if err != nil {
-		return fmt.Errorf("cannot stop idle Bazel server because neither bazel nor bazelisk is on PATH")
+		return err
 	}
 
 	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(shutdownCtx, bin, "--output_base="+path, "shutdown")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("bazel shutdown failed for %s: %w: %s", path, err, strings.TrimSpace(string(output)))
+	if !bazelProcessPIDIsActive(pid) {
+		logger.Info("idle Bazel server already stopped", "output_base", path, "pid", pid)
+		return nil
 	}
-	logger.Info("stopped idle Bazel server", "output_base", path)
-	return nil
+
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		if err == syscall.ESRCH {
+			logger.Info("idle Bazel server already stopped", "output_base", path, "pid", pid)
+			return nil
+		}
+		return fmt.Errorf("failed to signal idle Bazel server pid %d for %s: %w", pid, path, err)
+	}
+	logger.Info("sent SIGTERM to idle Bazel server", "output_base", path, "pid", pid)
+
+	if waitForBazelPIDExit(shutdownCtx, pid, 5*time.Second) {
+		logger.Info("stopped idle Bazel server", "output_base", path, "pid", pid)
+		return nil
+	}
+
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+		if err == syscall.ESRCH {
+			logger.Info("idle Bazel server stopped before forced kill", "output_base", path, "pid", pid)
+			return nil
+		}
+		return fmt.Errorf("failed to force-stop idle Bazel server pid %d for %s: %w", pid, path, err)
+	}
+	logger.Warn("sent SIGKILL to idle Bazel server after graceful stop timed out", "output_base", path, "pid", pid)
+
+	if waitForBazelPIDExit(shutdownCtx, pid, 2*time.Second) {
+		logger.Info("force-stopped idle Bazel server", "output_base", path, "pid", pid)
+		return nil
+	}
+	return fmt.Errorf("idle Bazel server pid %d still appears active after signal escalation for %s", pid, path)
+}
+
+func bazelServerPID(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("cannot read Bazel server pid file %s: %w", path, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("invalid Bazel server pid in %s", path)
+	}
+	return pid, nil
+}
+
+func waitForBazelPIDExit(ctx context.Context, pid int, timeout time.Duration) bool {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if !bazelProcessPIDIsActive(pid) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline.C:
+			return !bazelProcessPIDIsActive(pid)
+		case <-ticker.C:
+		}
+	}
+}
+
+func bazelProcessPIDIsActive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == syscall.ESRCH {
+		return false
+	}
+	if err != nil && err != syscall.EPERM {
+		return false
+	}
+
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "stat=")
+	output, psErr := cmd.Output()
+	if psErr != nil {
+		return err == nil || err == syscall.EPERM
+	}
+	stat := strings.TrimSpace(string(output))
+	return stat != "" && !strings.Contains(stat, "Z")
 }
 
 func deleteBazelOutputBase(path string, logger *slog.Logger) error {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -590,6 +590,18 @@ bazel(workspace) bazel(workspace) --output_base=/private/tmp/workspace-ob --work
 	}
 }
 
+func TestBazelServerPIDsForOutputBaseFromPSSkipsActiveClients(t *testing.T) {
+	ps := `
+18473 bazel(workspace) bazel(workspace) --output_base=/private/tmp/workspace-ob --workspace_directory=/Users/test/workspace
+777 /nix/store/abc/bin/bazel bazel test //... --output_base /private/tmp/workspace-ob
+888 bazel(other) bazel(other) --output_base=/private/tmp/other-ob
+`
+	pids := bazelServerPIDsForOutputBaseFromPS(ps, "/private/tmp/workspace-ob")
+	if len(pids) != 1 || pids[0] != 18473 {
+		t.Fatalf("got pids %v, want [18473]", pids)
+	}
+}
+
 func TestApplyBazelCleanupTargetsDeletesEligibleOutputBase(t *testing.T) {
 	root := t.TempDir()
 	outputBase := filepath.Join(root, "_bazel_jess", "stale")

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -655,6 +655,7 @@ func TestApplyBazelCleanupTargetsStopsIdleServerBeforeDeletingOutputBase(t *test
 	if runtime.GOOS == "windows" {
 		t.Skip("fake bazel shell script is Unix-only")
 	}
+	requireProcessTable(t)
 	root := t.TempDir()
 	outputBase := filepath.Join(root, "_bazel_jess", "stale-idle")
 	makeBazelOutputBase(t, outputBase)
@@ -719,6 +720,7 @@ func TestApplyBazelCleanupTargetsStopsIdleServerBeforeDeletingOutputBase(t *test
 }
 
 func TestApplyBazelCleanupTargetsDeletesIdleOutputBaseWithoutPIDFile(t *testing.T) {
+	requireProcessTable(t)
 	root := t.TempDir()
 	outputBase := filepath.Join(root, "_bazel_jess", "stale-idle-no-pid")
 	makeBazelOutputBase(t, outputBase)
@@ -746,6 +748,13 @@ func TestApplyBazelCleanupTargetsDeletesIdleOutputBaseWithoutPIDFile(t *testing.
 	}
 	if _, err := os.Stat(outputBase); !os.IsNotExist(err) {
 		t.Fatalf("expected output base to be deleted, stat err=%v", err)
+	}
+}
+
+func requireProcessTable(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("ps"); err != nil {
+		t.Skip("process-table integration test requires ps")
 	}
 }
 

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -648,18 +650,30 @@ func TestApplyBazelCleanupTargetsStopsIdleServerBeforeDeletingOutputBase(t *test
 		t.Fatal(err)
 	}
 
+	server := exec.Command("sleep", "60")
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = server.Process.Kill()
+		_ = server.Wait()
+	}()
+	if err := os.WriteFile(filepath.Join(outputBase, "server", "server.pid"), []byte(strconv.Itoa(server.Process.Pid)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	binDir := filepath.Join(root, "bin")
 	mustMkdir(t, binDir)
-	argsPath := filepath.Join(root, "bazel-args")
+	bazelMarker := filepath.Join(root, "bazel-invoked")
 	fakeBazel := filepath.Join(binDir, "bazel")
-	if err := os.WriteFile(fakeBazel, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$BAZEL_SHUTDOWN_ARGS\"\n"), 0755); err != nil {
+	if err := os.WriteFile(fakeBazel, []byte("#!/bin/sh\ntouch \"$BAZEL_INVOKED\"\nexit 42\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	fakePS := filepath.Join(binDir, "ps")
-	if err := os.WriteFile(fakePS, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+	fakeBazelisk := filepath.Join(binDir, "bazelisk")
+	if err := os.WriteFile(fakeBazelisk, []byte("#!/bin/sh\ntouch \"$BAZEL_INVOKED\"\nexit 42\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("BAZEL_SHUTDOWN_ARGS", argsPath)
+	t.Setenv("BAZEL_INVOKED", bazelMarker)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -683,13 +697,8 @@ func TestApplyBazelCleanupTargetsStopsIdleServerBeforeDeletingOutputBase(t *test
 	if _, err := os.Stat(outputBase); !os.IsNotExist(err) {
 		t.Fatalf("expected output base to be deleted, stat err=%v", err)
 	}
-	args, err := os.ReadFile(argsPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wantArgs := "--output_base=" + outputBase + "\nshutdown\n"
-	if string(args) != wantArgs {
-		t.Fatalf("shutdown args = %q, want %q", string(args), wantArgs)
+	if _, err := os.Stat(bazelMarker); !os.IsNotExist(err) {
+		t.Fatalf("cleanup must not invoke bazel/bazelisk during idle-server stop, marker err=%v", err)
 	}
 }
 

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -654,9 +654,13 @@ func TestApplyBazelCleanupTargetsStopsIdleServerBeforeDeletingOutputBase(t *test
 	if err := server.Start(); err != nil {
 		t.Fatal(err)
 	}
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- server.Wait()
+	}()
 	defer func() {
 		_ = server.Process.Kill()
-		_ = server.Wait()
+		<-serverDone
 	}()
 	if err := os.WriteFile(filepath.Join(outputBase, "server", "server.pid"), []byte(strconv.Itoa(server.Process.Pid)), 0644); err != nil {
 		t.Fatal(err)

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -706,6 +706,37 @@ func TestApplyBazelCleanupTargetsStopsIdleServerBeforeDeletingOutputBase(t *test
 	}
 }
 
+func TestApplyBazelCleanupTargetsDeletesIdleOutputBaseWithoutPIDFile(t *testing.T) {
+	root := t.TempDir()
+	outputBase := filepath.Join(root, "_bazel_jess", "stale-idle-no-pid")
+	makeBazelOutputBase(t, outputBase)
+	if err := os.Remove(filepath.Join(outputBase, "server", "server.pid")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := applyBazelCleanupTargets(context.Background(), "bazel", LevelAggressive, []CleanupTarget{
+		{
+			Type:   "output_base",
+			Name:   "stale-idle-no-pid",
+			Path:   outputBase,
+			Bytes:  123,
+			Active: true,
+			Action: "stop_idle_server_then_delete_output_base",
+		},
+	}, nil, root, logger)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.ItemsCleaned != 1 {
+		t.Fatalf("items cleaned = %d, want 1", result.ItemsCleaned)
+	}
+	if _, err := os.Stat(outputBase); !os.IsNotExist(err) {
+		t.Fatalf("expected output base to be deleted, stat err=%v", err)
+	}
+}
+
 func TestCleanupRepoLocalBazelSymlinksOnlyRemovesLinksIntoDeletedOutputBase(t *testing.T) {
 	root := t.TempDir()
 	deletedOutputBase := filepath.Join(root, "_bazel_jess", "deleted")


### PR DESCRIPTION
## Summary
- replace idle Bazel server cleanup's bazel/bazelisk shutdown call with PID-file signaling
- avoid network/tool bootstrap during critical disk-pressure cleanup
- add a regression test that fails if cleanup invokes bazel or bazelisk for the idle-server stop path

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
- git diff --check