### PR TITLE
package: refresh Linux cleanup config surface

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -251,6 +251,33 @@ func TestPackagedLinuxConfigParsesCurrentNixPolicy(t *testing.T) {
 	if cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan != "3d" {
 		t.Errorf("expected home_manager_critical_delete_generations_older_than=3d, got %q", cfg.Nix.HomeManagerCriticalDeleteGenerationsOlderThan)
 	}
+	if cfg.Policy.CooldownBypassLevel != "critical" {
+		t.Errorf("expected policy.cooldown_bypass_level=critical, got %q", cfg.Policy.CooldownBypassLevel)
+	}
+	if !cfg.Podman.BuildKitPrune {
+		t.Error("expected podman.buildkit_prune=true")
+	}
+	if cfg.Podman.BuildKitPruneKeepStorageMB != 8192 {
+		t.Errorf("expected podman.buildkit_prune_keep_storage_mb=8192, got %d", cfg.Podman.BuildKitPruneKeepStorageMB)
+	}
+	if cfg.Podman.CriticalSystemPrune {
+		t.Error("expected podman.critical_system_prune=false")
+	}
+	if len(cfg.Bazel.WorkspaceRoots) != 3 {
+		t.Errorf("expected 3 bazel.workspace_roots, got %d", len(cfg.Bazel.WorkspaceRoots))
+	}
+	if cfg.DevArtifacts.ScanMaxDuration != "30s" {
+		t.Errorf("expected dev_artifacts.scan_max_duration=30s, got %q", cfg.DevArtifacts.ScanMaxDuration)
+	}
+	if cfg.DevArtifacts.ScanMaxEntries != 250000 {
+		t.Errorf("expected dev_artifacts.scan_max_entries=250000, got %d", cfg.DevArtifacts.ScanMaxEntries)
+	}
+	if cfg.DevArtifacts.TempScanMaxRoots != 128 {
+		t.Errorf("expected dev_artifacts.temp_scan_max_roots=128, got %d", cfg.DevArtifacts.TempScanMaxRoots)
+	}
+	if !cfg.DevArtifacts.NixTempRoots {
+		t.Error("expected dev_artifacts.nix_temp_roots=true")
+	}
 }
 
 func homeManagerContractPath(t *testing.T) string {

--- a/docs/validation-status-2026-06-10.md
+++ b/docs/validation-status-2026-06-10.md
@@ -1,0 +1,65 @@
+# Validation Status: 2026-06-10
+
+Branch: `main`
+Commit: `df5906a`
+
+## Repo State
+
+- Canonical upstream: `github.com/Jesssullivan/tinyland-cleanup`
+- Local checkout: clean `main`, aligned with `github/main`
+- Historical fork: `tinyland-inc/tinyland-cleanup`, public and archived
+- Open PRs: none
+- Open GitHub issues: `#2`, `#4`, `#5`, `#6`, `#9`, `#82`, `#83`
+- Tags/releases: none yet
+
+Issue `#3` has materially landed through the Bazel cleanup series, but the
+broader productionization lane remains open through package, release, and
+GloriousFlywheel proof work.
+
+## Local Validation
+
+Passed locally on 2026-06-10 with repo-managed caches under `/tmp`:
+
+```sh
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
+```
+
+No cache pruning or destructive cleanup was performed during this validation.
+
+## Hosted CI
+
+Latest `main` CI passed:
+
+```text
+GitHub Actions run 26708506501
+Go: passed
+Bazel: passed
+Nix package: passed
+```
+
+## GloriousFlywheel Proof
+
+The manual GloriousFlywheel proof workflow remains configured for
+shared-cache-backed Bazel validation, not remote execution/offload.
+
+Current blocker:
+
+```text
+gh api repos/Jesssullivan/tinyland-cleanup/actions/runners
+total_count=0
+```
+
+The next operational step for `#9` is still to grant this repository access to
+an appropriate GloriousFlywheel runner, then dispatch the proof with:
+
+```sh
+gh workflow run "GloriousFlywheel Proof" \
+  --repo Jesssullivan/tinyland-cleanup \
+  -f bazel_remote_cache=grpc://bazel-cache.nix-cache.svc.cluster.local:9092
+```
+
+Record the runner name, cache endpoint reachability, and whether the proof is
+shared-cache-backed only. Do not describe this as Bazel RBE unless a separate
+remote-execution runner contract is proven.

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -11,6 +11,7 @@ target_free: 70
 
 policy:
   cooldown: 30m
+  cooldown_bypass_level: critical
   state_file: /var/lib/tinyland-cleanup/state.json
 
 thresholds:
@@ -47,6 +48,12 @@ docker:
 podman:
   prune_images_age: 24h
   protect_running_containers: true
+  machine_names: []
+  buildkit_prune: true
+  buildkit_prune_keep_duration: 24h
+  buildkit_prune_keep_storage_mb: 8192
+  buildkit_prune_min_reclaim_gb: 4
+  critical_system_prune: false
   clean_inside_vm: false
   trim_vm_disk: false
   compact_disk_offline: false
@@ -54,7 +61,9 @@ podman:
   compact_require_no_active_containers: true
   compact_keep_backup_until_restart: true
   compact_provider_allowlist:
-    - applehv
+    - qemu
+  compact_scratch_dir: ""
+  compact_qemu_img_path: ""
 
 nix:
   min_user_generations: 5
@@ -77,6 +86,10 @@ nix:
 bazel:
   roots:
     - ~/.cache/bazel
+  workspace_roots:
+    - ~/git
+    - ~/src
+    - ~/projects
   bazelisk_cache: ~/.cache/bazelisk
   max_total_gb: 20
   keep_recent_output_bases: 5
@@ -97,12 +110,18 @@ dev_artifacts:
     - ~/git
     - ~/src
     - ~/projects
+  scan_max_duration: 30s
+  scan_max_entries: 250000
   temp_artifacts: true
   temp_scan_paths:
     - /tmp
     - /var/tmp
+  temp_scan_max_roots: 128
   temp_artifact_min_mb: 512
   temp_artifact_stale_after: 12h
+  nix_temp_roots: true
+  nix_temp_root_min_mb: 1
+  nix_temp_root_stale_after: 24h
   node_modules: true
   python_venvs: true
   rust_targets: false


### PR DESCRIPTION
## Summary

- Refresh the packaged Linux/Rocky config with current supported policy keys for cooldown bypass, Podman BuildKit pruning, Bazel workspace roots, and dev-artifact scan budgets.
- Strengthen the packaged Linux config test so strict decoding also proves those current package-policy keys.
- Add a 2026-06-10 validation note capturing the current package state, local Go validation, and the still-blocked GloriousFlywheel proof surface.

Refs #82.
Refs #9.

## Validation

- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./config`
- `git diff --check`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`

Skipped a fresh local `nix build` to avoid adding store pressure on Neo; hosted CI still covers the Nix package surface.
