### PR TITLE
cleanup: harden Neo pressure recovery paths

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -159,6 +159,8 @@ type PolicyConfig struct {
 	Cooldown string `yaml:"cooldown"`
 	// CooldownBypassLevel is the minimum cleanup level that ignores cooldown.
 	CooldownBypassLevel string `yaml:"cooldown_bypass_level"`
+	// MinimumFreeGB bypasses cooldown until the monitored filesystem has this much free space.
+	MinimumFreeGB int `yaml:"minimum_free_gb"`
 	// StateFile stores daemon cleanup state such as per-plugin last-run timestamps.
 	StateFile string `yaml:"state_file"`
 }
@@ -321,6 +323,10 @@ type DevArtifactsConfig struct {
 	RustTargets bool `yaml:"rust_targets"`
 	// ZigArtifacts enables Zig .zig-cache/ and zig-out/ cleanup
 	ZigArtifacts bool `yaml:"zig_artifacts"`
+	// AgentWorktreeArtifacts enables cleanup of generated outputs inside agent worktree roots.
+	AgentWorktreeArtifacts bool `yaml:"agent_worktree_artifacts"`
+	// PnpmStore enables pnpm store prune for the rebuildable global package store.
+	PnpmStore bool `yaml:"pnpm_store"`
 	// GoBuildCache enables Go build cache cleanup
 	GoBuildCache bool `yaml:"go_build_cache"`
 	// HaskellCache enables .ghcup/cache and .cabal/store cleanup
@@ -352,6 +358,14 @@ type DarwinDevCachesConfig struct {
 	Bazelisk DarwinDevCacheToolConfig `yaml:"bazelisk"`
 	// Pip controls pip cache planning.
 	Pip DarwinDevCacheToolConfig `yaml:"pip"`
+	// NPM controls npm package cache planning.
+	NPM DarwinDevCacheToolConfig `yaml:"npm"`
+	// UV controls uv package cache planning.
+	UV DarwinDevCacheToolConfig `yaml:"uv"`
+	// Bun controls Bun cache planning.
+	Bun DarwinDevCacheToolConfig `yaml:"bun"`
+	// OpenCode controls opencode cache planning.
+	OpenCode DarwinDevCacheToolConfig `yaml:"opencode"`
 	// VSCode controls Visual Studio Code cache planning.
 	VSCode DarwinDevCacheToolConfig `yaml:"vscode"`
 	// Cursor controls Cursor cache planning.
@@ -426,6 +440,7 @@ func DefaultConfig() *Config {
 		Policy: PolicyConfig{
 			Cooldown:            "30m",
 			CooldownBypassLevel: "critical",
+			MinimumFreeGB:       0,
 			StateFile:           stateFile,
 		},
 		LogFile: logFile,
@@ -521,6 +536,8 @@ func DefaultConfig() *Config {
 			PythonVenvs:             true,
 			RustTargets:             true,
 			ZigArtifacts:            true,
+			AgentWorktreeArtifacts:  false,
+			PnpmStore:               false,
 			GoBuildCache:            true,
 			HaskellCache:            true,
 			LMStudioModels:          false,
@@ -547,6 +564,22 @@ func DefaultConfig() *Config {
 				KeepLatest: 2,
 			},
 			Pip: DarwinDevCacheToolConfig{
+				Enabled:        true,
+				StaleAfterDays: 14,
+			},
+			NPM: DarwinDevCacheToolConfig{
+				Enabled:        true,
+				StaleAfterDays: 14,
+			},
+			UV: DarwinDevCacheToolConfig{
+				Enabled:        true,
+				StaleAfterDays: 14,
+			},
+			Bun: DarwinDevCacheToolConfig{
+				Enabled:        true,
+				StaleAfterDays: 14,
+			},
+			OpenCode: DarwinDevCacheToolConfig{
 				Enabled:        true,
 				StaleAfterDays: 14,
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -328,6 +328,12 @@ func TestDevArtifactsConfigDefaults(t *testing.T) {
 	if !cfg.DevArtifacts.ZigArtifacts {
 		t.Error("DevArtifacts.ZigArtifacts should be true by default")
 	}
+	if cfg.DevArtifacts.AgentWorktreeArtifacts {
+		t.Error("DevArtifacts.AgentWorktreeArtifacts should be false by default")
+	}
+	if cfg.DevArtifacts.PnpmStore {
+		t.Error("DevArtifacts.PnpmStore should be false by default")
+	}
 	if !cfg.DevArtifacts.GoBuildCache {
 		t.Error("DevArtifacts.GoBuildCache should be true by default")
 	}
@@ -578,6 +584,19 @@ func TestDarwinDevCacheDefaults(t *testing.T) {
 	if cfg.DarwinDevCaches.Bazelisk.KeepLatest != 2 {
 		t.Errorf("DarwinDevCaches.Bazelisk.KeepLatest should default to 2, got %d", cfg.DarwinDevCaches.Bazelisk.KeepLatest)
 	}
+	for name, tool := range map[string]DarwinDevCacheToolConfig{
+		"NPM":      cfg.DarwinDevCaches.NPM,
+		"UV":       cfg.DarwinDevCaches.UV,
+		"Bun":      cfg.DarwinDevCaches.Bun,
+		"OpenCode": cfg.DarwinDevCaches.OpenCode,
+	} {
+		if !tool.Enabled {
+			t.Errorf("DarwinDevCaches.%s.Enabled should default to true", name)
+		}
+		if tool.StaleAfterDays != 14 {
+			t.Errorf("DarwinDevCaches.%s.StaleAfterDays should default to 14, got %d", name, tool.StaleAfterDays)
+		}
+	}
 	if !cfg.DarwinDevCaches.VSCode.Enabled {
 		t.Error("DarwinDevCaches.VSCode.Enabled should default to true")
 	}
@@ -602,6 +621,8 @@ func TestLoadConfigWithNewFields(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	content := `
+policy:
+  minimum_free_gb: 25
 enable:
   dev_artifacts: true
   bazel: true
@@ -622,6 +643,8 @@ dev_artifacts:
   python_venvs: true
   rust_targets: false
   go_build_cache: true
+  agent_worktree_artifacts: false
+  pnpm_store: false
   haskell_cache: false
   lmstudio_models: true
   protect_paths:
@@ -696,6 +719,18 @@ darwin_dev_caches:
   pip:
     enabled: true
     stale_after_days: 7
+  npm:
+    enabled: true
+    stale_after_days: 6
+  uv:
+    enabled: false
+    stale_after_days: 8
+  bun:
+    enabled: true
+    stale_after_days: 9
+  opencode:
+    enabled: true
+    stale_after_days: 11
   vscode:
     enabled: true
     stale_after_days: 10
@@ -715,6 +750,9 @@ darwin_dev_caches:
 
 	if !cfg.Enable.DevArtifacts {
 		t.Error("Enable.DevArtifacts should be true")
+	}
+	if cfg.Policy.MinimumFreeGB != 25 {
+		t.Errorf("Policy.MinimumFreeGB should be 25 per config, got %d", cfg.Policy.MinimumFreeGB)
 	}
 	if !cfg.Enable.Bazel {
 		t.Error("Enable.Bazel should be true")
@@ -748,6 +786,12 @@ darwin_dev_caches:
 	}
 	if cfg.DevArtifacts.RustTargets {
 		t.Error("DevArtifacts.RustTargets should be false per config")
+	}
+	if cfg.DevArtifacts.AgentWorktreeArtifacts {
+		t.Error("DevArtifacts.AgentWorktreeArtifacts should be false per config")
+	}
+	if cfg.DevArtifacts.PnpmStore {
+		t.Error("DevArtifacts.PnpmStore should be false per config")
 	}
 	if !cfg.DevArtifacts.ZigArtifacts {
 		t.Error("DevArtifacts.ZigArtifacts should stay true by default when omitted")
@@ -907,6 +951,21 @@ darwin_dev_caches:
 	}
 	if cfg.DarwinDevCaches.Pip.StaleAfterDays != 7 {
 		t.Errorf("DarwinDevCaches.Pip.StaleAfterDays should be 7 per config, got %d", cfg.DarwinDevCaches.Pip.StaleAfterDays)
+	}
+	if cfg.DarwinDevCaches.NPM.StaleAfterDays != 6 {
+		t.Errorf("DarwinDevCaches.NPM.StaleAfterDays should be 6 per config, got %d", cfg.DarwinDevCaches.NPM.StaleAfterDays)
+	}
+	if cfg.DarwinDevCaches.UV.Enabled {
+		t.Error("DarwinDevCaches.UV.Enabled should be false per config")
+	}
+	if cfg.DarwinDevCaches.UV.StaleAfterDays != 8 {
+		t.Errorf("DarwinDevCaches.UV.StaleAfterDays should be 8 per config, got %d", cfg.DarwinDevCaches.UV.StaleAfterDays)
+	}
+	if cfg.DarwinDevCaches.Bun.StaleAfterDays != 9 {
+		t.Errorf("DarwinDevCaches.Bun.StaleAfterDays should be 9 per config, got %d", cfg.DarwinDevCaches.Bun.StaleAfterDays)
+	}
+	if cfg.DarwinDevCaches.OpenCode.StaleAfterDays != 11 {
+		t.Errorf("DarwinDevCaches.OpenCode.StaleAfterDays should be 11 per config, got %d", cfg.DarwinDevCaches.OpenCode.StaleAfterDays)
 	}
 	if cfg.DarwinDevCaches.VSCode.StaleAfterDays != 10 {
 		t.Errorf("DarwinDevCaches.VSCode.StaleAfterDays should be 10 per config, got %d", cfg.DarwinDevCaches.VSCode.StaleAfterDays)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -24,6 +24,9 @@ policy:
   # Conservative default preserves the historical behavior: only critical
   # pressure bypasses cooldown. Incident-prone hosts can set "aggressive".
   cooldown_bypass_level: critical
+  # Optional absolute runway. When set, plugin cooldown is bypassed until the
+  # monitored filesystem has at least this many GiB free.
+  minimum_free_gb: 0
   state_file: ~/.local/state/tinyland-cleanup/state.json
 
 # Enable/disable specific cleanup plugins
@@ -212,6 +215,10 @@ dev_artifacts:
   python_venvs: true
   rust_targets: true
   zig_artifacts: true
+  # Host-specific pressure profiles can opt into these global/agent-local
+  # surfaces after reviewing active-process protection and store semantics.
+  agent_worktree_artifacts: false
+  pnpm_store: false
   go_build_cache: true
   haskell_cache: true
   lmstudio_models: false
@@ -238,6 +245,18 @@ darwin_dev_caches:
     enabled: true
     keep_latest: 2
   pip:
+    enabled: true
+    stale_after_days: 14
+  npm:
+    enabled: true
+    stale_after_days: 14
+  uv:
+    enabled: true
+    stale_after_days: 14
+  bun:
+    enabled: true
+    stale_after_days: 14
+  opencode:
     enabled: true
     stale_after_days: 14
   vscode:

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -69,13 +69,23 @@ Runtime boundary:
 - moderate, aggressive, and critical classify stale repository cache, disk
   cache, and Bazelisk download entries as `delete_cache_tier` only when the
   total Bazel footprint exceeds `max_total_gb`;
-- real cleanup skips Bazel mutation if active Bazel process inspection fails;
 - cache-tier cleanup is skipped while active Bazel or Bazelisk client commands
   are visible;
 - process-visible explicit `--output_base` directories are included in the plan
   even when they are outside configured output-user roots; active clients and
   idle/server-only output-base visibility protect only their own output base and
   do not globally block stale unrelated output-base cleanup;
+- partial output-base directories with `execroot/` but missing the full
+  `action_cache/` + `server/` shape are reported as
+  `partial_output_base` and can be deleted when stale, inactive, and outside
+  retention;
+- output-user-root repository caches such as `_bazel_$USER/cache/repos/v1` are
+  reported as `repository_cache` candidates instead of being hidden under the
+  parent `_bazel_$USER` tree;
+- if active Bazel process inspection fails, cleanup continues with
+  candidate-local evidence only; idle-server shutdown remains unavailable
+  without process visibility, but stale inactive output bases and cache tiers
+  can still be handled when their own local activity checks are clear;
 - aggressive and critical cleanup may classify stale idle-server-only output
   bases as `stop_idle_server_then_delete_output_base` when
   `allow_stop_idle_servers` is enabled; real cleanup runs

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -182,28 +182,31 @@ and active editor or IDE processes.
 
 For workspace build artifacts, the `dev-artifacts` plan reports rebuildable
 targets such as `node_modules`, Python virtualenvs, Rust `target/` directories,
-Zig `.zig-cache` and `zig-out` directories, Go build cache, Haskell caches,
-opt-in LM Studio model caches, and review-only large local disk/image artifacts
-such as `.dmg`, `.img`, `.qcow2`, `.raw`, `.iso`, `.sparsebundle`, `.utm`,
-`.pvm`, and `.vmwarevm` targets. Warning level reports only; moderate and above
-mark eligible stale artifacts as deletion or cache-clean targets while
-preserving configured protected paths. Large local disk/image artifacts are
-always protected and excluded from estimated reclaim because they can be
-developer-owned state. Mounted disk images are reported as active protected
-targets with their mount point so operators know to detach them before any
-manual cleanup or compaction. Sparsebundle targets also report logical size
-from `Info.plist` when available; detached APFS sparsebundles may still reject
-`hdiutil compact`, so treat them as manual migrate/delete decisions rather than
-automatic reclaim. The plan also surfaces large top-level temporary
-proof/output directories from configured `dev_artifacts.temp_scan_paths`, but
-those root targets are review-only and excluded from estimated reclaim. For
-stale inactive temporary roots, known generated subdirectories such as Rust
-`target/`, `node_modules`, Python virtualenvs, and Zig outputs can still appear
-as narrower reclaim candidates so cleanup can preserve the worktree or proof
-root while pruning rebuildable output. Active process command lines that
-reference the temp root mark the root active, suppress nested generated
-cleanup, and avoid full size walks of that root during dry-run planning. The
-plan also protects matching artifact families when active
+Zig `.zig-cache` and `zig-out` directories, opt-in agent worktree Rust
+`target/` directories under roots such as `~/.claude/worktrees`, opt-in pnpm
+store pruning, Go build cache, Haskell caches, opt-in LM Studio model caches,
+and review-only large local disk/image artifacts such as `.dmg`, `.img`,
+`.qcow2`, `.raw`, `.iso`, `.sparsebundle`, `.utm`, `.pvm`, and `.vmwarevm`
+targets. Warning level reports only; moderate and above mark eligible stale
+artifacts as deletion or cache-clean targets while preserving configured
+protected paths. Large local disk/image artifacts are always protected and
+excluded from estimated reclaim because they can be developer-owned state.
+Mounted disk images are reported as active protected targets with their mount
+point so operators know to detach them before any manual cleanup or compaction.
+Sparsebundle targets also report logical size from `Info.plist` when available;
+detached APFS sparsebundles may still reject `hdiutil compact`, so treat them
+as manual migrate/delete decisions rather than automatic reclaim. The plan also
+surfaces large top-level temporary proof/output directories from configured
+`dev_artifacts.temp_scan_paths`; recognized proof-lane roots such as
+`t2035b-mi.*` are classified separately, but those root targets are still
+review-only and excluded from estimated reclaim. For stale inactive temporary
+roots, known generated subdirectories such as Rust `target/`, `node_modules`,
+Python virtualenvs, and Zig outputs can still appear as narrower reclaim
+candidates so cleanup can preserve the worktree or proof root while pruning
+rebuildable output. Active process command lines that reference the temp root
+mark the root active, suppress nested generated cleanup, and avoid full size
+walks of that root during dry-run planning. The plan also protects matching
+artifact families when active
 package manager, compiler, language server, runtime, or LM Studio processes are
 visible, and it preserves any candidate artifact directory that contains files
 tracked by Git. For `node_modules`, Python virtualenvs, Rust `target/`, and Zig

--- a/main.go
+++ b/main.go
@@ -141,28 +141,28 @@ func main() {
 		return
 	}
 
-	// Setup log file directory
-	if err := ensureLogDir(cfg.LogFile); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Setup logging - write to both stderr and log file
 	logLevel := slog.LevelInfo
 	if *verbose {
 		logLevel = slog.LevelDebug
 	}
 
-	// Open log file for writing
-	logFile, err := os.OpenFile(cfg.LogFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to open log file: %v\n", err)
-		os.Exit(1)
+	logWriters := []io.Writer{os.Stderr}
+	var logFile *os.File
+	if cfg.LogFile != "" {
+		if err := ensureLogDir(cfg.LogFile); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to create log directory for %s: %v; continuing with stderr logging only\n", cfg.LogFile, err)
+		} else if file, err := os.OpenFile(cfg.LogFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to open log file %s: %v; continuing with stderr logging only\n", cfg.LogFile, err)
+		} else {
+			logFile = file
+			defer logFile.Close()
+			logWriters = append(logWriters, logFile)
+		}
 	}
-	defer logFile.Close()
 
-	// Create multi-writer for both stderr and log file
-	multiWriter := io.MultiWriter(os.Stderr, logFile)
+	// Create multi-writer for stderr and the configured log file when available.
+	multiWriter := io.MultiWriter(logWriters...)
 	logger := slog.New(slog.NewTextHandler(multiWriter, &slog.HandlerOptions{
 		Level: logLevel,
 	}))
@@ -293,6 +293,7 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 	if cooldown > 0 {
 		report.CooldownSeconds = int64(cooldown / time.Second)
 	}
+	report.MinimumFreeBytes = d.minimumFreeBytes()
 	report.StateFile = expandPathHome(d.config.Policy.StateFile)
 	state, stateErr := d.loadStateForCycle()
 	if stateErr != nil {
@@ -457,6 +458,12 @@ type cycleReport struct {
 	TargetFreeDeficitBytes int64 `json:"target_free_deficit_bytes"`
 	// TargetFreeMet reports whether the host already satisfies the target.
 	TargetFreeMet bool `json:"target_free_met"`
+	// MinimumFreeBytes is an absolute free-space runway that bypasses cooldown while unmet.
+	MinimumFreeBytes uint64 `json:"minimum_free_bytes,omitempty"`
+	// MinimumFreeDeficitBytes is the remaining free-space gap to the absolute runway.
+	MinimumFreeDeficitBytes int64 `json:"minimum_free_deficit_bytes,omitempty"`
+	// MinimumFreeMet reports whether the host already satisfies the absolute runway.
+	MinimumFreeMet bool `json:"minimum_free_met"`
 	// StopReason explains why remaining cleanup plugins were skipped.
 	StopReason string `json:"stop_reason,omitempty"`
 	// PlannedEstimatedBytesFreed aggregates dry-run plugin plan estimates.
@@ -688,6 +695,9 @@ func (d *daemon) loadStateForCycle() (*cleanupState, error) {
 }
 
 func (d *daemon) shouldApplyCooldown(report cycleReport, level monitor.CleanupLevel) bool {
+	if report.MinimumFreeBytes > 0 && !report.MinimumFreeMet {
+		return false
+	}
 	return !d.dryRun &&
 		!report.ForcedLevel &&
 		level < d.cooldownBypassLevel() &&
@@ -729,6 +739,16 @@ func (d *daemon) updateHostFreeAfter(report *cycleReport, beforeStats *monitor.D
 }
 
 func (d *daemon) updateTargetFreeStatus(report *cycleReport, stats *monitor.DiskStats) {
+	if report.MinimumFreeBytes > 0 {
+		if stats.Free >= report.MinimumFreeBytes {
+			report.MinimumFreeDeficitBytes = 0
+			report.MinimumFreeMet = true
+		} else {
+			report.MinimumFreeDeficitBytes = int64(report.MinimumFreeBytes - stats.Free)
+			report.MinimumFreeMet = false
+		}
+	}
+
 	targetFreeBytes, ok := targetFreeBytes(stats.Total, d.config.TargetFree)
 	if !ok {
 		return
@@ -744,6 +764,13 @@ func (d *daemon) updateTargetFreeStatus(report *cycleReport, stats *monitor.Disk
 
 	report.TargetFreeDeficitBytes = int64(targetFreeBytes - stats.Free)
 	report.TargetFreeMet = false
+}
+
+func (d *daemon) minimumFreeBytes() uint64 {
+	if d.config == nil || d.config.Policy.MinimumFreeGB <= 0 {
+		return 0
+	}
+	return uint64(d.config.Policy.MinimumFreeGB) * 1024 * 1024 * 1024
 }
 
 func targetFreeBytes(totalBytes uint64, targetUsedPercent int) (uint64, bool) {

--- a/main_test.go
+++ b/main_test.go
@@ -578,6 +578,52 @@ func TestRunOnceConfiguredAggressiveBypassesCooldown(t *testing.T) {
 	}
 }
 
+func TestRunOnceMinimumFreeRunwayBypassesCooldown(t *testing.T) {
+	var output bytes.Buffer
+	mock := &reportingPlugin{}
+	daemon := newTestDaemon(t, mock, &output)
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	daemon.now = func() time.Time { return now }
+	daemon.config.Policy.Cooldown = "30m"
+	daemon.config.Policy.MinimumFreeGB = 25
+	daemon.config.Policy.StateFile = filepath.Join(t.TempDir(), "state.json")
+	state := newCleanupState()
+	state.recordPluginRun("reporting", plugins.LevelAggressive, now.Add(-10*time.Minute), plugins.CleanupResult{
+		Plugin: "reporting",
+		Level:  plugins.LevelAggressive,
+	})
+	if err := saveCleanupState(daemon.config.Policy.StateFile, state); err != nil {
+		t.Fatal(err)
+	}
+
+	total := uint64(100 * 1024 * 1024 * 1024)
+	free := uint64(10 * 1024 * 1024 * 1024)
+	daemon.diskStats = sequenceDiskStats(t,
+		diskStats(total, free, 90),
+		diskStats(total, free, 90),
+		diskStats(total, free, 90),
+		diskStats(total, free, 90),
+	)
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelNone); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	if !mock.called {
+		t.Fatal("minimum free runway should bypass cooldown while unmet")
+	}
+	report := decodeCycleReport(t, output.Bytes())
+	if report.MinimumFreeBytes != 25*1024*1024*1024 {
+		t.Fatalf("minimum free bytes = %d, want 25GiB", report.MinimumFreeBytes)
+	}
+	if report.MinimumFreeMet {
+		t.Fatal("minimum free runway should be unmet")
+	}
+	if report.Plugins[0].SkipReason == "cooldown" {
+		t.Fatal("plugin should not be skipped by cooldown while minimum free runway is unmet")
+	}
+}
+
 func TestRunOnceInvalidCooldownBypassLevelDefaultsToCritical(t *testing.T) {
 	var output bytes.Buffer
 	mock := &reportingPlugin{}

--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -146,7 +146,7 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 	if cfg.Bazel.MaxTotalGB > 0 && totalPhysical > int64(cfg.Bazel.MaxTotalGB)*bazelGiB {
 		plan.Warnings = append(plan.Warnings, "detected Bazel cache footprint exceeds configured review budget")
 	}
-	plan.Warnings = append(plan.Warnings, "Bazel cleanup deletes rebuildable cache tiers only when the total footprint exceeds the configured budget and active-use inspection succeeds")
+	plan.Warnings = append(plan.Warnings, "Bazel cleanup deletes rebuildable cache tiers only when the total footprint exceeds the configured budget; output-base deletion remains limited to stale inactive candidates using process inspection when available and candidate-local activity evidence otherwise")
 	plan.Warnings = append(plan.Warnings, "Bazel output-base byte counts use a bounded recursive allocation estimate; cache tier counts use bounded top-level allocation estimates")
 
 	return plan, activeErr
@@ -162,8 +162,7 @@ func (p *BazelPlugin) Cleanup(ctx context.Context, level CleanupLevel, cfg *conf
 
 	plan, activeErr := p.buildCleanupPlan(ctx, level, cfg, logger)
 	if activeErr != nil {
-		logger.Warn("skipping Bazel cleanup because active process inspection failed", "error", activeErr)
-		return result
+		logger.Warn("Bazel active process inspection failed; continuing with candidate-local activity evidence only", "error", activeErr)
 	}
 
 	home, _ := os.UserHomeDir()
@@ -229,11 +228,11 @@ func (p *BazelPlugin) discoverCandidates(home string, cfg config.BazelConfig, ac
 
 	protectedOutputBases := outputBasesProtectedByWorkspaces(cfg.ProtectWorkspaces, home)
 	for i := range candidates {
-		if candidates[i].Type == "output_base" && protectedOutputBases[candidates[i].Path] {
+		if bazelCandidateIsOutputBaseLike(candidates[i].Type) && protectedOutputBases[candidates[i].Path] {
 			candidates[i].Protected = true
 			candidates[i].Reason = "reachable from configured protected workspace"
 		}
-		if candidates[i].Type == "output_base" {
+		if bazelCandidateIsOutputBaseLike(candidates[i].Type) {
 			activity := bazelOutputBaseActivity(candidates[i].Path)
 			if activity.Active {
 				mergeBazelCandidate(&candidates[i], bazelCandidate{
@@ -311,13 +310,16 @@ func discoverBazelRootCandidates(root string) []bazelCandidate {
 	if isBazelOutputBase(root) {
 		return []bazelCandidate{newBazelCandidate("output_base", filepath.Base(root), root, info.ModTime())}
 	}
+	if isBazelPartialOutputBase(root) {
+		return []bazelCandidate{newBazelCandidate("partial_output_base", filepath.Base(root), root, info.ModTime())}
+	}
 	if isBazelRemoteCacheRoot(root) {
 		return []bazelCandidate{newBazelCandidate("remote_cache", filepath.Base(root), root, info.ModTime())}
 	}
 
 	base := filepath.Base(root)
 	if strings.HasPrefix(base, "_bazel_") {
-		return discoverBazelOutputBases(root)
+		return discoverBazelOutputUserRootCandidates(root)
 	}
 
 	entries, err := os.ReadDir(root)
@@ -335,8 +337,12 @@ func discoverBazelRootCandidates(root string) []bazelCandidate {
 			if info, err := entry.Info(); err == nil {
 				candidates = append(candidates, newBazelCandidate("output_base", entry.Name(), path, info.ModTime()))
 			}
+		case isBazelPartialOutputBase(path):
+			if info, err := entry.Info(); err == nil {
+				candidates = append(candidates, newBazelCandidate("partial_output_base", entry.Name(), path, info.ModTime()))
+			}
 		case strings.HasPrefix(entry.Name(), "_bazel_"):
-			candidates = append(candidates, discoverBazelOutputBases(path)...)
+			candidates = append(candidates, discoverBazelOutputUserRootCandidates(path)...)
 		case entry.Name() == "repository_cache":
 			if info, err := entry.Info(); err == nil {
 				candidates = append(candidates, newBazelCandidate("repository_cache", entry.Name(), path, info.ModTime()))
@@ -355,6 +361,18 @@ func discoverBazelRootCandidates(root string) []bazelCandidate {
 	return candidates
 }
 
+func discoverBazelOutputUserRootCandidates(outputUserRoot string) []bazelCandidate {
+	var candidates []bazelCandidate
+	candidates = append(candidates, discoverBazelOutputBases(outputUserRoot)...)
+
+	repoCache := filepath.Join(outputUserRoot, "cache", "repos", "v1")
+	if info, err := os.Stat(repoCache); err == nil && info.IsDir() {
+		candidates = append(candidates, newBazelCandidate("repository_cache", filepath.Join("cache", "repos", "v1"), repoCache, info.ModTime()))
+	}
+
+	return candidates
+}
+
 func discoverBazelOutputBases(outputUserRoot string) []bazelCandidate {
 	entries, err := os.ReadDir(outputUserRoot)
 	if err != nil {
@@ -367,14 +385,16 @@ func discoverBazelOutputBases(outputUserRoot string) []bazelCandidate {
 			continue
 		}
 		path := filepath.Join(outputUserRoot, entry.Name())
-		if !isBazelOutputBase(path) {
-			continue
-		}
 		info, err := entry.Info()
 		if err != nil {
 			continue
 		}
-		candidates = append(candidates, newBazelCandidate("output_base", entry.Name(), path, info.ModTime()))
+		switch {
+		case isBazelOutputBase(path):
+			candidates = append(candidates, newBazelCandidate("output_base", entry.Name(), path, info.ModTime()))
+		case isBazelPartialOutputBase(path):
+			candidates = append(candidates, newBazelCandidate("partial_output_base", entry.Name(), path, info.ModTime()))
+		}
 	}
 	return candidates
 }
@@ -472,7 +492,7 @@ func refineBazelOutputBaseCandidateBytes(ctx context.Context, candidates []bazel
 
 	refined := false
 	for i := range candidates {
-		if candidates[i].Type != "output_base" && candidates[i].Type != "remote_cache" {
+		if !bazelCandidateIsOutputBaseLike(candidates[i].Type) && candidates[i].Type != "remote_cache" {
 			continue
 		}
 		logical, physical, err := estimateBazelCandidateBytesRecursive(estimateCtx, candidates[i].Path)
@@ -538,6 +558,13 @@ func isBazelOutputBase(path string) bool {
 		}
 	}
 	return true
+}
+
+func isBazelPartialOutputBase(path string) bool {
+	if isBazelOutputBase(path) {
+		return false
+	}
+	return pathExistsAndIsDir(filepath.Join(path, "execroot"))
 }
 
 func isBazelRemoteCacheRoot(path string) bool {
@@ -653,7 +680,7 @@ func newestBazelOutputBases(candidates []bazelCandidate, keep int) map[string]bo
 
 	var outputBases []bazelCandidate
 	for _, candidate := range candidates {
-		if candidate.Type == "output_base" {
+		if bazelCandidateIsOutputBaseLike(candidate.Type) {
 			outputBases = append(outputBases, candidate)
 		}
 	}
@@ -671,7 +698,8 @@ func newestBazelOutputBases(candidates []bazelCandidate, keep int) map[string]bo
 }
 
 func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration, now time.Time, protectedByRecent bool, globalActive bool, budgetExceeded bool, level CleanupLevel, cfg config.BazelConfig) CleanupTarget {
-	active := candidate.Active || (candidate.Type != "output_base" && globalActive)
+	outputBaseLike := bazelCandidateIsOutputBaseLike(candidate.Type)
+	active := candidate.Active || (!outputBaseLike && globalActive)
 	idleServerOnly := candidate.Type == "output_base" && candidate.IdleServer && !candidate.ActiveClient
 	stale := !candidate.ModTime.After(now.Add(-staleAfter))
 	idleServerStopEligible := candidate.Type == "output_base" &&
@@ -705,7 +733,7 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 	case level == LevelWarning:
 		action = "review"
 		reason = "warning level reports Bazel cache footprint only"
-	case candidate.Type != "output_base":
+	case !outputBaseLike:
 		if !budgetExceeded {
 			action = "review_cache_budget"
 			reason = "within configured Bazel cache budget"
@@ -721,6 +749,9 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 		action = "keep"
 		protected = true
 		reason = "newer than configured Bazel stale threshold"
+	case candidate.Type == "partial_output_base":
+		action = "delete_partial_output_base"
+		reason = "stale inactive partial output base outside retention policy"
 	default:
 		action = "delete_output_base"
 		reason = "stale inactive output base outside retention policy"
@@ -747,11 +778,15 @@ func bazelCandidateTier(candidateType string) string {
 	switch candidateType {
 	case "bazelisk":
 		return CleanupTierSafe
-	case "repository_cache", "disk_cache", "remote_cache", "output_base":
+	case "repository_cache", "disk_cache", "remote_cache", "output_base", "partial_output_base":
 		return CleanupTierWarm
 	default:
 		return CleanupTierWarm
 	}
+}
+
+func bazelCandidateIsOutputBaseLike(candidateType string) bool {
+	return candidateType == "output_base" || candidateType == "partial_output_base"
 }
 
 func bazelEstimatedCandidateBytes(targets []CleanupTarget) int64 {
@@ -812,6 +847,8 @@ func bazelTargetEligibleForDeletion(target CleanupTarget) bool {
 	switch target.Action {
 	case "delete_output_base":
 		return target.Type == "output_base"
+	case "delete_partial_output_base":
+		return target.Type == "partial_output_base"
 	case "stop_idle_server_then_delete_output_base":
 		return target.Type == "output_base"
 	case "delete_cache_tier":
@@ -828,6 +865,8 @@ func deleteBazelTarget(ctx context.Context, target CleanupTarget, logger *slog.L
 	switch target.Type {
 	case "output_base":
 		return deleteBazelOutputBase(target.Path, logger)
+	case "partial_output_base":
+		return deleteBazelPartialOutputBase(target.Path, logger)
 	case "repository_cache", "disk_cache", "remote_cache", "bazelisk":
 		return deleteBazelCacheTier(target.Type, target.Path, logger)
 	default:
@@ -1074,6 +1113,16 @@ func deleteBazelOutputBase(path string, logger *slog.Logger) error {
 	return os.RemoveAll(path)
 }
 
+func deleteBazelPartialOutputBase(path string, logger *slog.Logger) error {
+	if !isBazelPartialOutputBase(path) {
+		return fmt.Errorf("refusing to delete non-Bazel partial output base: %s", path)
+	}
+	if err := normalizeBazelDeletionPermissions(path, logger); err != nil {
+		return err
+	}
+	return os.RemoveAll(path)
+}
+
 func cleanupRepoLocalBazelSymlinksForDeletedOutputBase(workspaceRoots []string, home string, outputBase string, logger *slog.Logger) int {
 	if len(workspaceRoots) == 0 || outputBase == "" {
 		return 0
@@ -1170,7 +1219,7 @@ func bazelCacheTierPathAllowed(targetType, path string) bool {
 
 	switch targetType {
 	case "repository_cache":
-		return filepath.Base(path) == "repository_cache"
+		return filepath.Base(path) == "repository_cache" || bazelOutputUserRootRepositoryCachePathAllowed(path)
 	case "disk_cache":
 		return filepath.Base(path) == "disk_cache"
 	case "remote_cache":
@@ -1191,6 +1240,19 @@ func bazelCacheTierPathAllowed(targetType, path string) bool {
 	default:
 		return false
 	}
+}
+
+func bazelOutputUserRootRepositoryCachePathAllowed(path string) bool {
+	parts := strings.Split(filepath.Clean(path), string(os.PathSeparator))
+	for idx := 0; idx < len(parts)-3; idx++ {
+		if strings.HasPrefix(parts[idx], "_bazel_") &&
+			parts[idx+1] == "cache" &&
+			parts[idx+2] == "repos" &&
+			parts[idx+3] == "v1" {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeBazelDeletionPermissions(root string, logger *slog.Logger) error {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -19,6 +19,10 @@ func TestDiscoverBazelRootCandidates(t *testing.T) {
 	root := t.TempDir()
 	outputBase := filepath.Join(root, "_bazel_jess", "abc123")
 	makeBazelOutputBase(t, outputBase)
+	partialOutputBase := filepath.Join(root, "_bazel_jess", "partial123")
+	mustMkdir(t, filepath.Join(partialOutputBase, "execroot", "repo"))
+	repoCache := filepath.Join(root, "_bazel_jess", "cache", "repos", "v1")
+	mustMkdir(t, filepath.Join(repoCache, "content_addressable"))
 	explicitOutputBase := filepath.Join(root, "tinyvectors-external-smoke-ob")
 	makeBazelOutputBase(t, explicitOutputBase)
 	mustMkdir(t, filepath.Join(root, "repository_cache"))
@@ -36,14 +40,28 @@ func TestDiscoverBazelRootCandidates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	resolvedPartialOutputBase, err := filepath.EvalSymlinks(partialOutputBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedRepoCache, err := filepath.EvalSymlinks(repoCache)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	for _, candidateType := range []string{"output_base", "repository_cache", "disk_cache", "remote_cache"} {
+	for _, candidateType := range []string{"output_base", "partial_output_base", "repository_cache", "disk_cache", "remote_cache"} {
 		if !byType[candidateType] {
 			t.Fatalf("expected %s candidate, got %#v", candidateType, candidates)
 		}
 	}
 	if !byPath[resolvedExplicitOutputBase] {
 		t.Fatalf("expected direct explicit output base %s, got %#v", explicitOutputBase, candidates)
+	}
+	if !byPath[resolvedPartialOutputBase] {
+		t.Fatalf("expected partial output base %s, got %#v", partialOutputBase, candidates)
+	}
+	if !byPath[resolvedRepoCache] {
+		t.Fatalf("expected output-user-root repository cache %s, got %#v", repoCache, candidates)
 	}
 }
 
@@ -309,6 +327,38 @@ func TestBazelPlanTargetsDeletesCacheTiersOnlyWhenBudgetExceeded(t *testing.T) {
 	}
 	if targets[0].Action != "review_cache_budget" {
 		t.Fatalf("within-budget cache tier action = %q, want review_cache_budget", targets[0].Action)
+	}
+}
+
+func TestBazelPlanTargetsDeletesStalePartialOutputBase(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cfg := config.BazelConfig{
+		KeepRecentOutputBases: 0,
+		StaleAfter:            "14d",
+		CriticalStaleAfter:    "3d",
+	}
+	candidates := []bazelCandidate{
+		{
+			Type:     "partial_output_base",
+			Name:     "partial",
+			Path:     "/tmp/partial",
+			ModTime:  now.Add(-30 * 24 * time.Hour),
+			Physical: 10,
+		},
+	}
+
+	targets, total := bazelPlanTargets(candidates, cfg, LevelModerate, now, false)
+	if total != 10 {
+		t.Fatalf("total physical = %d, want 10", total)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected one target, got %d", len(targets))
+	}
+	if targets[0].Action != "delete_partial_output_base" || targets[0].Protected {
+		t.Fatalf("partial output base should be an eligible delete target: %#v", targets[0])
+	}
+	if targets[0].Tier != CleanupTierWarm || targets[0].Reclaim != CleanupReclaimHost {
+		t.Fatalf("partial output base policy = tier %q reclaim %q, want warm/host", targets[0].Tier, targets[0].Reclaim)
 	}
 }
 

--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -1223,28 +1223,39 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 	}
 
 	if cfg.Pip.Enabled {
-		for _, pipPath := range []string{
+		targets = append(targets, p.darwinDirectoryCacheTargets(home, cfg.Pip, level, enforce, "pip", "pip cache", []string{
 			filepath.Join(home, "Library", "Caches", "pip"),
 			filepath.Join(home, ".cache", "pip"),
-		} {
-			if !pathExistsAndIsDir(pipPath) {
-				continue
-			}
-			stale := dirModTimeStale(pipPath, cfg.Pip.StaleAfterDays)
-			eligible := level >= LevelModerate && stale
-			action := darwinCacheAction(false, enforce, eligible)
-			target := CleanupTarget{
-				Type:      "pip",
-				Name:      filepath.Base(pipPath),
-				Path:      pipPath,
-				Bytes:     getDirAllocatedBytes(pipPath),
-				Protected: darwinCacheProtected(false, enforce, eligible),
-				Action:    action,
-				Reason:    darwinCacheReason(false, enforce, eligible, "pip cache", fmt.Sprintf("stale-after policy is %d days", cfg.Pip.StaleAfterDays)),
-			}
-			annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(action))
-			targets = append(targets, target)
-		}
+		})...)
+	}
+
+	if cfg.NPM.Enabled {
+		targets = append(targets, p.darwinDirectoryCacheTargets(home, cfg.NPM, level, enforce, "npm-cache", "npm cache", []string{
+			filepath.Join(home, ".npm", "_cacache"),
+			filepath.Join(home, "Library", "Caches", "npm"),
+		})...)
+	}
+
+	if cfg.UV.Enabled {
+		targets = append(targets, p.darwinDirectoryCacheTargets(home, cfg.UV, level, enforce, "uv-cache", "uv cache", []string{
+			filepath.Join(home, ".cache", "uv"),
+			filepath.Join(home, "Library", "Caches", "uv"),
+		})...)
+	}
+
+	if cfg.Bun.Enabled {
+		targets = append(targets, p.darwinDirectoryCacheTargets(home, cfg.Bun, level, enforce, "bun-cache", "Bun cache", []string{
+			filepath.Join(home, ".cache", "bun"),
+			filepath.Join(home, ".cache", ".bun"),
+			filepath.Join(home, "Library", "Caches", "bun"),
+		})...)
+	}
+
+	if cfg.OpenCode.Enabled {
+		targets = append(targets, p.darwinDirectoryCacheTargets(home, cfg.OpenCode, level, enforce, "opencode-cache", "opencode cache", []string{
+			filepath.Join(home, ".cache", "opencode"),
+			filepath.Join(home, "Library", "Caches", "opencode"),
+		})...)
 	}
 
 	if cfg.VSCode.Enabled {
@@ -1262,6 +1273,39 @@ func (p *CachePlugin) darwinDeveloperCacheTargets(home string, cfg config.Darwin
 	}
 
 	return targets
+}
+
+func (p *CachePlugin) darwinDirectoryCacheTargets(home string, cfg config.DarwinDevCacheToolConfig, level CleanupLevel, enforce bool, targetType string, displayName string, paths []string) []CleanupTarget {
+	targets := make([]CleanupTarget, 0, len(paths))
+	for _, path := range paths {
+		if !pathExistsAndIsDir(path) {
+			continue
+		}
+		stale := dirModTimeStale(path, cfg.StaleAfterDays)
+		eligible := level >= LevelCritical || (level >= LevelModerate && stale)
+		action := darwinCacheAction(false, enforce, eligible)
+		target := CleanupTarget{
+			Type:      targetType,
+			Name:      darwinHomeRelativePath(home, path),
+			Path:      path,
+			Bytes:     getDirAllocatedBytes(path),
+			Protected: darwinCacheProtected(false, enforce, eligible),
+			Action:    action,
+			Reason: darwinCacheReason(false, enforce, eligible,
+				displayName,
+				fmt.Sprintf("stale-after policy is %d days; critical pressure can delete rebuildable package caches", cfg.StaleAfterDays)),
+		}
+		annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(action))
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+func darwinHomeRelativePath(home string, path string) string {
+	if rel, err := filepath.Rel(home, path); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return filepath.Base(path)
 }
 
 func (p *CachePlugin) darwinEditorCacheTargets(home string, cfg config.DarwinDevCacheToolConfig, activeProcesses map[string]bool, level CleanupLevel, enforce bool, targetType, displayName, appSupportName string, processNames []string) []CleanupTarget {

--- a/plugins/darwin_dev_cache_test.go
+++ b/plugins/darwin_dev_cache_test.go
@@ -60,7 +60,7 @@ func TestDarwinDeveloperCacheTargetsClassifyProtectedVersions(t *testing.T) {
 		t.Fatalf("expected two newest Bazelisk caches to be protected: v2=%#v v3=%#v", bazeliskV2, bazeliskV3)
 	}
 
-	pip := findCleanupTarget(t, targets, "pip", "pip")
+	pip := findCleanupTarget(t, targets, "pip", "Library/Caches/pip")
 	if pip.Bytes <= 0 {
 		t.Fatalf("expected pip cache size to be measured: %#v", pip)
 	}
@@ -155,6 +155,44 @@ func TestDarwinDeveloperCacheTargetsEditorCaches(t *testing.T) {
 	}
 	if _, err := os.Stat(vscodeSettings); err != nil {
 		t.Fatalf("test settings fixture should exist: %v", err)
+	}
+}
+
+func TestDarwinDeveloperCacheTargetsSafePackageAndAgentCaches(t *testing.T) {
+	home := t.TempDir()
+	cfg := config.DefaultConfig().DarwinDevCaches
+	cfg.Enforce = true
+
+	targetDirs := []string{
+		filepath.Join(home, ".npm", "_cacache"),
+		filepath.Join(home, ".cache", "uv"),
+		filepath.Join(home, ".cache", "bun"),
+		filepath.Join(home, ".cache", "opencode"),
+	}
+	for _, dir := range targetDirs {
+		writeFileAt(t, filepath.Join(dir, "cache.bin"), "cache")
+		mustChtimes(t, dir, time.Now().Add(-30*24*time.Hour))
+	}
+
+	plugin := &CachePlugin{}
+	targets := plugin.darwinDeveloperCacheTargets(home, cfg, map[string]bool{}, LevelModerate)
+
+	for _, want := range []struct {
+		targetType string
+		name       string
+	}{
+		{"npm-cache", ".npm/_cacache"},
+		{"uv-cache", ".cache/uv"},
+		{"bun-cache", ".cache/bun"},
+		{"opencode-cache", ".cache/opencode"},
+	} {
+		target := findCleanupTarget(t, targets, want.targetType, want.name)
+		if target.Action != "delete" || target.Protected {
+			t.Fatalf("expected %s %s to be an opt-in delete target: %#v", want.targetType, want.name, target)
+		}
+		if target.Tier != CleanupTierSafe || target.Reclaim != CleanupReclaimHost {
+			t.Fatalf("unexpected policy for %s %s: %#v", want.targetType, want.name, target)
+		}
 	}
 }
 

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -1,7 +1,8 @@
 // Package plugins provides cleanup plugin implementations.
 // devartifacts.go scans for stale development artifacts like node_modules,
-// .venv, Rust target/, Zig artifacts, Go build cache, Haskell caches,
-// LM Studio models, and review-only large local artifacts.
+// .venv, Rust target/, Zig artifacts, agent worktree outputs, pnpm store,
+// Go build cache, Haskell caches, LM Studio models, and review-only large
+// local artifacts.
 package plugins
 
 import (
@@ -29,6 +30,7 @@ const devArtifactRecentOutputGrace = 2 * time.Hour
 var tempArtifactPathPattern = regexp.MustCompile(`(?:/private)?/tmp/[^\s"'<>]+|/var/tmp/[^\s"'<>]+`)
 var absoluteDevArtifactPathPattern = regexp.MustCompile(`(?:~|/)[^\s"'<>]+`)
 var nixTempRootNamePattern = regexp.MustCompile(`^(?:nix-shell\.[A-Za-z0-9]+|nix-develop-\d+-\d+|nix-\d+-\d+|nix-build-[A-Za-z0-9._+@=-]+-\d+)$`)
+var temporaryProofLaneNamePattern = regexp.MustCompile(`^t[0-9]+[A-Za-z]*-[A-Za-z0-9._-]+$`)
 
 var errDevArtifactScanBudgetExceeded = errors.New("dev artifact scan budget exceeded")
 
@@ -296,9 +298,15 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 			p.planLargeLocalArtifacts(scanCtx, expanded, largeLocalArtifactMinBytes(daCfg), daCfg.ProtectPaths, mountedImages, &targets, scanBudget)
 		}
 	}
+	if daCfg.AgentWorktreeArtifacts && daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
+		p.planAgentWorktreeArtifacts(scanCtx, home, rustAge, mutates, daCfg, active, tracker, &targets, scanBudget)
+	}
 
 	if daCfg.GoBuildCache {
 		p.planGoBuildCache(ctx, level, active, &targets)
+	}
+	if daCfg.PnpmStore {
+		p.planPnpmStore(ctx, home, level, active, &targets)
 	}
 	if daCfg.HaskellCache {
 		p.planHaskellCaches(ctx, home, level, active, &targets)
@@ -451,10 +459,29 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 			return result
 		}
 	}
+	if daCfg.AgentWorktreeArtifacts && daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
+		freed := p.cleanAgentWorktreeArtifacts(scanCtx, home, rustAge, daCfg, active, tracker, logger, scanBudget)
+		result.BytesFreed += freed
+		if freed > 0 {
+			result.ItemsCleaned++
+		}
+	}
+	if scanBudget.exhausted() {
+		logger.Warn("stopping dev artifact cleanup because scan budget was exhausted", "truncated_paths", strings.Join(scanBudget.truncatedDetails(), "; "))
+		return result
+	}
 
 	// Go build cache (not path-dependent - it's a global cache)
 	if daCfg.GoBuildCache && !active.GlobalFamilyActive("go-build-cache") {
 		freed := p.cleanGoBuildCache(ctx, level, logger)
+		result.BytesFreed += freed
+		if freed > 0 {
+			result.ItemsCleaned++
+		}
+	}
+
+	if daCfg.PnpmStore && !active.GlobalFamilyActive("node_modules") {
+		freed := p.cleanPnpmStore(ctx, home, level, logger)
 		result.BytesFreed += freed
 		if freed > 0 {
 			result.ItemsCleaned++
@@ -539,11 +566,74 @@ func (p *DevArtifactsPlugin) planZigArtifacts(ctx context.Context, scanPath stri
 	}
 }
 
+func (p *DevArtifactsPlugin) planAgentWorktreeArtifacts(ctx context.Context, home string, rustAge time.Duration, mutates bool, daCfg config.DevArtifactsConfig, active devArtifactActivity, tracker *devArtifactGitTracker, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
+	for _, root := range agentWorktreeRoots(home) {
+		if !pathExistsAndIsDir(root) {
+			continue
+		}
+		p.planRustTargets(ctx, root, rustAge, mutates, daCfg.ProtectPaths, active, tracker, targets, budgets...)
+	}
+}
+
 func (p *DevArtifactsPlugin) planLargeLocalArtifacts(ctx context.Context, scanPath string, minBytes int64, protectPaths []string, mountedImages map[string]string, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
 	budget := optionalDevArtifactScanBudget(budgets)
 	p.findLargeLocalArtifacts(ctx, scanPath, minBytes, protectPaths, mountedImages, func(target CleanupTarget) {
 		*targets = append(*targets, target)
 	}, budget)
+}
+
+func agentWorktreeRoots(home string) []string {
+	return []string{
+		filepath.Join(home, ".claude", "worktrees"),
+	}
+}
+
+func (p *DevArtifactsPlugin) planPnpmStore(ctx context.Context, home string, level CleanupLevel, active devArtifactActivity, targets *[]CleanupTarget) {
+	path := pnpmStorePath(home)
+	if !pathExistsAndIsDir(path) {
+		return
+	}
+	size, err := getDirAllocatedBytesContext(ctx, path)
+	if err != nil || size == 0 {
+		return
+	}
+
+	target := CleanupTarget{
+		Type:  "pnpm-store",
+		Name:  ".local/share/pnpm",
+		Path:  path,
+		Bytes: size,
+	}
+	if activeReason, ok := active.FamilyReason("node_modules"); ok {
+		target.Action = "protect"
+		target.Active = true
+		target.Protected = true
+		target.Reason = "active package manager or Node process detected: " + activeReason
+	} else if level >= LevelModerate {
+		target.Action = "clean-cache"
+		target.Reason = "pnpm store prune removes unreferenced rebuildable package-store entries"
+	} else {
+		target.Action = "report"
+		target.Protected = true
+		target.Reason = "warning level reports pnpm store without pruning it"
+	}
+	annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(target.Action))
+	*targets = append(*targets, target)
+}
+
+func pnpmStorePath(home string) string {
+	return filepath.Join(home, ".local", "share", "pnpm")
+}
+
+func (p *DevArtifactsPlugin) cleanAgentWorktreeArtifacts(ctx context.Context, home string, rustAge time.Duration, daCfg config.DevArtifactsConfig, active devArtifactActivity, tracker *devArtifactGitTracker, logger *slog.Logger, budgets ...*devArtifactScanBudget) int64 {
+	var totalFreed int64
+	for _, root := range agentWorktreeRoots(home) {
+		if !pathExistsAndIsDir(root) {
+			continue
+		}
+		totalFreed += p.cleanRustTargets(ctx, root, rustAge, daCfg.ProtectPaths, active, tracker, logger, budgets...)
+	}
+	return totalFreed
 }
 
 func (p *DevArtifactsPlugin) planTemporaryArtifacts(ctx context.Context, scanPath string, minBytes int64, staleAfter time.Duration, daCfg config.DevArtifactsConfig, activeRoots map[string]string, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
@@ -776,6 +866,12 @@ func (p *DevArtifactsPlugin) forEachStaleTemporaryRoot(ctx context.Context, scan
 func (p *DevArtifactsPlugin) temporaryArtifactTarget(path string, physicalBytes int64, modTime time.Time, staleAfter time.Duration, now time.Time, protected bool, activeReason string) CleanupTarget {
 	action := "review_temp_artifact"
 	reason := fmt.Sprintf("large top-level temporary artifact is older than %s; manual review required before deletion", formatDevArtifactAge(staleAfter))
+	targetType := "temporary-dev-artifact"
+	if isTemporaryProofLaneName(filepath.Base(path)) {
+		targetType = "temporary-proof-lane"
+		action = "review_temp_proof_lane"
+		reason = fmt.Sprintf("known temporary proof lane is older than %s; root deletion requires manual review, nested rebuildable artifacts may be cleaned separately", formatDevArtifactAge(staleAfter))
+	}
 	active := activeReason != ""
 	isProtected := true
 	switch {
@@ -790,7 +886,7 @@ func (p *DevArtifactsPlugin) temporaryArtifactTarget(path string, physicalBytes 
 		reason = fmt.Sprintf("temporary artifact is newer than %s", formatDevArtifactAge(staleAfter))
 	}
 	target := CleanupTarget{
-		Type:      "temporary-dev-artifact",
+		Type:      targetType,
 		Name:      filepath.Base(path),
 		Path:      path,
 		Bytes:     physicalBytes,
@@ -801,6 +897,10 @@ func (p *DevArtifactsPlugin) temporaryArtifactTarget(path string, physicalBytes 
 	}
 	annotateCleanupTargetPolicy(&target, CleanupTierDestructive, CleanupReclaimNone)
 	return target
+}
+
+func isTemporaryProofLaneName(name string) bool {
+	return temporaryProofLaneNamePattern.MatchString(name)
 }
 
 func (p *DevArtifactsPlugin) nixTemporaryRootTarget(path string, physicalBytes int64, modTime time.Time, staleAfter time.Duration, now time.Time, protected bool, activeReason string, canDelete bool) CleanupTarget {
@@ -1148,9 +1248,9 @@ func (p *DevArtifactsPlugin) devArtifactTarget(targetType, name, path string, by
 
 func devArtifactTier(targetType string) string {
 	switch targetType {
-	case "go-build-cache", "haskell-ghcup-cache":
+	case "go-build-cache", "haskell-ghcup-cache", "pnpm-store":
 		return CleanupTierSafe
-	case "lmstudio-models", "large-local-artifact":
+	case "lmstudio-models", "large-local-artifact", "temporary-proof-lane":
 		return CleanupTierDestructive
 	default:
 		return CleanupTierWarm
@@ -2341,6 +2441,34 @@ func (p *DevArtifactsPlugin) cleanGoBuildCache(ctx context.Context, level Cleanu
 	freed := safeBytesDiff(sizeBefore, sizeAfter)
 	if freed > 0 {
 		logger.Info("cleaned Go build cache", "freed_mb", freed/(1024*1024))
+	}
+	return freed
+}
+
+func (p *DevArtifactsPlugin) cleanPnpmStore(ctx context.Context, home string, level CleanupLevel, logger *slog.Logger) int64 {
+	if level < LevelModerate {
+		return 0
+	}
+	if _, err := exec.LookPath("pnpm"); err != nil {
+		return 0
+	}
+
+	storePath := pnpmStorePath(home)
+	sizeBefore := getDirSize(storePath)
+	if sizeBefore == 0 {
+		return 0
+	}
+
+	logger.Debug("pruning pnpm store", "path", storePath)
+	if output, err := exec.CommandContext(ctx, "pnpm", "store", "prune").CombinedOutput(); err != nil {
+		logger.Debug("pnpm store prune failed", "error", err, "output", strings.TrimSpace(string(output)))
+		return 0
+	}
+
+	sizeAfter := getDirSize(storePath)
+	freed := safeBytesDiff(sizeBefore, sizeAfter)
+	if freed > 0 {
+		logger.Info("pruned pnpm store", "freed_mb", freed/(1024*1024))
 	}
 	return freed
 }

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -936,6 +936,35 @@ func TestPlanTemporaryArtifactsReportsReviewOnlyTargets(t *testing.T) {
 	}
 }
 
+func TestPlanTemporaryArtifactsClassifiesProofLanes(t *testing.T) {
+	p := NewDevArtifactsPlugin()
+	tmpDir := t.TempDir()
+	proofLane := filepath.Join(tmpDir, "t2035b-mi.0WfaPi")
+	if err := os.MkdirAll(proofLane, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proofLane, "artifact"), []byte("artifact"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(proofLane, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	var targets []CleanupTarget
+	cfg := config.DefaultConfig().DevArtifacts
+	cfg.NixTempRoots = false
+	p.planTemporaryArtifacts(context.Background(), tmpDir, 1, 6*time.Hour, cfg, nil, &targets)
+
+	target := findDevArtifactTarget(t, targets, "temporary-proof-lane", proofLane)
+	if target.Action != "review_temp_proof_lane" || !target.Protected || target.Reclaim != CleanupReclaimNone {
+		t.Fatalf("expected proof lane to remain review-only, got %#v", target)
+	}
+	if !strings.Contains(target.Reason, "nested rebuildable artifacts") {
+		t.Fatalf("expected nested-artifact guidance in reason, got %q", target.Reason)
+	}
+}
+
 func TestPlanTemporaryArtifactsDoesNotChargeSymlinkTargets(t *testing.T) {
 	p := NewDevArtifactsPlugin()
 	tmpDir := t.TempDir()
@@ -967,6 +996,57 @@ func TestPlanTemporaryArtifactsDoesNotChargeSymlinkTargets(t *testing.T) {
 		if target.Path == root {
 			t.Fatalf("symlink forest should not be reported as large temp artifact, got %#v", target)
 		}
+	}
+}
+
+func TestPlanCleanupReportsAgentWorktreeRustTargets(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	worktree := filepath.Join(home, ".claude", "worktrees", "session-a", "repo")
+	targetDir := filepath.Join(worktree, "target", "debug")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cargoToml := filepath.Join(worktree, "Cargo.toml")
+	if err := os.WriteFile(cargoToml, []byte("[package]\nname = \"agent-worktree\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "artifact"), make([]byte, 2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(cargoToml, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := agentWorktreeArtifactConfig()
+	plan := p.PlanCleanup(context.Background(), LevelCritical, cfg, slog.Default())
+
+	target := findDevArtifactTarget(t, plan.Targets, "rust-target", filepath.Join(worktree, "target"))
+	if target.Action != "delete" || target.Protected {
+		t.Fatalf("expected agent worktree Rust target to be deletable, got %#v", target)
+	}
+}
+
+func TestPlanCleanupReportsPnpmStorePruneTarget(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := filepath.Join(home, ".local", "share", "pnpm", "store", "v3")
+	if err := os.MkdirAll(store, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "pkg"), make([]byte, 2*1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := pnpmStoreConfig()
+	plan := p.PlanCleanup(context.Background(), LevelModerate, cfg, slog.Default())
+
+	target := findDevArtifactTarget(t, plan.Targets, "pnpm-store", filepath.Join(home, ".local", "share", "pnpm"))
+	if target.Action != "clean-cache" || target.Protected || target.Tier != CleanupTierSafe {
+		t.Fatalf("expected pnpm store prune target, got %#v", target)
 	}
 }
 
@@ -1155,6 +1235,40 @@ func tempGeneratedArtifactConfig(tmpDir string) *config.Config {
 	cfg.DevArtifacts.PythonVenvs = false
 	cfg.DevArtifacts.RustTargets = true
 	cfg.DevArtifacts.ZigArtifacts = false
+	cfg.DevArtifacts.GoBuildCache = false
+	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.LargeLocalArtifacts = false
+	cfg.DevArtifacts.LMStudioModels = false
+	return cfg
+}
+
+func agentWorktreeArtifactConfig() *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.DevArtifacts.ScanPaths = nil
+	cfg.DevArtifacts.TempArtifacts = false
+	cfg.DevArtifacts.AgentWorktreeArtifacts = true
+	cfg.DevArtifacts.NodeModules = false
+	cfg.DevArtifacts.PythonVenvs = false
+	cfg.DevArtifacts.RustTargets = true
+	cfg.DevArtifacts.ZigArtifacts = false
+	cfg.DevArtifacts.PnpmStore = false
+	cfg.DevArtifacts.GoBuildCache = false
+	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.LargeLocalArtifacts = false
+	cfg.DevArtifacts.LMStudioModels = false
+	return cfg
+}
+
+func pnpmStoreConfig() *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.DevArtifacts.ScanPaths = nil
+	cfg.DevArtifacts.TempArtifacts = false
+	cfg.DevArtifacts.AgentWorktreeArtifacts = false
+	cfg.DevArtifacts.NodeModules = false
+	cfg.DevArtifacts.PythonVenvs = false
+	cfg.DevArtifacts.RustTargets = false
+	cfg.DevArtifacts.ZigArtifacts = false
+	cfg.DevArtifacts.PnpmStore = true
 	cfg.DevArtifacts.GoBuildCache = false
 	cfg.DevArtifacts.HaskellCache = false
 	cfg.DevArtifacts.LargeLocalArtifacts = false

--- a/plugins/podman.go
+++ b/plugins/podman.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -976,9 +977,13 @@ func detectMachine() (bool, string) {
 	cmd := exec.Command("podman", "machine", "list", "--format", "{{.Name}}\t{{.Running}}")
 	output, err := cmd.Output()
 	if err != nil {
-		return false, ""
+		return false, detectMachineNameFromConfig()
 	}
-	return parsePodmanMachineList(string(output))
+	running, name := parsePodmanMachineList(string(output))
+	if name == "" {
+		name = detectMachineNameFromConfig()
+	}
+	return running, name
 }
 
 func parsePodmanMachineList(output string) (bool, string) {
@@ -1010,6 +1015,73 @@ func parsePodmanMachineList(output string) (bool, string) {
 		return false, defaultMachine
 	}
 	return false, firstMachine
+}
+
+func detectMachineNameFromConfig() string {
+	home, _ := os.UserHomeDir()
+	return podmanMachineNameFromConfig(home, detectMachineProvider())
+}
+
+func podmanMachineNameFromConfig(home string, preferredProvider string) string {
+	for _, provider := range podmanProviderSearchOrder(preferredProvider) {
+		configDir := filepath.Join(home, ".config", "containers", "podman", "machine", provider)
+		if name := podmanMachineNameFromConfigDir(configDir); name != "" {
+			return name
+		}
+	}
+
+	for _, provider := range podmanProviderSearchOrder(preferredProvider) {
+		dataDir := filepath.Join(home, ".local", "share", "containers", "podman", "machine", provider)
+		if entries, err := os.ReadDir(dataDir); err == nil && len(entries) > 0 {
+			return "podman-machine-default"
+		}
+	}
+	return ""
+}
+
+func podmanProviderSearchOrder(preferredProvider string) []string {
+	seen := map[string]bool{}
+	var providers []string
+	add := func(provider string) {
+		provider = strings.TrimSpace(provider)
+		if provider == "" || seen[provider] {
+			return
+		}
+		seen[provider] = true
+		providers = append(providers, provider)
+	}
+	add(preferredProvider)
+	add("applehv")
+	add("libkrun")
+	add("qemu")
+	return providers
+}
+
+func podmanMachineNameFromConfigDir(configDir string) string {
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		return ""
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".json")
+		if name == "" {
+			continue
+		}
+		if name == "podman-machine-default" {
+			return name
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
 }
 
 // getPodmanSocket returns the Podman socket path.
@@ -1851,15 +1923,57 @@ func (p *PodmanPlugin) getMachineDiskPath(ctx context.Context) (string, error) {
 
 	// Strategy 2: Read internal config JSON from known provider paths
 	home, _ := os.UserHomeDir()
-	providers := []string{"libkrun", "applehv", "qemu"}
+	providers := podmanProviderSearchOrder(p.environment.VMProvider)
 	for _, provider := range providers {
 		configDir := filepath.Join(home, ".config/containers/podman/machine", provider)
 		if path, err := p.readDiskPathFromConfig(configDir); err == nil {
 			return path, nil
 		}
 	}
+	if path, err := podmanMachineDiskPathFromDataDirs(home, p.environment.MachineName, providers); err == nil {
+		return path, nil
+	}
 
 	return "", fmt.Errorf("disk path not found in machine config")
+}
+
+func podmanMachineDiskPathFromDataDirs(home string, machineName string, providers []string) (string, error) {
+	if machineName == "" {
+		return "", fmt.Errorf("machine name is empty")
+	}
+	for _, provider := range providers {
+		dataDir := filepath.Join(home, ".local", "share", "containers", "podman", "machine", provider)
+		if path := podmanMachineDiskPathFromDataDir(dataDir, machineName); path != "" {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("disk path not found in Podman machine data directories")
+}
+
+func podmanMachineDiskPathFromDataDir(dataDir string, machineName string) string {
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		return ""
+	}
+	var matches []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, machineName) {
+			continue
+		}
+		switch filepath.Ext(name) {
+		case ".raw", ".qcow2":
+			matches = append(matches, filepath.Join(dataDir, name))
+		}
+	}
+	sort.Strings(matches)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
 }
 
 // readDiskPathFromConfig reads the disk image path from a machine config JSON file.

--- a/plugins/podman_compaction_test.go
+++ b/plugins/podman_compaction_test.go
@@ -23,6 +23,38 @@ func TestParsePodmanMachineListSelectsStoppedDefault(t *testing.T) {
 	}
 }
 
+func TestPodmanMachineFallbackDiscoversConfigAndDataDisk(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "containers", "podman", "machine", "applehv")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "podman-machine-default.json"), []byte(`{"ImagePath":{"Path":"/tmp/podman.raw"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if name := podmanMachineNameFromConfig(home, "applehv"); name != "podman-machine-default" {
+		t.Fatalf("expected config fallback machine name, got %q", name)
+	}
+
+	dataDir := filepath.Join(home, ".local", "share", "containers", "podman", "machine", "applehv")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	diskPath := filepath.Join(dataDir, "podman-machine-default-arm64.raw")
+	if err := os.WriteFile(diskPath, []byte("raw disk placeholder"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := podmanMachineDiskPathFromDataDirs(home, "podman-machine-default", []string{"applehv"})
+	if err != nil {
+		t.Fatalf("expected data-dir disk fallback, got error: %v", err)
+	}
+	if found != diskPath {
+		t.Fatalf("expected fallback disk path %q, got %q", diskPath, found)
+	}
+}
+
 func TestPodmanCriticalPlanReportsStoppedMachineDisk(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/report_text.go
+++ b/report_text.go
@@ -73,6 +73,14 @@ func writeTextReport(w io.Writer, report cycleReport) error {
 			return err
 		}
 	}
+	if report.MinimumFreeBytes > 0 {
+		if _, err := fmt.Fprintf(w, "minimum free: need %s free, deficit %s\n",
+			formatByteCount(int64(report.MinimumFreeBytes)),
+			formatByteCount(report.MinimumFreeDeficitBytes),
+		); err != nil {
+			return err
+		}
+	}
 	if report.StopReason != "" {
 		if _, err := fmt.Fprintf(w, "stop: %s\n", report.StopReason); err != nil {
 			return err


### PR DESCRIPTION
## Summary
- keep tinyland-cleanup running when the configured log file cannot be opened
- add policy.minimum_free_gb cooldown bypass runway reporting
- expand Bazel discovery for partial output bases and _bazel_USER/cache/repos/v1
- make Bazel cleanup degrade to candidate-local evidence when ps inspection fails
- add Podman machine config/data-dir fallback discovery for stopped or lock-blocked machines
- add typed Darwin cache targets for npm/uv/bun/opencode
- add opt-in dev-artifact support for .claude worktree Rust targets, pnpm store prune, and temporary proof-lane classification

## Validation
- env GOCACHE=/private/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
- Nix consumer/package validation in lab with --override-input tinyland-cleanup-upstream path:/Users/jess/git/tinyland-cleanup