### PR TITLE
apfs: avoid OS-update snapshot reclaim estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- APFS snapshot dry-run estimates now exclude protected OS-update snapshots
+  from the aggregate thinning reclaim target when no date-form Time Machine
+  local snapshots are present.
 - Active Bazel client processes no longer globally protect unrelated stale
   output bases; active clients still protect their own output base, and shared
   cache-tier cleanup remains deferred while Bazel client work is visible.

--- a/plugins/apfs_darwin.go
+++ b/plugins/apfs_darwin.go
@@ -434,9 +434,19 @@ func apfsSnapshotEstimateBytes(snapshots []snapshotInfo) (int64, int64) {
 	return count * 5 * apfsGiB, count * 15 * apfsGiB
 }
 
+func apfsThinnableSnapshotEstimateBytes(snapshots []snapshotInfo) (int64, int64) {
+	var count int64
+	for _, snapshot := range snapshots {
+		if apfsSnapshotHasTime(snapshot) && apfsSnapshotKind(snapshot) != "os-update" {
+			count++
+		}
+	}
+	return count * 5 * apfsGiB, count * 15 * apfsGiB
+}
+
 func apfsPlanTargets(snapshots []snapshotInfo, level CleanupLevel, cfg config.APFSConfig, requestGB int, backupActive bool, sudoPasswordless bool, now time.Time) []CleanupTarget {
 	var targets []CleanupTarget
-	low, _ := apfsSnapshotEstimateBytes(snapshots)
+	low, _ := apfsThinnableSnapshotEstimateBytes(snapshots)
 	requestBytes := int64(requestGB) * apfsGiB
 	thinEstimate := low
 	if requestBytes > 0 && requestBytes < thinEstimate {
@@ -448,13 +458,16 @@ func apfsPlanTargets(snapshots []snapshotInfo, level CleanupLevel, cfg config.AP
 		Tier:      CleanupTierPrivileged,
 		Name:      "local snapshot thinning",
 		Bytes:     thinEstimate,
-		Protected: level < LevelModerate || !cfg.ThinEnabled || !sudoPasswordless || backupActive,
+		Protected: thinEstimate == 0 || level < LevelModerate || !cfg.ThinEnabled || !sudoPasswordless || backupActive,
 		Action:    "thin_local_snapshots",
 		Reason:    "request APFS local snapshot thinning through tmutil",
 	}
 	if thinTarget.Protected {
 		thinTarget.Action = "protect"
 		thinTarget.Reason = "snapshot thinning is not currently eligible"
+		if thinEstimate == 0 {
+			thinTarget.Reason = "no date-form Time Machine local snapshots are eligible for thinning"
+		}
 	}
 	annotateCleanupTargetPolicy(&thinTarget, thinTarget.Tier, hostReclaimForAction(thinTarget.Action))
 	targets = append(targets, thinTarget)

--- a/plugins/apfs_darwin_test.go
+++ b/plugins/apfs_darwin_test.go
@@ -288,8 +288,41 @@ func TestAPFSPlanTargetsReportsOSUpdateSnapshotsConservatively(t *testing.T) {
 	if osUpdateTarget.Action != "keep" || !osUpdateTarget.Protected {
 		t.Fatalf("OS-update snapshot should be protected review-only evidence, got %#v", osUpdateTarget)
 	}
-	if got := apfsEstimatedCandidateBytes(targets); got != 10*apfsGiB {
+	if got := apfsEstimatedCandidateBytes(targets); got != 5*apfsGiB {
 		t.Fatalf("estimated candidate bytes = %d, want thinning estimate only", got)
+	}
+}
+
+func TestAPFSPlanTargetsDoesNotEstimateOSUpdateOnlySnapshots(t *testing.T) {
+	now := time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC)
+	snapshots := []snapshotInfo{
+		{
+			Date:       "com.apple.os.update-DEDECEC55622993FB7EF1CB6A97E976433E7F84ECCE5514C9C380AF59534732D",
+			Kind:       "os-update",
+			Identifier: "com.apple.os.update-DEDECEC55622993FB7EF1CB6A97E976433E7F84ECCE5514C9C380AF59534732D",
+		},
+		{
+			Date:       "com.apple.os.update-MSUPrepareUpdate",
+			Kind:       "os-update",
+			Identifier: "com.apple.os.update-MSUPrepareUpdate",
+		},
+	}
+	cfg := config.APFSConfig{
+		ThinEnabled:     true,
+		MaxThinGB:       50,
+		KeepRecentDays:  1,
+		DeleteOSUpdates: true,
+	}
+
+	targets := apfsPlanTargets(snapshots, LevelCritical, cfg, 50, false, true, now)
+	if len(targets) != 3 {
+		t.Fatalf("expected aggregate target plus 2 snapshots, got %d", len(targets))
+	}
+	if targets[0].Action != "protect" || !targets[0].Protected || targets[0].Bytes != 0 {
+		t.Fatalf("OS-update-only thinning target should be protected with no estimate, got %#v", targets[0])
+	}
+	if got := apfsEstimatedCandidateBytes(targets); got != 0 {
+		t.Fatalf("estimated candidate bytes = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- exclude protected macOS OS-update snapshots from the aggregate APFS thinning reclaim estimate
- keep OS-update snapshots visible as protected review evidence
- add regression coverage for OS-update-only snapshot lists

## Validation
- go test ./plugins
- go test ./...
- git diff --check