### PR TITLE
cache: retry transient Darwin cache removal failures

### DIFF
--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -1390,7 +1390,7 @@ func (p *CachePlugin) cleanupDarwinDeveloperCacheTargets(ctx context.Context, le
 			sizeBefore = getDirAllocatedBytes(target.Path)
 		}
 		result.EstimatedBytesFreed += sizeBefore
-		if err := os.RemoveAll(target.Path); err != nil {
+		if err := removeDarwinDeveloperCacheTarget(target.Path); err != nil {
 			result.Error = err
 			logger.Warn("failed to delete Darwin developer cache target", "path", target.Path, "type", target.Type, "error", err)
 			continue
@@ -1408,6 +1408,28 @@ func (p *CachePlugin) cleanupDarwinDeveloperCacheTargets(ctx context.Context, le
 			"freed_mb", freed/(1024*1024))
 	}
 	return result
+}
+
+func removeDarwinDeveloperCacheTarget(path string) error {
+	return removeAllDarwinCacheTargetWithRetry(path, os.RemoveAll, time.Sleep, 3)
+}
+
+func removeAllDarwinCacheTargetWithRetry(path string, removeAll func(string) error, sleep func(time.Duration), attempts int) error {
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err = removeAll(path)
+		if err == nil || !pathExists(path) {
+			return nil
+		}
+		if attempt < attempts {
+			sleep(time.Duration(attempt) * 100 * time.Millisecond)
+		}
+	}
+	return err
 }
 
 func listDarwinCacheEntries(root string) []darwinCacheEntry {

--- a/plugins/darwin_dev_cache_test.go
+++ b/plugins/darwin_dev_cache_test.go
@@ -229,6 +229,29 @@ func TestCleanupDarwinDeveloperCacheTargetsDeletesOnlyEligibleTargets(t *testing
 	}
 }
 
+func TestRemoveAllDarwinCacheTargetWithRetryHandlesTransientNonEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeFileAt(t, filepath.Join(dir, "cache.bin"), "cache")
+
+	attempts := 0
+	err := removeAllDarwinCacheTargetWithRetry(dir, func(path string) error {
+		attempts++
+		if attempts == 1 {
+			return os.ErrInvalid
+		}
+		return os.RemoveAll(path)
+	}, func(time.Duration) {}, 3)
+	if err != nil {
+		t.Fatalf("expected retry to remove cache target, got %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected exactly two remove attempts, got %d", attempts)
+	}
+	if pathExists(dir) {
+		t.Fatalf("expected cache directory to be removed")
+	}
+}
+
 func TestCacheCleanupDarwinDevCachesDisabledEnforcementSkipsLegacyMutation(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary
- retry Darwin developer-cache RemoveAll calls when cache writers race deletion and leave a transient non-empty directory
- keep the retry bounded and scoped to typed Darwin dev-cache targets
- add a deterministic regression test for retry behavior

## Validation
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS="-mod=vendor -count=1" go test ./plugins -run "Test(RemoveAllDarwinCacheTargetWithRetryHandlesTransientNonEmptyDirectory|CleanupDarwinDeveloperCacheTargetsDeletesOnlyEligibleTargets|CacheCleanupDarwinDevCachesUsesTypedTargetsWhenEnforced)"
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS="-mod=vendor -count=1" go test ./...
- env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS="-mod=vendor" go vet ./...

Observed on Neo during critical cleanup: uv cache deletion returned `unlinkat ... directory not empty`; this keeps the cache plugin from failing the whole typed-cache cleanup path on a transient writer race.