### PR TITLE
TIN-2170: add inode-aware pressure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ builder and runner machines.
 
 - Dry-run behavior must stay useful enough for operator review.
 - Cleanup policy should explain what it plans to remove and why.
-- Host free-space accounting should be measured before and after cleanup.
-- Real cleanup should stop once the configured host free-space target is met.
+- Host free-space and inode accounting should be measured before and after cleanup.
+- Real cleanup should stop once the configured host free-space target is met
+  and inode pressure has cleared.
 - Daemon-triggered cleanup should honor cooldown state below the configured
   bypass severity.
 - Privileged actions, offline compaction, and service disruption must remain
@@ -61,6 +62,10 @@ Use JSON when another tool needs the stable report schema:
 ```sh
 tinyland-cleanup --once --dry-run --level critical --output json
 ```
+
+Byte and inode thresholds are evaluated in parallel. This matters for Nix
+stores and runner hosts where small-file sprawl can exhaust inodes while byte
+usage still looks healthy.
 
 List available plugin names before constraining an evidence run:
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,9 @@ type Config struct {
 	// Thresholds for disk usage (percentage)
 	Thresholds Thresholds `yaml:"thresholds"`
 
+	// InodeThresholds for inode usage (percentage)
+	InodeThresholds Thresholds `yaml:"inode_thresholds"`
+
 	// TargetFree is the legacy config key for target maximum used percentage after cleanup.
 	TargetFree int `yaml:"target_free"`
 
@@ -105,6 +108,10 @@ type MountConfig struct {
 	ThresholdWarning int `yaml:"threshold_warning,omitempty"`
 	// ThresholdCritical overrides the global critical threshold
 	ThresholdCritical int `yaml:"threshold_critical,omitempty"`
+	// ThresholdInodeWarning overrides the global inode warning threshold
+	ThresholdInodeWarning int `yaml:"threshold_inode_warning,omitempty"`
+	// ThresholdInodeCritical overrides the global inode critical threshold
+	ThresholdInodeCritical int `yaml:"threshold_inode_critical,omitempty"`
 }
 
 // Thresholds defines disk usage thresholds for graduated cleanup.
@@ -163,6 +170,11 @@ type PolicyConfig struct {
 	MinimumFreeGB int `yaml:"minimum_free_gb"`
 	// StateFile stores daemon cleanup state such as per-plugin last-run timestamps.
 	StateFile string `yaml:"state_file"`
+	// InodeNoProgressLimit is the number of consecutive cleanup cycles that fail
+	// to relieve inode pressure before the daemon stops bypassing cooldown for
+	// inode-only escalation and backs off to the cooldown cadence. Zero uses the
+	// built-in default.
+	InodeNoProgressLimit int `yaml:"inode_no_progress_limit"`
 }
 
 // DockerConfig holds Docker-specific cleanup settings.
@@ -436,12 +448,19 @@ func DefaultConfig() *Config {
 			Aggressive: 90,
 			Critical:   95,
 		},
+		InodeThresholds: Thresholds{
+			Warning:    80,
+			Moderate:   85,
+			Aggressive: 90,
+			Critical:   95,
+		},
 		TargetFree: 70,
 		Policy: PolicyConfig{
-			Cooldown:            "30m",
-			CooldownBypassLevel: "critical",
-			MinimumFreeGB:       0,
-			StateFile:           stateFile,
+			Cooldown:             "30m",
+			CooldownBypassLevel:  "critical",
+			MinimumFreeGB:        0,
+			StateFile:            stateFile,
+			InodeNoProgressLimit: 3,
 		},
 		LogFile: logFile,
 		Enable: EnableFlags{

--- a/config/config_pbt_test.go
+++ b/config/config_pbt_test.go
@@ -28,6 +28,12 @@ func TestConfigRoundtrip(t *testing.T) {
 				Aggressive: rapid.IntRange(86, 94).Draw(rt, "aggressive"),
 				Critical:   rapid.IntRange(95, 99).Draw(rt, "critical"),
 			},
+			InodeThresholds: Thresholds{
+				Warning:    rapid.IntRange(50, 70).Draw(rt, "inode_warning"),
+				Moderate:   rapid.IntRange(71, 85).Draw(rt, "inode_moderate"),
+				Aggressive: rapid.IntRange(86, 94).Draw(rt, "inode_aggressive"),
+				Critical:   rapid.IntRange(95, 99).Draw(rt, "inode_critical"),
+			},
 			TargetFree: rapid.IntRange(10, 50).Draw(rt, "target_free"),
 		}
 
@@ -62,6 +68,12 @@ func TestConfigRoundtrip(t *testing.T) {
 		}
 		if loaded.Thresholds.Critical != cfg.Thresholds.Critical {
 			rt.Fatalf("Critical threshold mismatch: expected %d, got %d", cfg.Thresholds.Critical, loaded.Thresholds.Critical)
+		}
+		if loaded.InodeThresholds.Warning != cfg.InodeThresholds.Warning {
+			rt.Fatalf("Inode warning threshold mismatch: expected %d, got %d", cfg.InodeThresholds.Warning, loaded.InodeThresholds.Warning)
+		}
+		if loaded.InodeThresholds.Critical != cfg.InodeThresholds.Critical {
+			rt.Fatalf("Inode critical threshold mismatch: expected %d, got %d", cfg.InodeThresholds.Critical, loaded.InodeThresholds.Critical)
 		}
 		if loaded.TargetFree != cfg.TargetFree {
 			rt.Fatalf("TargetFree mismatch: expected %d, got %d", cfg.TargetFree, loaded.TargetFree)
@@ -117,6 +129,15 @@ func TestDefaultConfigValid(t *testing.T) {
 	if cfg.Thresholds.Aggressive >= cfg.Thresholds.Critical {
 		t.Errorf("aggressive >= critical: %d >= %d", cfg.Thresholds.Aggressive, cfg.Thresholds.Critical)
 	}
+	if cfg.InodeThresholds.Warning >= cfg.InodeThresholds.Moderate {
+		t.Errorf("inode warning >= moderate: %d >= %d", cfg.InodeThresholds.Warning, cfg.InodeThresholds.Moderate)
+	}
+	if cfg.InodeThresholds.Moderate >= cfg.InodeThresholds.Aggressive {
+		t.Errorf("inode moderate >= aggressive: %d >= %d", cfg.InodeThresholds.Moderate, cfg.InodeThresholds.Aggressive)
+	}
+	if cfg.InodeThresholds.Aggressive >= cfg.InodeThresholds.Critical {
+		t.Errorf("inode aggressive >= critical: %d >= %d", cfg.InodeThresholds.Aggressive, cfg.InodeThresholds.Critical)
+	}
 
 	// Thresholds must be percentages (0-100)
 	if cfg.Thresholds.Warning < 0 || cfg.Thresholds.Warning > 100 {
@@ -124,6 +145,12 @@ func TestDefaultConfigValid(t *testing.T) {
 	}
 	if cfg.Thresholds.Critical < 0 || cfg.Thresholds.Critical > 100 {
 		t.Errorf("Critical threshold out of range: %d", cfg.Thresholds.Critical)
+	}
+	if cfg.InodeThresholds.Warning < 0 || cfg.InodeThresholds.Warning > 100 {
+		t.Errorf("Inode warning threshold out of range: %d", cfg.InodeThresholds.Warning)
+	}
+	if cfg.InodeThresholds.Critical < 0 || cfg.InodeThresholds.Critical > 100 {
+		t.Errorf("Inode critical threshold out of range: %d", cfg.InodeThresholds.Critical)
 	}
 
 	// TargetFree must be less than Warning threshold

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,18 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Thresholds.Critical != 95 {
 		t.Errorf("expected Critical=95, got %d", cfg.Thresholds.Critical)
 	}
+	if cfg.InodeThresholds.Warning != 80 {
+		t.Errorf("expected inode Warning=80, got %d", cfg.InodeThresholds.Warning)
+	}
+	if cfg.InodeThresholds.Moderate != 85 {
+		t.Errorf("expected inode Moderate=85, got %d", cfg.InodeThresholds.Moderate)
+	}
+	if cfg.InodeThresholds.Aggressive != 90 {
+		t.Errorf("expected inode Aggressive=90, got %d", cfg.InodeThresholds.Aggressive)
+	}
+	if cfg.InodeThresholds.Critical != 95 {
+		t.Errorf("expected inode Critical=95, got %d", cfg.InodeThresholds.Critical)
+	}
 	if cfg.Policy.Cooldown != "30m" {
 		t.Errorf("expected cooldown=30m, got %q", cfg.Policy.Cooldown)
 	}
@@ -122,6 +134,48 @@ thresholds:
 	// Should use defaults for unspecified values
 	if cfg.Thresholds.Moderate != 85 {
 		t.Errorf("expected default Moderate=85, got %d", cfg.Thresholds.Moderate)
+	}
+}
+
+func TestLoadConfigInodeThresholds(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `
+inode_thresholds:
+  warning: 70
+  moderate: 80
+  aggressive: 90
+  critical: 98
+monitored_mounts:
+  - path: /nix
+    label: nix
+    threshold_inode_warning: 60
+    threshold_inode_critical: 92
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.InodeThresholds.Warning != 70 {
+		t.Fatalf("expected inode warning 70, got %d", cfg.InodeThresholds.Warning)
+	}
+	if cfg.InodeThresholds.Critical != 98 {
+		t.Fatalf("expected inode critical 98, got %d", cfg.InodeThresholds.Critical)
+	}
+	if len(cfg.MonitoredMounts) != 1 {
+		t.Fatalf("expected one mount, got %d", len(cfg.MonitoredMounts))
+	}
+	mount := cfg.MonitoredMounts[0]
+	if mount.ThresholdInodeWarning != 60 {
+		t.Fatalf("expected mount inode warning 60, got %d", mount.ThresholdInodeWarning)
+	}
+	if mount.ThresholdInodeCritical != 92 {
+		t.Fatalf("expected mount inode critical 92, got %d", mount.ThresholdInodeCritical)
 	}
 }
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -37,6 +37,11 @@ policy:
   # monitored filesystem has at least this many GiB free.
   minimum_free_gb: 0
   state_file: ~/.local/state/tinyland-cleanup/state.json
+  # Inode-pressure circuit breaker. When inode-only critical pressure persists
+  # without being relieved for this many consecutive cycles, the daemon stops
+  # bypassing cooldown and backs off to the cooldown cadence instead of running
+  # every plugin every poll interval. Zero uses the built-in default (3).
+  inode_no_progress_limit: 3
 
 # Enable/disable specific cleanup plugins
 enable:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -12,6 +12,15 @@ thresholds:
   aggressive: 90   # Level 3: Prune volumes
   critical: 95     # Level 4: Emergency cleanup
 
+# Inode usage thresholds (percentage). These are evaluated in parallel with
+# byte thresholds, so small-file pressure can trigger cleanup even when bytes
+# are still healthy.
+inode_thresholds:
+  warning: 80
+  moderate: 85
+  aggressive: 90
+  critical: 95
+
 # Target maximum used-space percentage after cleanup.
 # Historical key name is target_free.
 target_free: 70
@@ -75,6 +84,8 @@ github_runner:
 #     label: "nix"
 #     threshold_warning: 70
 #     threshold_critical: 85
+#     threshold_inode_warning: 70
+#     threshold_inode_critical: 90
 
 # Docker-specific settings
 docker:

--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -4,6 +4,12 @@ Nix cleanup is now planned before mutation. The plugin reports dry-run store
 reclaim estimates, visible profile generations, and active Nix work before it
 touches generations or the store.
 
+The daemon monitors byte pressure and inode pressure independently. This is
+important for `/nix/store`: many small store paths can exhaust filesystem
+inodes while byte usage still appears safe. Configure `monitored_mounts` for
+`/nix` or `/nix/store` and tune `inode_thresholds` when deploying the daemon as
+a node-level prevention control.
+
 Review with:
 
 ```sh
@@ -116,6 +122,20 @@ opt-in because it can be long-running.
 Recommended Rocky or Linux runner defaults:
 
 ```yaml
+inode_thresholds:
+  warning: 80
+  moderate: 85
+  aggressive: 90
+  critical: 95
+
+monitored_mounts:
+  - path: /nix
+    label: nix
+    threshold_warning: 70
+    threshold_critical: 85
+    threshold_inode_warning: 70
+    threshold_inode_critical: 90
+
 nix:
   min_user_generations: 3
   min_home_manager_generations: 3

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -58,7 +58,7 @@ The JSON report includes:
 
 - the selected cleanup level;
 - monitored mount status;
-- host free-space before and after the cycle;
+- host free-space and inode status before and after the cycle;
 - the configured target maximum used percentage and equivalent free-space
   deficit;
 - daemon state file and configured cleanup cooldown;
@@ -67,6 +67,12 @@ The JSON report includes:
 - optional `plugin_filter` when `--plugins` constrains the cycle;
 - enabled plugins that would run;
 - plugin descriptions and dry-run skip reasons.
+
+Byte thresholds and `inode_thresholds` are evaluated in parallel. A monitored
+mount can therefore enter warning, moderate, aggressive, or critical cleanup
+because bytes are scarce, inodes are scarce, or both. Mount reports include
+`byte_level`, `inode_level`, `inodes_total`, `inodes_free`, and
+`inodes_used_percent` when the filesystem reports inode statistics.
 
 Dry-run mode does not call plugin cleanup methods. A plugin entry with
 `skip_reason: "dry_run"` means the plugin is enabled and would run at that
@@ -148,14 +154,19 @@ Use `--output json` for automation. The report distinguishes:
 - `target_free_deficit_bytes`: remaining bytes needed to satisfy the target;
 - `target_free_met`: whether the current host free space satisfies the target;
 - `stop_reason`: why remaining plugins were skipped, currently
-  `target_free_met` when a real cleanup cycle reaches the target;
+  `target_free_met` when a real cleanup cycle reaches the byte target and inode
+  pressure has cleared;
 - `planned_estimated_bytes_freed`: aggregate dry-run reclaim estimate from
   plugin plans;
 - `planned_required_free_bytes`: largest free-space preflight requirement
   across plugin plans;
 - `planned_targets`: total number of dry-run targets across plugin plans;
 - `host_free_delta_bytes`: cycle-level host free-space delta for the monitored
-  path.
+  path;
+- `host_inodes_free_before`, `host_inodes_free_after`, and
+  `host_inodes_free_delta`: cycle-level inode accounting for the monitored
+  path when available;
+- `host_inode_level`: current inode pressure level for the monitored path.
 
 The cycle-level host delta is the operator truth for whether the machine gained
 usable space. Plugin byte counts are supporting evidence and may differ from

--- a/docs/rpm-packaging.md
+++ b/docs/rpm-packaging.md
@@ -31,6 +31,11 @@ Enable the service only after the dry-run plan matches the host policy:
 systemctl enable --now tinyland-cleanup.service
 ```
 
+For Nix-heavy Rocky runners, add `/nix` to `monitored_mounts` and review
+`inode_thresholds` before enabling the service. The packaged defaults include
+the inode threshold keys but keep the mount list conservative until a node role
+or operator config selects the host-specific filesystems.
+
 Build an RPM locally with:
 
 ```sh

--- a/docs/validation-status-2026-06-23.md
+++ b/docs/validation-status-2026-06-23.md
@@ -1,0 +1,55 @@
+# Validation Status: 2026-06-23
+
+Branch: `jess/tin-2170-inode-awareness`
+Commit: `4041891`
+
+## Scope
+
+This validation covers inode-aware pressure handling for TIN-2170/TIN-2165:
+
+- byte and inode pressure are evaluated independently;
+- inode pressure can escalate cleanup even when byte usage is healthy;
+- real cleanup does not stop at the byte target while inode pressure remains;
+- daemon state records inode no-progress cycles so unrelieved inode-only
+  escalation can back off to cooldown cadence;
+- JSON and text reports include host and mount inode evidence.
+
+## Local Validation
+
+Passed locally on aarch64-darwin:
+
+```sh
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...
+env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...
+nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+nix build .#default --no-link --print-build-logs --builders '' --max-jobs 1 --cores 1
+```
+
+No cleanup mutation was performed during validation.
+
+The Nix package build was forced to local single-job execution because the
+ambient remote-builder configuration intermittently waited on remote builder
+handoff. The package itself built and passed its check phase locally.
+
+## Lab Consumer Proof
+
+The lab Home Manager contract was validated against this working tree using the
+same upstream input that lab normally consumes from GitHub:
+
+```sh
+nix build .#checks.aarch64-darwin.tinyland-cleanup-config-test \
+  --no-link -L \
+  --override-input tinyland-cleanup-upstream path:/Users/jess/git/tinyland-cleanup \
+  --builders '' --max-jobs 1 --cores 1
+```
+
+The lab change renders `inode_thresholds` and per-mount
+`threshold_inode_warning` / `threshold_inode_critical` keys, including honey's
+`/nix` mount policy.
+
+## GloriousFlywheel Proof
+
+The Bazel workflow remains shared-cache-backed only. This validation does not
+prove remote execution/offload. Continue using `scripts/bazel-cache-backed.sh`
+with an explicit `BAZEL_REMOTE_CACHE` endpoint for GloriousFlywheel cache proof.

--- a/main.go
+++ b/main.go
@@ -55,6 +55,12 @@ var (
 	date    = "unknown"
 )
 
+// defaultInodeNoProgressLimit is the number of consecutive cleanup cycles that
+// must fail to relieve inode pressure before the daemon stops bypassing
+// cooldown for inode-only escalation. Used when policy.inode_no_progress_limit
+// is unset.
+const defaultInodeNoProgressLimit = 3
+
 func main() {
 	// Parse command line flags
 	var (
@@ -168,11 +174,15 @@ func main() {
 	}))
 
 	// Create disk monitor
-	diskMon := monitor.NewDiskMonitor(
+	diskMon := monitor.NewDiskMonitorWithInodeThresholds(
 		cfg.Thresholds.Warning,
 		cfg.Thresholds.Moderate,
 		cfg.Thresholds.Aggressive,
 		cfg.Thresholds.Critical,
+		cfg.InodeThresholds.Warning,
+		cfg.InodeThresholds.Moderate,
+		cfg.InodeThresholds.Aggressive,
+		cfg.InodeThresholds.Critical,
 	)
 
 	// Create cleanup daemon
@@ -228,6 +238,10 @@ func main() {
 		"moderate", cfg.Thresholds.Moderate,
 		"aggressive", cfg.Thresholds.Aggressive,
 		"critical", cfg.Thresholds.Critical,
+		"inode_warning", cfg.InodeThresholds.Warning,
+		"inode_moderate", cfg.InodeThresholds.Moderate,
+		"inode_aggressive", cfg.InodeThresholds.Aggressive,
+		"inode_critical", cfg.InodeThresholds.Critical,
 	)
 
 	if err := d.run(ctx); err != nil && err != context.Canceled {
@@ -280,13 +294,14 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 
 	now := d.currentTime()
 	report := cycleReport{
-		Timestamp:    now.UTC().Format(time.RFC3339),
-		DryRun:       d.dryRun,
-		ForcedLevel:  forcedLevel != monitor.LevelNone,
-		Level:        level.String(),
-		MonitorPath:  d.primaryMonitorPath(assessment),
-		Mounts:       assessment.Mounts,
-		PluginFilter: d.pluginFilter,
+		Timestamp:     now.UTC().Format(time.RFC3339),
+		DryRun:        d.dryRun,
+		ForcedLevel:   forcedLevel != monitor.LevelNone,
+		Level:         level.String(),
+		MonitorPath:   d.primaryMonitorPath(assessment),
+		MaxInodeLevel: assessment.InodeLevel.String(),
+		Mounts:        assessment.Mounts,
+		PluginFilter:  d.pluginFilter,
 	}
 
 	cooldown := d.cleanupCooldown()
@@ -300,6 +315,9 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 		report.StateError = stateErr.Error()
 		d.logger.Warn("failed to load cleanup state", "path", report.StateFile, "error", stateErr)
 	}
+	if stateErr == nil {
+		report.InodeNoProgressCount = state.inodeNoProgressCount(report.MonitorPath)
+	}
 	stateDirty := false
 
 	beforeStats, beforeErr := d.getDiskStats(report.MonitorPath)
@@ -308,11 +326,28 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 		d.logger.Warn("failed to measure host free space before cleanup", "path", report.MonitorPath, "error", beforeErr)
 	} else {
 		report.HostFreeBeforeBytes = beforeStats.Free
+		report.HostInodesTotal = beforeStats.InodesTotal
+		report.HostInodesFreeBefore = beforeStats.InodesFree
+		report.HostInodesUsedPercentBefore = beforeStats.InodesUsedPercent
+		report.HostInodeLevel = d.inodeLevelForPath(report.MonitorPath, beforeStats).String()
+		report.HostByteLevel = d.byteLevelForPath(report.MonitorPath, beforeStats).String()
 		d.updateTargetFreeStatus(&report, beforeStats)
 	}
 
 	if level == monitor.LevelNone {
 		return d.writeReport(report)
+	}
+
+	// Engage the inode-pressure circuit breaker for this cycle when inode-only
+	// escalation has repeatedly failed to free inodes, so cooldown is applied
+	// instead of bypassed (TIN-2170).
+	report.InodeBackoff = d.inodeBackoffActive(report)
+	if report.InodeBackoff {
+		d.logger.Warn("inode pressure unrelieved by recent cleanup cycles; backing off to cooldown cadence",
+			"path", report.MonitorPath,
+			"inode_level", report.HostInodeLevel,
+			"no_progress_count", report.InodeNoProgressCount,
+		)
 	}
 
 	// Convert monitor level to plugin level
@@ -333,7 +368,7 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 			WouldRun:    true,
 		}
 
-		if !d.dryRun && report.TargetFreeMet {
+		if !d.dryRun && d.cleanupTargetMet(report) {
 			pluginReport.WouldRun = false
 			pluginReport.SkipReason = "target_free_met"
 			if report.StopReason == "" {
@@ -412,6 +447,27 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 	report.TotalItemsCleaned = totalItems
 
 	d.updateHostFreeAfter(&report, beforeStats, beforeErr)
+
+	// Record inode reclaim progress for the monitored path so the circuit
+	// breaker can detect inode pressure that repeated cycles fail to relieve
+	// (TIN-2170). A cycle counts as progress when free inodes increased or inode
+	// pressure cleared; otherwise the no-progress counter advances toward the
+	// backoff limit.
+	if !d.dryRun && stateErr == nil && report.HostInodesTotal > 0 {
+		if parseLevel(report.MaxInodeLevel) != monitor.LevelNone {
+			improved := report.HostInodesFreeDelta > 0 ||
+				parseLevel(report.HostInodeLevel) == monitor.LevelNone
+			state.recordInodeProgress(report.MonitorPath, report.HostInodesFreeAfter,
+				report.HostInodesUsedPercentAfter, report.HostInodeLevel, now, improved)
+			stateDirty = true
+		} else if state.inodeNoProgressCount(report.MonitorPath) > 0 {
+			// Inode pressure cleared: reset the stale no-progress counter.
+			state.recordInodeProgress(report.MonitorPath, report.HostInodesFreeAfter,
+				report.HostInodesUsedPercentAfter, report.HostInodeLevel, now, true)
+			stateDirty = true
+		}
+	}
+
 	if stateDirty {
 		if err := saveCleanupState(report.StateFile, state); err != nil {
 			report.StateError = err.Error()
@@ -438,18 +494,37 @@ func (d *daemon) runOnce(ctx context.Context, forcedLevel monitor.CleanupLevel) 
 }
 
 type cycleReport struct {
-	Timestamp           string `json:"timestamp"`
-	DryRun              bool   `json:"dry_run"`
-	ForcedLevel         bool   `json:"forced_level"`
-	Level               string `json:"level"`
-	MonitorPath         string `json:"monitor_path"`
-	HostFreeBeforeBytes uint64 `json:"host_free_before_bytes"`
-	HostFreeAfterBytes  uint64 `json:"host_free_after_bytes"`
-	HostFreeDeltaBytes  int64  `json:"host_free_delta_bytes"`
-	HostFreeError       string `json:"host_free_error,omitempty"`
-	StateFile           string `json:"state_file,omitempty"`
-	StateError          string `json:"state_error,omitempty"`
-	CooldownSeconds     int64  `json:"cooldown_seconds,omitempty"`
+	Timestamp                   string  `json:"timestamp"`
+	DryRun                      bool    `json:"dry_run"`
+	ForcedLevel                 bool    `json:"forced_level"`
+	Level                       string  `json:"level"`
+	MonitorPath                 string  `json:"monitor_path"`
+	HostFreeBeforeBytes         uint64  `json:"host_free_before_bytes"`
+	HostFreeAfterBytes          uint64  `json:"host_free_after_bytes"`
+	HostFreeDeltaBytes          int64   `json:"host_free_delta_bytes"`
+	HostInodesTotal             uint64  `json:"host_inodes_total,omitempty"`
+	HostInodesFreeBefore        uint64  `json:"host_inodes_free_before,omitempty"`
+	HostInodesFreeAfter         uint64  `json:"host_inodes_free_after,omitempty"`
+	HostInodesFreeDelta         int64   `json:"host_inodes_free_delta,omitempty"`
+	HostInodesUsedPercentBefore float64 `json:"host_inodes_used_percent_before,omitempty"`
+	HostInodesUsedPercentAfter  float64 `json:"host_inodes_used_percent_after,omitempty"`
+	HostInodeLevel              string  `json:"host_inode_level,omitempty"`
+	// HostByteLevel is the byte-driven cleanup level for the monitored primary
+	// path, used to tell apart inode-only escalation from byte pressure.
+	HostByteLevel string `json:"host_byte_level,omitempty"`
+	// MaxInodeLevel is the highest inode-driven level across all monitored mounts
+	// and gates the cleanup stop condition.
+	MaxInodeLevel string `json:"max_inode_level,omitempty"`
+	// InodeNoProgressCount is the number of consecutive prior cycles that failed
+	// to relieve inode pressure on the primary path.
+	InodeNoProgressCount int `json:"inode_no_progress_count,omitempty"`
+	// InodeBackoff reports that the inode-pressure circuit breaker engaged this
+	// cycle, so the daemon applied cooldown instead of bypassing it.
+	InodeBackoff    bool   `json:"inode_backoff,omitempty"`
+	HostFreeError   string `json:"host_free_error,omitempty"`
+	StateFile       string `json:"state_file,omitempty"`
+	StateError      string `json:"state_error,omitempty"`
+	CooldownSeconds int64  `json:"cooldown_seconds,omitempty"`
 	// TargetUsedPercent is the legacy target_free config value as a maximum used percentage.
 	TargetUsedPercent int `json:"target_used_percent"`
 	// TargetFreeBytes is the free-space equivalent required to satisfy TargetUsedPercent.
@@ -480,13 +555,18 @@ type cycleReport struct {
 }
 
 type mountReport struct {
-	Label       string  `json:"label"`
-	Path        string  `json:"path"`
-	UsedPercent float64 `json:"used_percent"`
-	FreeGB      float64 `json:"free_gb"`
-	FreeBytes   uint64  `json:"free_bytes"`
-	Level       string  `json:"level"`
-	Error       string  `json:"error,omitempty"`
+	Label             string  `json:"label"`
+	Path              string  `json:"path"`
+	UsedPercent       float64 `json:"used_percent"`
+	FreeGB            float64 `json:"free_gb"`
+	FreeBytes         uint64  `json:"free_bytes"`
+	ByteLevel         string  `json:"byte_level"`
+	InodesTotal       uint64  `json:"inodes_total,omitempty"`
+	InodesFree        uint64  `json:"inodes_free,omitempty"`
+	InodesUsedPercent float64 `json:"inodes_used_percent,omitempty"`
+	InodeLevel        string  `json:"inode_level,omitempty"`
+	Level             string  `json:"level"`
+	Error             string  `json:"error,omitempty"`
 }
 
 type pluginCycleReport struct {
@@ -519,8 +599,13 @@ type pluginListEntry struct {
 }
 
 type mountAssessment struct {
-	Level  monitor.CleanupLevel
-	Mounts []mountReport
+	Level monitor.CleanupLevel
+	// InodeLevel is the highest inode-driven cleanup level across all monitored
+	// mounts. It is tracked separately from Level so the cleanup stop condition
+	// does not declare success while any mount still has inode pressure, even
+	// when that mount is not the byte-pressure primary.
+	InodeLevel monitor.CleanupLevel
+	Mounts     []mountReport
 }
 
 // assessMounts monitors all configured mount points and returns the highest
@@ -548,30 +633,22 @@ func (d *daemon) assessMounts() mountAssessment {
 				continue
 			}
 
-			// Use per-mount thresholds if configured, otherwise use global
-			mountMonitor := d.monitor
-			if mount.ThresholdWarning > 0 || mount.ThresholdCritical > 0 {
-				warning := d.config.Thresholds.Warning
-				moderate := d.config.Thresholds.Moderate
-				aggressive := d.config.Thresholds.Aggressive
-				critical := d.config.Thresholds.Critical
-				if mount.ThresholdWarning > 0 {
-					warning = mount.ThresholdWarning
-				}
-				if mount.ThresholdCritical > 0 {
-					critical = mount.ThresholdCritical
-				}
-				mountMonitor = monitor.NewDiskMonitor(warning, moderate, aggressive, critical)
-			}
-
+			mountMonitor := d.monitorForMount(mount)
+			byteLevel := mountMonitor.CheckByteLevel(stats)
+			inodeLevel := mountMonitor.CheckInodeLevel(stats)
 			mountLevel := mountMonitor.CheckLevel(stats)
 			assessment.Mounts = append(assessment.Mounts, mountReport{
-				Label:       label,
-				Path:        mount.Path,
-				UsedPercent: stats.UsedPercent,
-				FreeGB:      stats.FreeGB,
-				FreeBytes:   stats.Free,
-				Level:       mountLevel.String(),
+				Label:             label,
+				Path:              mount.Path,
+				UsedPercent:       stats.UsedPercent,
+				FreeGB:            stats.FreeGB,
+				FreeBytes:         stats.Free,
+				ByteLevel:         byteLevel.String(),
+				InodesTotal:       stats.InodesTotal,
+				InodesFree:        stats.InodesFree,
+				InodesUsedPercent: stats.InodesUsedPercent,
+				InodeLevel:        inodeLevelDisplay(inodeLevel, stats.InodesTotal),
+				Level:             mountLevel.String(),
 			})
 
 			d.logger.Info("disk status",
@@ -579,11 +656,18 @@ func (d *daemon) assessMounts() mountAssessment {
 				"path", mount.Path,
 				"used_percent", fmt.Sprintf("%.1f%%", stats.UsedPercent),
 				"free_gb", fmt.Sprintf("%.1fGB", stats.FreeGB),
+				"inodes_used_percent", fmt.Sprintf("%.1f%%", stats.InodesUsedPercent),
+				"inodes_free", stats.InodesFree,
+				"byte_level", byteLevel.String(),
+				"inode_level", inodeLevel.String(),
 				"level", mountLevel.String(),
 			)
 
 			if mountLevel > assessment.Level {
 				assessment.Level = mountLevel
+			}
+			if inodeLevel > assessment.InodeLevel {
+				assessment.InodeLevel = inodeLevel
 			}
 		}
 	} else {
@@ -607,30 +691,116 @@ func (d *daemon) assessMounts() mountAssessment {
 			return assessment
 		}
 		detectedLevel := d.monitor.CheckLevel(stats)
+		byteLevel := d.monitor.CheckByteLevel(stats)
+		inodeLevel := d.monitor.CheckInodeLevel(stats)
 
 		assessment.Mounts = append(assessment.Mounts, mountReport{
-			Label:       monitorPath,
-			Path:        monitorPath,
-			UsedPercent: stats.UsedPercent,
-			FreeGB:      stats.FreeGB,
-			FreeBytes:   stats.Free,
-			Level:       detectedLevel.String(),
+			Label:             monitorPath,
+			Path:              monitorPath,
+			UsedPercent:       stats.UsedPercent,
+			FreeGB:            stats.FreeGB,
+			FreeBytes:         stats.Free,
+			ByteLevel:         byteLevel.String(),
+			InodesTotal:       stats.InodesTotal,
+			InodesFree:        stats.InodesFree,
+			InodesUsedPercent: stats.InodesUsedPercent,
+			InodeLevel:        inodeLevelDisplay(inodeLevel, stats.InodesTotal),
+			Level:             detectedLevel.String(),
 		})
 
 		d.logger.Info("disk status",
 			"used_percent", fmt.Sprintf("%.1f%%", stats.UsedPercent),
 			"free_gb", fmt.Sprintf("%.1fGB", stats.FreeGB),
+			"inodes_used_percent", fmt.Sprintf("%.1f%%", stats.InodesUsedPercent),
+			"inodes_free", stats.InodesFree,
+			"byte_level", byteLevel.String(),
+			"inode_level", inodeLevel.String(),
 			"level", detectedLevel.String(),
 		)
 
 		assessment.Level = detectedLevel
+		assessment.InodeLevel = inodeLevel
 	}
 
 	return assessment
 }
 
+// inodeLevelDisplay returns the inode cleanup level as a string, or "" when the
+// filesystem does not report a usable inode count, so callers can distinguish
+// "no inode pressure" (none) from "inodes not measured" (empty).
+func inodeLevelDisplay(level monitor.CleanupLevel, inodesTotal uint64) string {
+	if inodesTotal == 0 {
+		return ""
+	}
+	return level.String()
+}
+
 func (d *daemon) checkMounts() monitor.CleanupLevel {
 	return d.assessMounts().Level
+}
+
+func (d *daemon) monitorForMount(mount config.MountConfig) *monitor.DiskMonitor {
+	if mount.ThresholdWarning <= 0 &&
+		mount.ThresholdCritical <= 0 &&
+		mount.ThresholdInodeWarning <= 0 &&
+		mount.ThresholdInodeCritical <= 0 {
+		return d.monitor
+	}
+
+	warning := d.config.Thresholds.Warning
+	moderate := d.config.Thresholds.Moderate
+	aggressive := d.config.Thresholds.Aggressive
+	critical := d.config.Thresholds.Critical
+	if mount.ThresholdWarning > 0 {
+		warning = mount.ThresholdWarning
+	}
+	if mount.ThresholdCritical > 0 {
+		critical = mount.ThresholdCritical
+	}
+
+	inodeWarning := d.config.InodeThresholds.Warning
+	inodeModerate := d.config.InodeThresholds.Moderate
+	inodeAggressive := d.config.InodeThresholds.Aggressive
+	inodeCritical := d.config.InodeThresholds.Critical
+	if mount.ThresholdInodeWarning > 0 {
+		inodeWarning = mount.ThresholdInodeWarning
+	}
+	if mount.ThresholdInodeCritical > 0 {
+		inodeCritical = mount.ThresholdInodeCritical
+	}
+
+	return monitor.NewDiskMonitorWithInodeThresholds(
+		warning,
+		moderate,
+		aggressive,
+		critical,
+		inodeWarning,
+		inodeModerate,
+		inodeAggressive,
+		inodeCritical,
+	)
+}
+
+func (d *daemon) inodeLevelForPath(path string, stats *monitor.DiskStats) monitor.CleanupLevel {
+	if d.config != nil {
+		for _, mount := range d.config.MonitoredMounts {
+			if mount.Path == path {
+				return d.monitorForMount(mount).CheckInodeLevel(stats)
+			}
+		}
+	}
+	return d.monitor.CheckInodeLevel(stats)
+}
+
+func (d *daemon) byteLevelForPath(path string, stats *monitor.DiskStats) monitor.CleanupLevel {
+	if d.config != nil {
+		for _, mount := range d.config.MonitoredMounts {
+			if mount.Path == path {
+				return d.monitorForMount(mount).CheckByteLevel(stats)
+			}
+		}
+	}
+	return d.monitor.CheckByteLevel(stats)
 }
 
 func (d *daemon) primaryMonitorPath(assessment mountAssessment) string {
@@ -698,10 +868,42 @@ func (d *daemon) shouldApplyCooldown(report cycleReport, level monitor.CleanupLe
 	if report.MinimumFreeBytes > 0 && !report.MinimumFreeMet {
 		return false
 	}
-	return !d.dryRun &&
-		!report.ForcedLevel &&
-		level < d.cooldownBypassLevel() &&
-		d.cleanupCooldown() > 0
+	if d.dryRun || report.ForcedLevel || d.cleanupCooldown() <= 0 {
+		return false
+	}
+	if level >= d.cooldownBypassLevel() {
+		// An escalation at/above the bypass level normally ignores cooldown.
+		// Circuit breaker: when that escalation is driven solely by inode
+		// pressure that recent cycles have repeatedly failed to relieve, resume
+		// applying cooldown so the daemon backs off to the cooldown cadence
+		// instead of churning every poll interval (TIN-2170).
+		return report.InodeBackoff
+	}
+	return true
+}
+
+// inodeBackoffActive reports whether the circuit breaker should engage: the
+// monitor-path escalation is forced by inode pressure (not bytes) at/above the
+// bypass level, and the configured number of consecutive cleanup cycles have
+// failed to free inodes on that path.
+func (d *daemon) inodeBackoffActive(report cycleReport) bool {
+	bypass := d.cooldownBypassLevel()
+	if parseLevel(report.HostInodeLevel) < bypass {
+		return false
+	}
+	if parseLevel(report.HostByteLevel) >= bypass {
+		// Bytes are independently at/above the bypass level, so cleanup is
+		// expected to make byte progress; do not back off.
+		return false
+	}
+	return report.InodeNoProgressCount >= d.inodeNoProgressLimit()
+}
+
+func (d *daemon) inodeNoProgressLimit() int {
+	if d.config != nil && d.config.Policy.InodeNoProgressLimit > 0 {
+		return d.config.Policy.InodeNoProgressLimit
+	}
+	return defaultInodeNoProgressLimit
 }
 
 func (d *daemon) cooldownBypassLevel() monitor.CleanupLevel {
@@ -732,10 +934,23 @@ func (d *daemon) updateHostFreeAfter(report *cycleReport, beforeStats *monitor.D
 	}
 
 	report.HostFreeAfterBytes = afterStats.Free
+	report.HostInodesTotal = afterStats.InodesTotal
+	report.HostInodesFreeAfter = afterStats.InodesFree
+	report.HostInodesUsedPercentAfter = afterStats.InodesUsedPercent
+	report.HostInodeLevel = d.inodeLevelForPath(report.MonitorPath, afterStats).String()
 	if beforeErr == nil && beforeStats != nil {
 		report.HostFreeDeltaBytes = int64(afterStats.Free) - int64(beforeStats.Free)
+		report.HostInodesFreeDelta = int64(afterStats.InodesFree) - int64(beforeStats.InodesFree)
 	}
 	d.updateTargetFreeStatus(report, afterStats)
+}
+
+func (d *daemon) cleanupTargetMet(report cycleReport) bool {
+	// Do not declare the cleanup target met while any monitored mount still has
+	// inode pressure, even if it is not the byte-pressure primary path. The byte
+	// target alone is insufficient because an inode-exhausted filesystem can have
+	// ample free bytes (the honey nix-store crunch, TIN-2165/TIN-2170).
+	return report.TargetFreeMet && parseLevel(report.MaxInodeLevel) == monitor.LevelNone
 }
 
 func (d *daemon) updateTargetFreeStatus(report *cycleReport, stats *monitor.DiskStats) {

--- a/main_test.go
+++ b/main_test.go
@@ -326,6 +326,170 @@ func TestRunOnceStopsAfterTargetFreeMet(t *testing.T) {
 	}
 }
 
+func TestRunOnceDoesNotStopWhenTargetFreeMetButInodesPressured(t *testing.T) {
+	var output bytes.Buffer
+	first := &reportingPlugin{
+		name: "first",
+		result: plugins.CleanupResult{
+			Plugin:       "first",
+			Level:        plugins.LevelCritical,
+			ItemsCleaned: 1,
+		},
+	}
+	second := &reportingPlugin{
+		name: "second",
+		result: plugins.CleanupResult{
+			Plugin:       "second",
+			Level:        plugins.LevelCritical,
+			ItemsCleaned: 1,
+		},
+	}
+	daemon := newTestDaemonWithPlugins(t, &output, first, second)
+	daemon.config.TargetFree = 70
+	inodePressure := diskStatsWithInodes(1000, 400, 60, 1000, 20, 98)
+	daemon.diskStats = sequenceDiskStats(t,
+		inodePressure,
+		inodePressure,
+		inodePressure,
+		inodePressure,
+		inodePressure,
+	)
+
+	if err := daemon.runOnce(context.Background(), monitor.LevelNone); err != nil {
+		t.Fatalf("runOnce failed: %v", err)
+	}
+
+	if !first.called {
+		t.Fatal("expected first plugin cleanup to run")
+	}
+	if !second.called {
+		t.Fatal("second plugin should still run while inode pressure remains")
+	}
+
+	report := decodeCycleReport(t, output.Bytes())
+	if !report.TargetFreeMet {
+		t.Fatal("expected byte target free to be met")
+	}
+	if report.HostInodeLevel != "critical" {
+		t.Fatalf("expected host inode level critical, got %q", report.HostInodeLevel)
+	}
+	if report.StopReason != "" {
+		t.Fatalf("did not expect stop reason while inode pressure remains, got %q", report.StopReason)
+	}
+	if len(report.Plugins) != 2 {
+		t.Fatalf("expected 2 plugin reports, got %d", len(report.Plugins))
+	}
+	if !report.Plugins[1].WouldRun {
+		t.Fatalf("expected second plugin to run, skip reason %q", report.Plugins[1].SkipReason)
+	}
+}
+
+func TestRunOnceInodeBackoffEngagesAfterRepeatedNoProgress(t *testing.T) {
+	var output bytes.Buffer
+	plugin := &reportingPlugin{
+		name: "nix",
+		result: plugins.CleanupResult{
+			Plugin:       "nix",
+			Level:        plugins.LevelCritical,
+			ItemsCleaned: 1,
+		},
+	}
+	d := newTestDaemonWithPlugins(t, &output, plugin)
+	d.config.TargetFree = 70
+	// Byte target met (free 400 >= 300) but inodes pinned at 98% with no
+	// improvement across cycles: inode-only critical escalation.
+	d.diskStats = sequenceDiskStats(t, diskStatsWithInodes(1000, 400, 60, 1000, 20, 98))
+
+	limit := d.config.Policy.InodeNoProgressLimit
+	if limit <= 0 {
+		t.Fatalf("expected a positive inode no-progress limit, got %d", limit)
+	}
+
+	// The first `limit` cycles run aggressively because critical pressure
+	// bypasses cooldown; the breaker has not yet tripped.
+	for i := 0; i < limit; i++ {
+		output.Reset()
+		if err := d.runOnce(context.Background(), monitor.LevelNone); err != nil {
+			t.Fatalf("cycle %d runOnce failed: %v", i, err)
+		}
+		rep := decodeCycleReport(t, output.Bytes())
+		if rep.InodeBackoff {
+			t.Fatalf("cycle %d unexpectedly backed off (count=%d)", i, rep.InodeNoProgressCount)
+		}
+		if len(rep.Plugins) != 1 || rep.Plugins[0].SkipReason != "" {
+			t.Fatalf("cycle %d expected plugin to run, got %+v", i, rep.Plugins)
+		}
+	}
+
+	// After `limit` consecutive no-progress cycles the breaker engages and the
+	// daemon backs off to the cooldown cadence instead of churning.
+	output.Reset()
+	if err := d.runOnce(context.Background(), monitor.LevelNone); err != nil {
+		t.Fatalf("backoff cycle runOnce failed: %v", err)
+	}
+	rep := decodeCycleReport(t, output.Bytes())
+	if !rep.InodeBackoff {
+		t.Fatalf("expected inode backoff to engage, count=%d", rep.InodeNoProgressCount)
+	}
+	if len(rep.Plugins) != 1 || rep.Plugins[0].WouldRun || rep.Plugins[0].SkipReason != "cooldown" {
+		t.Fatalf("expected plugin cooldown skip, got %+v", rep.Plugins)
+	}
+}
+
+func TestCleanupTargetMetRequiresAllMountsInodeClear(t *testing.T) {
+	d := &daemon{}
+	cases := []struct {
+		name          string
+		targetFreeMet bool
+		maxInodeLevel string
+		want          bool
+	}{
+		{"bytes met, no inode pressure", true, monitor.LevelNone.String(), true},
+		{"bytes met, inode critical on some mount", true, monitor.LevelCritical.String(), false},
+		{"bytes met, inode warning on some mount", true, monitor.LevelWarning.String(), false},
+		{"bytes met, inode unmeasured", true, "", true},
+		{"bytes not met", false, monitor.LevelNone.String(), false},
+	}
+	for _, tc := range cases {
+		report := cycleReport{TargetFreeMet: tc.targetFreeMet, MaxInodeLevel: tc.maxInodeLevel}
+		if got := d.cleanupTargetMet(report); got != tc.want {
+			t.Errorf("%s: cleanupTargetMet = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestAssessMountsTracksMaxInodeLevelAcrossMounts(t *testing.T) {
+	var output bytes.Buffer
+	d := newTestDaemonWithPlugins(t, &output)
+	d.config.MonitoredMounts = []config.MountConfig{
+		{Path: "/data", Label: "data"},
+		{Path: "/nix", Label: "nix"},
+	}
+	byPath := map[string]*monitor.DiskStats{
+		// Byte-critical primary with no inode pressure.
+		"/data": diskStats(1000, 40, 96),
+		// Healthy bytes but inode-critical secondary (the honey /nix case).
+		"/nix": diskStatsWithInodes(1000, 800, 20, 1000, 40, 96),
+	}
+	d.diskStats = func(path string) (*monitor.DiskStats, error) {
+		stats, ok := byPath[path]
+		if !ok {
+			t.Fatalf("unexpected path %q", path)
+		}
+		cp := *stats
+		cp.Path = path
+		return &cp, nil
+	}
+
+	assessment := d.assessMounts()
+	if assessment.Level != monitor.LevelCritical {
+		t.Fatalf("assessment.Level = %s, want critical (byte pressure on /data)", assessment.Level)
+	}
+	if assessment.InodeLevel != monitor.LevelCritical {
+		t.Fatalf("assessment.InodeLevel = %s, want critical (inode pressure on /nix)", assessment.InodeLevel)
+	}
+}
+
 func TestApplyTargetUsedPercentOverride(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.TargetFree = 70
@@ -670,6 +834,9 @@ func newTestDaemonWithPlugins(t *testing.T, output io.Writer, registeredPlugins 
 	t.Helper()
 
 	cfg := config.DefaultConfig()
+	stateRoot := t.TempDir()
+	cfg.LogFile = filepath.Join(stateRoot, "disk-cleanup.log")
+	cfg.Policy.StateFile = filepath.Join(stateRoot, "state.json")
 	registry := plugins.NewRegistry()
 	for _, plugin := range registeredPlugins {
 		registry.Register(plugin)
@@ -696,6 +863,16 @@ func diskStats(total, free uint64, usedPercent float64) *monitor.DiskStats {
 		FreePercent: 100 - usedPercent,
 		FreeGB:      float64(free) / (1024 * 1024 * 1024),
 	}
+}
+
+func diskStatsWithInodes(total, free uint64, usedPercent float64, inodesTotal, inodesFree uint64, inodesUsedPercent float64) *monitor.DiskStats {
+	stats := diskStats(total, free, usedPercent)
+	stats.InodesTotal = inodesTotal
+	stats.InodesFree = inodesFree
+	stats.InodesUsed = inodesTotal - inodesFree
+	stats.InodesUsedPercent = inodesUsedPercent
+	stats.InodesFreePercent = 100 - inodesUsedPercent
+	return stats
 }
 
 func sequenceDiskStats(t *testing.T, stats ...*monitor.DiskStats) func(string) (*monitor.DiskStats, error) {

--- a/monitor/disk.go
+++ b/monitor/disk.go
@@ -21,6 +21,16 @@ type DiskStats struct {
 	FreePercent float64
 	// FreeGB is free space in gigabytes
 	FreeGB float64
+	// InodesTotal is the total inode count reported by the filesystem
+	InodesTotal uint64
+	// InodesUsed is the number of allocated inodes
+	InodesUsed uint64
+	// InodesFree is the number of available inodes
+	InodesFree uint64
+	// InodesUsedPercent is the percentage of inodes used
+	InodesUsedPercent float64
+	// InodesFreePercent is the percentage of inodes free
+	InodesFreePercent float64
 }
 
 // GetDiskStats returns disk statistics for the specified path.
@@ -30,14 +40,25 @@ func GetDiskStats(path string) (*DiskStats, error) {
 		return nil, err
 	}
 
+	inodesUsed := usage.InodesUsed
+	if usage.InodesTotal > 0 && usage.InodesFree <= usage.InodesTotal {
+		inodesUsed = usage.InodesTotal - usage.InodesFree
+	}
+	inodesUsedPercent := inodeUsedPercent(usage.InodesTotal, inodesUsed, usage.InodesUsedPercent)
+
 	return &DiskStats{
-		Path:        path,
-		Total:       usage.Total,
-		Used:        usage.Used,
-		Free:        usage.Free,
-		UsedPercent: usage.UsedPercent,
-		FreePercent: 100.0 - usage.UsedPercent,
-		FreeGB:      float64(usage.Free) / (1024 * 1024 * 1024),
+		Path:              path,
+		Total:             usage.Total,
+		Used:              usage.Used,
+		Free:              usage.Free,
+		UsedPercent:       usage.UsedPercent,
+		FreePercent:       100.0 - usage.UsedPercent,
+		FreeGB:            float64(usage.Free) / (1024 * 1024 * 1024),
+		InodesTotal:       usage.InodesTotal,
+		InodesUsed:        inodesUsed,
+		InodesFree:        usage.InodesFree,
+		InodesUsedPercent: inodesUsedPercent,
+		InodesFreePercent: inodeFreePercent(usage.InodesTotal, inodesUsedPercent),
 	}, nil
 }
 
@@ -56,15 +77,44 @@ type DiskMonitor struct {
 	ThresholdAggressive float64
 	// ThresholdCritical percentage for critical level
 	ThresholdCritical float64
+	// ThresholdInodeWarning percentage for inode warning level
+	ThresholdInodeWarning float64
+	// ThresholdInodeModerate percentage for inode moderate level
+	ThresholdInodeModerate float64
+	// ThresholdInodeAggressive percentage for inode aggressive level
+	ThresholdInodeAggressive float64
+	// ThresholdInodeCritical percentage for inode critical level
+	ThresholdInodeCritical float64
 }
 
 // NewDiskMonitor creates a new disk monitor with the specified thresholds.
 func NewDiskMonitor(warning, moderate, aggressive, critical int) *DiskMonitor {
+	return NewDiskMonitorWithInodeThresholds(warning, moderate, aggressive, critical, warning, moderate, aggressive, critical)
+}
+
+// NewDiskMonitorWithInodeThresholds creates a disk monitor with independent byte and inode thresholds.
+func NewDiskMonitorWithInodeThresholds(warning, moderate, aggressive, critical, inodeWarning, inodeModerate, inodeAggressive, inodeCritical int) *DiskMonitor {
+	if inodeWarning <= 0 {
+		inodeWarning = warning
+	}
+	if inodeModerate <= 0 {
+		inodeModerate = moderate
+	}
+	if inodeAggressive <= 0 {
+		inodeAggressive = aggressive
+	}
+	if inodeCritical <= 0 {
+		inodeCritical = critical
+	}
 	return &DiskMonitor{
-		ThresholdWarning:    float64(warning),
-		ThresholdModerate:   float64(moderate),
-		ThresholdAggressive: float64(aggressive),
-		ThresholdCritical:   float64(critical),
+		ThresholdWarning:         float64(warning),
+		ThresholdModerate:        float64(moderate),
+		ThresholdAggressive:      float64(aggressive),
+		ThresholdCritical:        float64(critical),
+		ThresholdInodeWarning:    float64(inodeWarning),
+		ThresholdInodeModerate:   float64(inodeModerate),
+		ThresholdInodeAggressive: float64(inodeAggressive),
+		ThresholdInodeCritical:   float64(inodeCritical),
 	}
 }
 
@@ -104,19 +154,58 @@ func (l CleanupLevel) String() string {
 
 // CheckLevel determines the cleanup level needed based on disk usage.
 func (m *DiskMonitor) CheckLevel(stats *DiskStats) CleanupLevel {
-	if stats.UsedPercent >= m.ThresholdCritical {
+	byteLevel := m.CheckByteLevel(stats)
+	inodeLevel := m.CheckInodeLevel(stats)
+	if inodeLevel > byteLevel {
+		return inodeLevel
+	}
+	return byteLevel
+}
+
+// CheckByteLevel determines the cleanup level needed based on byte usage.
+func (m *DiskMonitor) CheckByteLevel(stats *DiskStats) CleanupLevel {
+	return levelForPercent(stats.UsedPercent, m.ThresholdWarning, m.ThresholdModerate, m.ThresholdAggressive, m.ThresholdCritical)
+}
+
+// CheckInodeLevel determines the cleanup level needed based on inode usage.
+func (m *DiskMonitor) CheckInodeLevel(stats *DiskStats) CleanupLevel {
+	if stats.InodesTotal == 0 {
+		return LevelNone
+	}
+	return levelForPercent(stats.InodesUsedPercent, m.ThresholdInodeWarning, m.ThresholdInodeModerate, m.ThresholdInodeAggressive, m.ThresholdInodeCritical)
+}
+
+func levelForPercent(usedPercent, warning, moderate, aggressive, critical float64) CleanupLevel {
+	if usedPercent >= critical {
 		return LevelCritical
 	}
-	if stats.UsedPercent >= m.ThresholdAggressive {
+	if usedPercent >= aggressive {
 		return LevelAggressive
 	}
-	if stats.UsedPercent >= m.ThresholdModerate {
+	if usedPercent >= moderate {
 		return LevelModerate
 	}
-	if stats.UsedPercent >= m.ThresholdWarning {
+	if usedPercent >= warning {
 		return LevelWarning
 	}
 	return LevelNone
+}
+
+func inodeFreePercent(total uint64, usedPercent float64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return 100.0 - usedPercent
+}
+
+func inodeUsedPercent(total uint64, used uint64, reported float64) float64 {
+	if total == 0 {
+		return 0
+	}
+	if used > 0 {
+		return float64(used) / float64(total) * 100
+	}
+	return reported
 }
 
 // Check performs a disk check and returns the current stats and required level.

--- a/monitor/disk_test.go
+++ b/monitor/disk_test.go
@@ -43,6 +43,71 @@ func TestDiskMonitorCheckLevel(t *testing.T) {
 	}
 }
 
+func TestDiskMonitorCheckLevelUsesInodePressure(t *testing.T) {
+	mon := NewDiskMonitor(80, 85, 90, 95)
+
+	stats := &DiskStats{
+		Path:              "/nix",
+		UsedPercent:       60,
+		FreePercent:       40,
+		InodesTotal:       1000,
+		InodesUsed:        960,
+		InodesFree:        40,
+		InodesUsedPercent: 96,
+		InodesFreePercent: 4,
+	}
+
+	if got := mon.CheckByteLevel(stats); got != LevelNone {
+		t.Fatalf("byte level = %s, want none", got)
+	}
+	if got := mon.CheckInodeLevel(stats); got != LevelCritical {
+		t.Fatalf("inode level = %s, want critical", got)
+	}
+	if got := mon.CheckLevel(stats); got != LevelCritical {
+		t.Fatalf("combined level = %s, want critical", got)
+	}
+}
+
+func TestDiskMonitorCheckLevelIgnoresUnavailableInodeStats(t *testing.T) {
+	mon := NewDiskMonitor(80, 85, 90, 95)
+	stats := &DiskStats{
+		UsedPercent:       60,
+		InodesUsedPercent: 99,
+	}
+
+	if got := mon.CheckInodeLevel(stats); got != LevelNone {
+		t.Fatalf("inode level = %s, want none when inode totals are unavailable", got)
+	}
+	if got := mon.CheckLevel(stats); got != LevelNone {
+		t.Fatalf("combined level = %s, want none", got)
+	}
+}
+
+func TestDiskMonitorCustomInodeThresholds(t *testing.T) {
+	mon := NewDiskMonitorWithInodeThresholds(80, 85, 90, 95, 50, 60, 70, 80)
+	stats := &DiskStats{
+		UsedPercent:       10,
+		InodesTotal:       100,
+		InodesUsedPercent: 75,
+	}
+
+	if got := mon.CheckLevel(stats); got != LevelAggressive {
+		t.Fatalf("combined level = %s, want aggressive", got)
+	}
+}
+
+func TestInodeUsedPercentPrefersCountedInodes(t *testing.T) {
+	if got := inodeUsedPercent(1000, 990, 0); got != 99 {
+		t.Fatalf("inode used percent = %v, want 99", got)
+	}
+	if got := inodeUsedPercent(1000, 0, 42); got != 42 {
+		t.Fatalf("inode used percent fallback = %v, want 42", got)
+	}
+	if got := inodeUsedPercent(0, 99, 42); got != 0 {
+		t.Fatalf("inode used percent unavailable = %v, want 0", got)
+	}
+}
+
 func TestCleanupLevelString(t *testing.T) {
 	tests := []struct {
 		level    CleanupLevel
@@ -88,6 +153,14 @@ func TestDiskStats(t *testing.T) {
 	if stats.FreePercent < 0 || stats.FreePercent > 100 {
 		t.Errorf("FreePercent %v out of range [0,100]", stats.FreePercent)
 	}
+	if stats.InodesTotal > 0 {
+		if stats.InodesUsedPercent < 0 || stats.InodesUsedPercent > 100 {
+			t.Errorf("InodesUsedPercent %v out of range [0,100]", stats.InodesUsedPercent)
+		}
+		if stats.InodesFreePercent < 0 || stats.InodesFreePercent > 100 {
+			t.Errorf("InodesFreePercent %v out of range [0,100]", stats.InodesFreePercent)
+		}
+	}
 
 	// UsedPercent + FreePercent should be ~100
 	total := stats.UsedPercent + stats.FreePercent
@@ -129,5 +202,17 @@ func TestNewDiskMonitor(t *testing.T) {
 	}
 	if mon.ThresholdCritical != 95 {
 		t.Errorf("ThresholdCritical = %v, want 95", mon.ThresholdCritical)
+	}
+	if mon.ThresholdInodeWarning != 70 {
+		t.Errorf("ThresholdInodeWarning = %v, want 70", mon.ThresholdInodeWarning)
+	}
+	if mon.ThresholdInodeModerate != 80 {
+		t.Errorf("ThresholdInodeModerate = %v, want 80", mon.ThresholdInodeModerate)
+	}
+	if mon.ThresholdInodeAggressive != 90 {
+		t.Errorf("ThresholdInodeAggressive = %v, want 90", mon.ThresholdInodeAggressive)
+	}
+	if mon.ThresholdInodeCritical != 95 {
+		t.Errorf("ThresholdInodeCritical = %v, want 95", mon.ThresholdInodeCritical)
 	}
 }

--- a/monitor/monitor_pbt_test.go
+++ b/monitor/monitor_pbt_test.go
@@ -7,6 +7,44 @@ import (
 	"pgregory.net/rapid"
 )
 
+// TestCheckLevelIsMaxOfByteAndInode verifies the combined level is always the
+// higher of the byte-driven and inode-driven levels across the joint space,
+// including filesystems that report no inode totals.
+func TestCheckLevelIsMaxOfByteAndInode(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		bw := rapid.IntRange(50, 70).Draw(t, "byte_warn")
+		bm := rapid.IntRange(bw+1, 85).Draw(t, "byte_mod")
+		ba := rapid.IntRange(bm+1, 94).Draw(t, "byte_agg")
+		bc := rapid.IntRange(ba+1, 99).Draw(t, "byte_crit")
+		iw := rapid.IntRange(50, 70).Draw(t, "inode_warn")
+		im := rapid.IntRange(iw+1, 85).Draw(t, "inode_mod")
+		ia := rapid.IntRange(im+1, 94).Draw(t, "inode_agg")
+		ic := rapid.IntRange(ia+1, 99).Draw(t, "inode_crit")
+
+		mon := NewDiskMonitorWithInodeThresholds(bw, bm, ba, bc, iw, im, ia, ic)
+
+		stats := &DiskStats{
+			UsedPercent: rapid.Float64Range(0, 100).Draw(t, "byte_pct"),
+			// InodesTotal of 0 must make the inode dimension contribute LevelNone.
+			InodesTotal:       rapid.Uint64Range(0, 100000).Draw(t, "inodes_total"),
+			InodesUsedPercent: rapid.Float64Range(0, 100).Draw(t, "inode_pct"),
+		}
+
+		byteLevel := mon.CheckByteLevel(stats)
+		inodeLevel := mon.CheckInodeLevel(stats)
+		want := byteLevel
+		if inodeLevel > want {
+			want = inodeLevel
+		}
+		if got := mon.CheckLevel(stats); got != want {
+			t.Fatalf("CheckLevel = %s, want max(byte=%s, inode=%s)", got, byteLevel, inodeLevel)
+		}
+		if stats.InodesTotal == 0 && inodeLevel != LevelNone {
+			t.Fatalf("inode level = %s with zero inode total, want none", inodeLevel)
+		}
+	})
+}
+
 // TestThresholdMonotonicity verifies higher usage never results in lower level.
 func TestThresholdMonotonicity(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
@@ -26,6 +64,29 @@ func TestThresholdMonotonicity(t *testing.T) {
 
 			if level < prevLevel {
 				t.Fatalf("level decreased from %d to %d at usage %d%%", prevLevel, level, usage)
+			}
+			prevLevel = level
+		}
+	})
+}
+
+// TestInodeThresholdMonotonicity verifies higher inode usage never results in lower level.
+func TestInodeThresholdMonotonicity(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		warn := rapid.IntRange(50, 70).Draw(t, "warn")
+		mod := rapid.IntRange(warn+1, 85).Draw(t, "mod")
+		agg := rapid.IntRange(mod+1, 94).Draw(t, "agg")
+		crit := rapid.IntRange(agg+1, 99).Draw(t, "crit")
+
+		mon := NewDiskMonitorWithInodeThresholds(80, 85, 90, 95, warn, mod, agg, crit)
+
+		prevLevel := LevelNone
+		for usage := 0; usage <= 100; usage++ {
+			stats := &DiskStats{InodesTotal: 1000, InodesUsedPercent: float64(usage)}
+			level := mon.CheckInodeLevel(stats)
+
+			if level < prevLevel {
+				t.Fatalf("inode level decreased from %d to %d at usage %d%%", prevLevel, level, usage)
 			}
 			prevLevel = level
 		}

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -13,6 +13,9 @@ policy:
   cooldown: 30m
   cooldown_bypass_level: critical
   state_file: /var/lib/tinyland-cleanup/state.json
+  # Back off inode-only critical escalation to the cooldown cadence after this
+  # many consecutive cycles fail to relieve inode pressure (0 = default 3).
+  inode_no_progress_limit: 3
 
 thresholds:
   warning: 80

--- a/packaging/linux/config.yaml
+++ b/packaging/linux/config.yaml
@@ -20,6 +20,12 @@ thresholds:
   aggressive: 90
   critical: 95
 
+inode_thresholds:
+  warning: 80
+  moderate: 85
+  aggressive: 90
+  critical: 95
+
 enable:
   cache: true
   nix_gc: true

--- a/report_text.go
+++ b/report_text.go
@@ -63,6 +63,24 @@ func writeTextReport(w io.Writer, report cycleReport) error {
 			return err
 		}
 	}
+	if report.HostInodesTotal > 0 {
+		after := "not measured"
+		afterUsed := report.HostInodesUsedPercentBefore
+		if report.HostFreeAfterBytes > 0 || report.HostInodesFreeAfter > 0 || report.HostInodesUsedPercentAfter > 0 {
+			after = formatCount(report.HostInodesFreeAfter)
+			afterUsed = report.HostInodesUsedPercentAfter
+		}
+		if _, err := fmt.Fprintf(w, "host inodes: %.1f%% used before, %.1f%% used after, %s free before, %s free after, delta %s, level %s\n",
+			report.HostInodesUsedPercentBefore,
+			afterUsed,
+			formatCount(report.HostInodesFreeBefore),
+			after,
+			formatSignedCount(report.HostInodesFreeDelta),
+			report.HostInodeLevel,
+		); err != nil {
+			return err
+		}
+	}
 
 	if report.TargetUsedPercent > 0 {
 		if _, err := fmt.Fprintf(w, "target: <=%d%% used, need %s free, deficit %s\n",
@@ -86,6 +104,12 @@ func writeTextReport(w io.Writer, report cycleReport) error {
 			return err
 		}
 	}
+	if report.InodeBackoff {
+		if _, err := fmt.Fprintf(w, "inode backoff: pressure unrelieved after %d cycles, applying cooldown\n",
+			report.InodeNoProgressCount); err != nil {
+			return err
+		}
+	}
 
 	if len(report.Mounts) > 0 {
 		if _, err := fmt.Fprintln(w, "mounts:"); err != nil {
@@ -102,13 +126,32 @@ func writeTextReport(w io.Writer, report cycleReport) error {
 				}
 				continue
 			}
-			if _, err := fmt.Fprintf(w, "- %s (%s): %.1f%% used, %s free, level %s\n",
+			inodeStatus := "inodes unavailable"
+			if mount.InodesTotal > 0 {
+				inodeStatus = fmt.Sprintf("%.1f%% inodes used, %s inodes free",
+					mount.InodesUsedPercent,
+					formatCount(mount.InodesFree))
+			}
+			if _, err := fmt.Fprintf(w, "- %s (%s): %.1f%% bytes used, %s free, %s, level %s",
 				label,
 				mount.Path,
 				mount.UsedPercent,
 				formatByteCount(int64(mount.FreeBytes)),
+				inodeStatus,
 				mount.Level,
 			); err != nil {
+				return err
+			}
+			if mount.ByteLevel != "" || mount.InodeLevel != "" {
+				inodeLevel := mount.InodeLevel
+				if inodeLevel == "" {
+					inodeLevel = "n/a"
+				}
+				if _, err := fmt.Fprintf(w, " (bytes %s, inodes %s)", mount.ByteLevel, inodeLevel); err != nil {
+					return err
+				}
+			}
+			if _, err := fmt.Fprintln(w); err != nil {
 				return err
 			}
 		}
@@ -341,6 +384,32 @@ func formatSignedByteCount(bytes int64) string {
 		return "+" + formatByteCount(bytes)
 	}
 	return "0 B"
+}
+
+func formatSignedCount(count int64) string {
+	if count < 0 {
+		return "-" + formatCount(uint64(-count))
+	}
+	if count > 0 {
+		return "+" + formatCount(uint64(count))
+	}
+	return "0"
+}
+
+func formatCount(count uint64) string {
+	value := float64(count)
+	// Use SI-style magnitude suffixes for inode counts. "G" (not "B") denotes
+	// billions so a count is never confused with a byte size in the same report.
+	units := []string{"", "K", "M", "G", "T"}
+	unit := 0
+	for value >= 1000 && unit < len(units)-1 {
+		value /= 1000
+		unit++
+	}
+	if unit == 0 {
+		return fmt.Sprintf("%d", count)
+	}
+	return fmt.Sprintf("%.1f%s", value, units[unit])
 }
 
 func formatByteCount(bytes int64) string {

--- a/state.go
+++ b/state.go
@@ -15,6 +15,10 @@ const cleanupStateVersion = 1
 type cleanupState struct {
 	Version int                          `json:"version"`
 	Plugins map[string]pluginStateRecord `json:"plugins"`
+	// Inodes tracks per-monitor-path inode reclaim progress so the daemon can
+	// detect inode pressure that repeated cleanup cycles fail to relieve and
+	// back off instead of churning every poll interval (TIN-2170).
+	Inodes map[string]inodeProgressRecord `json:"inodes,omitempty"`
 }
 
 type pluginStateRecord struct {
@@ -26,10 +30,22 @@ type pluginStateRecord struct {
 	LastError        string `json:"last_error,omitempty"`
 }
 
+// inodeProgressRecord records the inode state observed at the end of the most
+// recent cleanup cycle for one monitored path, plus a counter of consecutive
+// cycles that did not relieve inode pressure.
+type inodeProgressRecord struct {
+	LastRun               string  `json:"last_run"`
+	LastInodesFree        uint64  `json:"last_inodes_free"`
+	LastInodesUsedPercent float64 `json:"last_inodes_used_percent"`
+	LastInodeLevel        string  `json:"last_inode_level"`
+	NoProgressCount       int     `json:"no_progress_count"`
+}
+
 func newCleanupState() *cleanupState {
 	return &cleanupState{
 		Version: cleanupStateVersion,
 		Plugins: map[string]pluginStateRecord{},
+		Inodes:  map[string]inodeProgressRecord{},
 	}
 }
 
@@ -54,6 +70,9 @@ func loadCleanupState(path string) (*cleanupState, error) {
 	}
 	if state.Plugins == nil {
 		state.Plugins = map[string]pluginStateRecord{}
+	}
+	if state.Inodes == nil {
+		state.Inodes = map[string]inodeProgressRecord{}
 	}
 	if state.Version == 0 {
 		state.Version = cleanupStateVersion
@@ -116,4 +135,37 @@ func (s *cleanupState) recordPluginRun(plugin string, level plugins.CleanupLevel
 		record.LastError = result.Error.Error()
 	}
 	s.Plugins[plugin] = record
+}
+
+// inodeNoProgressCount returns the number of consecutive recent cleanup cycles
+// that failed to relieve inode pressure on path.
+func (s *cleanupState) inodeNoProgressCount(path string) int {
+	if s == nil || s.Inodes == nil || path == "" {
+		return 0
+	}
+	return s.Inodes[path].NoProgressCount
+}
+
+// recordInodeProgress updates the inode no-progress tracker for path. When
+// improved is true (the cycle increased free inodes or cleared inode pressure)
+// the counter resets; otherwise it increments so the daemon can detect
+// unrelievable inode pressure and back off.
+func (s *cleanupState) recordInodeProgress(path string, inodesFree uint64, usedPercent float64, level string, now time.Time, improved bool) {
+	if s == nil || path == "" {
+		return
+	}
+	if s.Inodes == nil {
+		s.Inodes = map[string]inodeProgressRecord{}
+	}
+	record := s.Inodes[path]
+	if improved {
+		record.NoProgressCount = 0
+	} else {
+		record.NoProgressCount++
+	}
+	record.LastRun = now.UTC().Format(time.RFC3339)
+	record.LastInodesFree = inodesFree
+	record.LastInodesUsedPercent = usedPercent
+	record.LastInodeLevel = level
+	s.Inodes[path] = record
 }

--- a/state_test.go
+++ b/state_test.go
@@ -8,6 +8,54 @@ import (
 	"github.com/Jesssullivan/tinyland-cleanup/plugins"
 )
 
+func TestInodeProgressTracking(t *testing.T) {
+	now := time.Now()
+	state := newCleanupState()
+
+	if got := state.inodeNoProgressCount("/nix"); got != 0 {
+		t.Fatalf("fresh state count = %d, want 0", got)
+	}
+
+	// Three consecutive cycles with no inode relief advance the counter.
+	for i := 1; i <= 3; i++ {
+		state.recordInodeProgress("/nix", 40, 96, "critical", now, false)
+		if got := state.inodeNoProgressCount("/nix"); got != i {
+			t.Fatalf("after %d no-progress cycles count = %d, want %d", i, got, i)
+		}
+	}
+
+	// A cycle that frees inodes resets the counter.
+	state.recordInodeProgress("/nix", 500, 50, "warning", now, true)
+	if got := state.inodeNoProgressCount("/nix"); got != 0 {
+		t.Fatalf("after improvement count = %d, want 0", got)
+	}
+
+	// Tracking is independent per path.
+	state.recordInodeProgress("/home", 10, 99, "critical", now, false)
+	if got := state.inodeNoProgressCount("/home"); got != 1 {
+		t.Fatalf("/home count = %d, want 1", got)
+	}
+	if got := state.inodeNoProgressCount("/nix"); got != 0 {
+		t.Fatalf("/nix count = %d, want 0 (unchanged)", got)
+	}
+
+	// Records survive a save/load round trip.
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := saveCleanupState(path, state); err != nil {
+		t.Fatalf("saveCleanupState: %v", err)
+	}
+	loaded, err := loadCleanupState(path)
+	if err != nil {
+		t.Fatalf("loadCleanupState: %v", err)
+	}
+	if got := loaded.inodeNoProgressCount("/home"); got != 1 {
+		t.Fatalf("loaded /home count = %d, want 1", got)
+	}
+	if rec := loaded.Inodes["/nix"]; rec.LastInodesFree != 500 || rec.LastInodeLevel != "warning" {
+		t.Fatalf("loaded /nix record = %+v, want free=500 level=warning", rec)
+	}
+}
+
 func TestCleanupStateRoundTripAndCooldown(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state.json")
 	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary\n- Adds inode usage thresholds alongside byte thresholds, including per-mount inode warning/critical overrides.\n- Reports inode totals/free/used percent and separates byte vs inode pressure in cycle output.\n- Prevents target-free short-circuiting while inode pressure remains, and adds inode no-progress backoff state.\n- Updates operator docs and packaged sample configs.\n\n## Validation\n- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS='-mod=vendor -count=1' go test ./...\n- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...