### PR TITLE
bazel: manage remote cache roots

### DIFF
--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -311,6 +311,9 @@ func discoverBazelRootCandidates(root string) []bazelCandidate {
 	if isBazelOutputBase(root) {
 		return []bazelCandidate{newBazelCandidate("output_base", filepath.Base(root), root, info.ModTime())}
 	}
+	if isBazelRemoteCacheRoot(root) {
+		return []bazelCandidate{newBazelCandidate("remote_cache", filepath.Base(root), root, info.ModTime())}
+	}
 
 	base := filepath.Base(root)
 	if strings.HasPrefix(base, "_bazel_") {
@@ -341,6 +344,10 @@ func discoverBazelRootCandidates(root string) []bazelCandidate {
 		case entry.Name() == "disk_cache":
 			if info, err := entry.Info(); err == nil {
 				candidates = append(candidates, newBazelCandidate("disk_cache", entry.Name(), path, info.ModTime()))
+			}
+		case isBazelRemoteCacheRoot(path):
+			if info, err := entry.Info(); err == nil {
+				candidates = append(candidates, newBazelCandidate("remote_cache", entry.Name(), path, info.ModTime()))
 			}
 		}
 	}
@@ -465,7 +472,7 @@ func refineBazelOutputBaseCandidateBytes(ctx context.Context, candidates []bazel
 
 	refined := false
 	for i := range candidates {
-		if candidates[i].Type != "output_base" {
+		if candidates[i].Type != "output_base" && candidates[i].Type != "remote_cache" {
 			continue
 		}
 		logical, physical, err := estimateBazelCandidateBytesRecursive(estimateCtx, candidates[i].Path)
@@ -531,6 +538,11 @@ func isBazelOutputBase(path string) bool {
 		}
 	}
 	return true
+}
+
+func isBazelRemoteCacheRoot(path string) bool {
+	base := filepath.Base(filepath.Clean(path))
+	return strings.HasPrefix(base, "bazel-") && pathExistsAndIsDir(filepath.Join(path, "cas"))
 }
 
 type bazelOutputBaseActivityInfo struct {
@@ -735,7 +747,7 @@ func bazelCandidateTier(candidateType string) string {
 	switch candidateType {
 	case "bazelisk":
 		return CleanupTierSafe
-	case "repository_cache", "disk_cache", "output_base":
+	case "repository_cache", "disk_cache", "remote_cache", "output_base":
 		return CleanupTierWarm
 	default:
 		return CleanupTierWarm
@@ -803,7 +815,7 @@ func bazelTargetEligibleForDeletion(target CleanupTarget) bool {
 	case "stop_idle_server_then_delete_output_base":
 		return target.Type == "output_base"
 	case "delete_cache_tier":
-		return target.Type == "repository_cache" || target.Type == "disk_cache" || target.Type == "bazelisk"
+		return target.Type == "repository_cache" || target.Type == "disk_cache" || target.Type == "remote_cache" || target.Type == "bazelisk"
 	default:
 		return false
 	}
@@ -816,7 +828,7 @@ func deleteBazelTarget(ctx context.Context, target CleanupTarget, logger *slog.L
 	switch target.Type {
 	case "output_base":
 		return deleteBazelOutputBase(target.Path, logger)
-	case "repository_cache", "disk_cache", "bazelisk":
+	case "repository_cache", "disk_cache", "remote_cache", "bazelisk":
 		return deleteBazelCacheTier(target.Type, target.Path, logger)
 	default:
 		return fmt.Errorf("refusing to delete unsupported Bazel target type %q", target.Type)
@@ -1161,6 +1173,8 @@ func bazelCacheTierPathAllowed(targetType, path string) bool {
 		return filepath.Base(path) == "repository_cache"
 	case "disk_cache":
 		return filepath.Base(path) == "disk_cache"
+	case "remote_cache":
+		return isBazelRemoteCacheRoot(path)
 	case "bazelisk":
 		parts := strings.Split(path, string(os.PathSeparator))
 		for idx := 0; idx < len(parts)-1; idx++ {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -23,6 +23,7 @@ func TestDiscoverBazelRootCandidates(t *testing.T) {
 	makeBazelOutputBase(t, explicitOutputBase)
 	mustMkdir(t, filepath.Join(root, "repository_cache"))
 	mustMkdir(t, filepath.Join(root, "disk_cache"))
+	mustMkdir(t, filepath.Join(root, "bazel-tinyland", "cas", "aa"))
 
 	candidates := discoverBazelRootCandidates(root)
 	byType := map[string]bool{}
@@ -36,7 +37,7 @@ func TestDiscoverBazelRootCandidates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, candidateType := range []string{"output_base", "repository_cache", "disk_cache"} {
+	for _, candidateType := range []string{"output_base", "repository_cache", "disk_cache", "remote_cache"} {
 		if !byType[candidateType] {
 			t.Fatalf("expected %s candidate, got %#v", candidateType, candidates)
 		}
@@ -267,6 +268,13 @@ func TestBazelPlanTargetsDeletesCacheTiersOnlyWhenBudgetExceeded(t *testing.T) {
 			Physical: 2 * bazelGiB,
 		},
 		{
+			Type:     "remote_cache",
+			Name:     "bazel-tinyland",
+			Path:     "/tmp/.cache/bazel-tinyland",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 2 * bazelGiB,
+		},
+		{
 			Type:     "repository_cache",
 			Name:     "fresh_repository_cache",
 			Path:     "/tmp/fresh_repository_cache",
@@ -276,8 +284,8 @@ func TestBazelPlanTargetsDeletesCacheTiersOnlyWhenBudgetExceeded(t *testing.T) {
 	}
 
 	targets, total := bazelPlanTargets(candidates, cfg, LevelModerate, now, false)
-	if total != 8*bazelGiB {
-		t.Fatalf("total physical = %d, want %d", total, 8*bazelGiB)
+	if total != 10*bazelGiB {
+		t.Fatalf("total physical = %d, want %d", total, 10*bazelGiB)
 	}
 
 	actions := map[string]CleanupTarget{}
@@ -285,7 +293,7 @@ func TestBazelPlanTargetsDeletesCacheTiersOnlyWhenBudgetExceeded(t *testing.T) {
 		actions[target.Name] = target
 	}
 
-	for _, name := range []string{"repository_cache", "disk_cache", "sha256/hash"} {
+	for _, name := range []string{"repository_cache", "disk_cache", "sha256/hash", "bazel-tinyland"} {
 		if actions[name].Action != "delete_cache_tier" || actions[name].Protected {
 			t.Fatalf("%s target should be a cache-tier deletion candidate: %#v", name, actions[name])
 		}


### PR DESCRIPTION
Add managed Bazel cleanup coverage for remote/disk cache roots such as ~/.cache/bazel-tinyland that store CAS content under a top-level cas/ directory.

This addresses the Neo disk-pressure shape where most reclaimable Bazel bytes are not output bases and therefore were outside the existing cleanup root model.

Validation:
- go test ./...

Linear: none; upstream cleanup package fix for lab TIN-1681 follow-through.