### PR TITLE
dev-artifacts: manage stale agent state

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -337,6 +337,18 @@ type DevArtifactsConfig struct {
 	ZigArtifacts bool `yaml:"zig_artifacts"`
 	// AgentWorktreeArtifacts enables cleanup of generated outputs inside agent worktree roots.
 	AgentWorktreeArtifacts bool `yaml:"agent_worktree_artifacts"`
+	// AgentWorktreeRootCleanup enables deletion of stale top-level agent worktree roots.
+	AgentWorktreeRootCleanup bool `yaml:"agent_worktree_root_cleanup"`
+	// AgentWorktreeRoots are top-level directories containing agent scratch worktrees.
+	AgentWorktreeRoots []string `yaml:"agent_worktree_roots"`
+	// AgentWorktreeStaleAfter is the age after which top-level agent worktrees are cleanup candidates.
+	AgentWorktreeStaleAfter string `yaml:"agent_worktree_stale_after"`
+	// AgentTranscriptCompression enables gzip compression for stale agent transcript JSONL files.
+	AgentTranscriptCompression bool `yaml:"agent_transcript_compression"`
+	// AgentTranscriptRoots are directories scanned recursively for agent transcript JSONL files.
+	AgentTranscriptRoots []string `yaml:"agent_transcript_roots"`
+	// AgentTranscriptCompressAfter is the age after which JSONL transcripts are compressed.
+	AgentTranscriptCompressAfter string `yaml:"agent_transcript_compress_after"`
 	// PnpmStore enables pnpm store prune for the rebuildable global package store.
 	PnpmStore bool `yaml:"pnpm_store"`
 	// GoBuildCache enables Go build cache cleanup
@@ -540,29 +552,37 @@ func DefaultConfig() *Config {
 			MinFileSizeMB:  10,
 		},
 		DevArtifacts: DevArtifactsConfig{
-			ScanPaths:               defaultScanPaths,
-			ScanMaxDuration:         "30s",
-			ScanMaxEntries:          250000,
-			TempArtifacts:           true,
-			TempScanPaths:           defaultTempScanPaths,
-			TempScanMaxRoots:        128,
-			TempArtifactMinMB:       256,
-			TempArtifactStaleAfter:  "6h",
-			NixTempRoots:            true,
-			NixTempRootMinMB:        1,
-			NixTempRootStaleAfter:   "24h",
-			NodeModules:             true,
-			PythonVenvs:             true,
-			RustTargets:             true,
-			ZigArtifacts:            true,
-			AgentWorktreeArtifacts:  false,
-			PnpmStore:               false,
-			GoBuildCache:            true,
-			HaskellCache:            true,
-			LMStudioModels:          false,
-			LargeLocalArtifacts:     true,
-			LargeLocalArtifactMinMB: 1024,
-			ProtectPaths:            []string{},
+			ScanPaths:                defaultScanPaths,
+			ScanMaxDuration:          "30s",
+			ScanMaxEntries:           250000,
+			TempArtifacts:            true,
+			TempScanPaths:            defaultTempScanPaths,
+			TempScanMaxRoots:         128,
+			TempArtifactMinMB:        256,
+			TempArtifactStaleAfter:   "6h",
+			NixTempRoots:             true,
+			NixTempRootMinMB:         1,
+			NixTempRootStaleAfter:    "24h",
+			NodeModules:              true,
+			PythonVenvs:              true,
+			RustTargets:              true,
+			ZigArtifacts:             true,
+			AgentWorktreeArtifacts:   false,
+			AgentWorktreeRootCleanup: false,
+			AgentWorktreeRoots: []string{
+				filepath.Join(home, ".claude", "worktrees"),
+			},
+			AgentWorktreeStaleAfter:      "14d",
+			AgentTranscriptCompression:   false,
+			AgentTranscriptRoots:         []string{filepath.Join(home, ".codex", "sessions")},
+			AgentTranscriptCompressAfter: "14d",
+			PnpmStore:                    false,
+			GoBuildCache:                 true,
+			HaskellCache:                 true,
+			LMStudioModels:               false,
+			LargeLocalArtifacts:          true,
+			LargeLocalArtifactMinMB:      1024,
+			ProtectPaths:                 []string{},
 		},
 		DarwinDevCaches: DarwinDevCachesConfig{
 			Enabled:    runtime.GOOS == "darwin",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -385,6 +385,24 @@ func TestDevArtifactsConfigDefaults(t *testing.T) {
 	if cfg.DevArtifacts.AgentWorktreeArtifacts {
 		t.Error("DevArtifacts.AgentWorktreeArtifacts should be false by default")
 	}
+	if cfg.DevArtifacts.AgentWorktreeRootCleanup {
+		t.Error("DevArtifacts.AgentWorktreeRootCleanup should be false by default")
+	}
+	if len(cfg.DevArtifacts.AgentWorktreeRoots) == 0 {
+		t.Error("DevArtifacts.AgentWorktreeRoots should include default roots")
+	}
+	if cfg.DevArtifacts.AgentWorktreeStaleAfter != "14d" {
+		t.Errorf("DevArtifacts.AgentWorktreeStaleAfter should default to 14d, got %q", cfg.DevArtifacts.AgentWorktreeStaleAfter)
+	}
+	if cfg.DevArtifacts.AgentTranscriptCompression {
+		t.Error("DevArtifacts.AgentTranscriptCompression should be false by default")
+	}
+	if len(cfg.DevArtifacts.AgentTranscriptRoots) == 0 {
+		t.Error("DevArtifacts.AgentTranscriptRoots should include default roots")
+	}
+	if cfg.DevArtifacts.AgentTranscriptCompressAfter != "14d" {
+		t.Errorf("DevArtifacts.AgentTranscriptCompressAfter should default to 14d, got %q", cfg.DevArtifacts.AgentTranscriptCompressAfter)
+	}
 	if cfg.DevArtifacts.PnpmStore {
 		t.Error("DevArtifacts.PnpmStore should be false by default")
 	}
@@ -698,6 +716,15 @@ dev_artifacts:
   rust_targets: false
   go_build_cache: true
   agent_worktree_artifacts: false
+  agent_worktree_root_cleanup: true
+  agent_worktree_roots:
+    - ~/.claude/worktrees
+    - ~/git/*/.claude/worktrees
+  agent_worktree_stale_after: 7d
+  agent_transcript_compression: true
+  agent_transcript_roots:
+    - ~/.codex/sessions
+  agent_transcript_compress_after: 7d
   pnpm_store: false
   haskell_cache: false
   lmstudio_models: true
@@ -843,6 +870,24 @@ darwin_dev_caches:
 	}
 	if cfg.DevArtifacts.AgentWorktreeArtifacts {
 		t.Error("DevArtifacts.AgentWorktreeArtifacts should be false per config")
+	}
+	if !cfg.DevArtifacts.AgentWorktreeRootCleanup {
+		t.Error("DevArtifacts.AgentWorktreeRootCleanup should be true per config")
+	}
+	if len(cfg.DevArtifacts.AgentWorktreeRoots) != 2 {
+		t.Errorf("expected 2 agent worktree roots, got %d", len(cfg.DevArtifacts.AgentWorktreeRoots))
+	}
+	if cfg.DevArtifacts.AgentWorktreeStaleAfter != "7d" {
+		t.Errorf("expected agent worktree stale policy 7d, got %q", cfg.DevArtifacts.AgentWorktreeStaleAfter)
+	}
+	if !cfg.DevArtifacts.AgentTranscriptCompression {
+		t.Error("DevArtifacts.AgentTranscriptCompression should be true per config")
+	}
+	if len(cfg.DevArtifacts.AgentTranscriptRoots) != 1 {
+		t.Errorf("expected 1 agent transcript root, got %d", len(cfg.DevArtifacts.AgentTranscriptRoots))
+	}
+	if cfg.DevArtifacts.AgentTranscriptCompressAfter != "7d" {
+		t.Errorf("expected agent transcript compression policy 7d, got %q", cfg.DevArtifacts.AgentTranscriptCompressAfter)
 	}
 	if cfg.DevArtifacts.PnpmStore {
 		t.Error("DevArtifacts.PnpmStore should be false per config")

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -234,6 +234,17 @@ dev_artifacts:
   # Host-specific pressure profiles can opt into these global/agent-local
   # surfaces after reviewing active-process protection and store semantics.
   agent_worktree_artifacts: false
+  # Stale top-level agent scratch worktrees are local-only generated state.
+  # Keep whole-root deletion opt-in and critical-only.
+  agent_worktree_root_cleanup: false
+  agent_worktree_roots:
+    - ~/.claude/worktrees
+  agent_worktree_stale_after: 14d
+  # Compress old JSONL transcripts instead of deleting session history.
+  agent_transcript_compression: false
+  agent_transcript_roots:
+    - ~/.codex/sessions
+  agent_transcript_compress_after: 14d
   pnpm_store: false
   go_build_cache: true
   haskell_cache: true

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -6,6 +6,7 @@
 package plugins
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/xml"
 	"errors"
@@ -277,6 +278,12 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 			p.planTemporaryGeneratedArtifacts(scanCtx, expanded, tempMinBytes, tempStaleAfter, nodeAge, venvAge, rustAge, zigAge, mutates, daCfg, active, activeTempRoots, tracker, &targets, scanBudget)
 		}
 	}
+	if daCfg.AgentTranscriptCompression {
+		p.planAgentTranscripts(scanCtx, home, parseNixPolicyDuration(daCfg.AgentTranscriptCompressAfter, 14*24*time.Hour), mutates, daCfg, &targets, scanBudget)
+	}
+	if daCfg.AgentWorktreeRootCleanup {
+		p.planAgentWorktreeRoots(scanCtx, home, level, daCfg, &targets, scanBudget)
+	}
 	for _, scanPath := range daCfg.ScanPaths {
 		expanded := expandHome(scanPath, home)
 		if !pathExistsAndIsDir(expanded) {
@@ -324,7 +331,7 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 
 	var estimated int64
 	for _, target := range targets {
-		if target.Action == "delete" || target.Action == "clean-cache" {
+		if target.Action == "delete" || target.Action == "compress" || target.Action == "clean-cache" {
 			estimated += target.Bytes
 		}
 	}
@@ -402,6 +409,24 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 				return result
 			}
 		}
+	}
+	if daCfg.AgentTranscriptCompression {
+		freed := p.compressAgentTranscripts(scanCtx, home, parseNixPolicyDuration(daCfg.AgentTranscriptCompressAfter, 14*24*time.Hour), daCfg, logger, scanBudget)
+		result.BytesFreed += freed
+		if freed > 0 {
+			result.ItemsCleaned++
+		}
+	}
+	if daCfg.AgentWorktreeRootCleanup {
+		freed := p.cleanAgentWorktreeRoots(scanCtx, home, level, daCfg, logger, scanBudget)
+		result.BytesFreed += freed
+		if freed > 0 {
+			result.ItemsCleaned++
+		}
+	}
+	if scanBudget.exhausted() {
+		logger.Warn("stopping dev artifact cleanup because scan budget was exhausted", "truncated_paths", strings.Join(scanBudget.truncatedDetails(), "; "))
+		return result
 	}
 
 	// Scan configured paths for dev artifacts
@@ -575,6 +600,19 @@ func (p *DevArtifactsPlugin) planAgentWorktreeArtifacts(ctx context.Context, hom
 	}
 }
 
+func (p *DevArtifactsPlugin) planAgentTranscripts(ctx context.Context, home string, staleAfter time.Duration, mutates bool, daCfg config.DevArtifactsConfig, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
+	p.forEachAgentTranscript(ctx, home, staleAfter, daCfg, func(path string, info os.FileInfo, activeReason string) {
+		*targets = append(*targets, p.agentTranscriptTarget(home, path, info.Size(), staleAfter, mutates, activeReason))
+	}, budgets...)
+}
+
+func (p *DevArtifactsPlugin) planAgentWorktreeRoots(ctx context.Context, home string, level CleanupLevel, daCfg config.DevArtifactsConfig, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
+	staleAfter := parseNixPolicyDuration(daCfg.AgentWorktreeStaleAfter, 14*24*time.Hour)
+	p.forEachAgentWorktreeRoot(ctx, home, staleAfter, daCfg, func(path string, info os.FileInfo, bytes int64, activeReason string) {
+		*targets = append(*targets, p.agentWorktreeRootTarget(path, bytes, info.ModTime(), staleAfter, time.Now(), level >= LevelCritical, p.isProtected(path, daCfg.ProtectPaths), activeReason))
+	}, budgets...)
+}
+
 func (p *DevArtifactsPlugin) planLargeLocalArtifacts(ctx context.Context, scanPath string, minBytes int64, protectPaths []string, mountedImages map[string]string, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
 	budget := optionalDevArtifactScanBudget(budgets)
 	p.findLargeLocalArtifacts(ctx, scanPath, minBytes, protectPaths, mountedImages, func(target CleanupTarget) {
@@ -586,6 +624,175 @@ func agentWorktreeRoots(home string) []string {
 	return []string{
 		filepath.Join(home, ".claude", "worktrees"),
 	}
+}
+
+func configuredAgentWorktreeRoots(home string, daCfg config.DevArtifactsConfig) []string {
+	roots := daCfg.AgentWorktreeRoots
+	if len(roots) == 0 {
+		roots = agentWorktreeRoots(home)
+	}
+	return expandConfiguredAgentRoots(home, roots)
+}
+
+func configuredAgentTranscriptRoots(home string, daCfg config.DevArtifactsConfig) []string {
+	roots := daCfg.AgentTranscriptRoots
+	if len(roots) == 0 {
+		roots = []string{filepath.Join(home, ".codex", "sessions")}
+	}
+	return expandConfiguredAgentRoots(home, roots)
+}
+
+func expandConfiguredAgentRoots(home string, roots []string) []string {
+	seen := map[string]struct{}{}
+	var expanded []string
+	for _, rawRoot := range roots {
+		root := filepath.Clean(expandHome(rawRoot, home))
+		matches := []string{root}
+		if strings.ContainsAny(root, "*?[") {
+			if globMatches, err := filepath.Glob(root); err == nil && len(globMatches) > 0 {
+				matches = globMatches
+			}
+		}
+		for _, match := range matches {
+			clean := filepath.Clean(match)
+			if _, ok := seen[clean]; ok {
+				continue
+			}
+			seen[clean] = struct{}{}
+			expanded = append(expanded, clean)
+		}
+	}
+	sort.Strings(expanded)
+	return expanded
+}
+
+func (p *DevArtifactsPlugin) forEachAgentTranscript(ctx context.Context, home string, staleAfter time.Duration, daCfg config.DevArtifactsConfig, callback func(path string, info os.FileInfo, activeReason string), budgets ...*devArtifactScanBudget) {
+	budget := optionalDevArtifactScanBudget(budgets)
+	roots := configuredAgentTranscriptRoots(home, daCfg)
+	activeRefs := activeAgentPathReferences(ctx, roots, home)
+	now := time.Now()
+	for _, root := range roots {
+		if !pathExistsAndIsDir(root) {
+			continue
+		}
+		filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err := budget.checkPath(ctx, path); err != nil {
+				return err
+			}
+			if err != nil || info == nil {
+				return nil
+			}
+			if info.IsDir() {
+				return nil
+			}
+			if !info.Mode().IsRegular() || !strings.HasSuffix(path, ".jsonl") {
+				return nil
+			}
+			if staleAfter > 0 && info.ModTime().After(now.Add(-staleAfter)) {
+				return nil
+			}
+			callback(path, info, activeRefs[filepath.Clean(path)])
+			return nil
+		})
+	}
+}
+
+func (p *DevArtifactsPlugin) forEachAgentWorktreeRoot(ctx context.Context, home string, staleAfter time.Duration, daCfg config.DevArtifactsConfig, callback func(path string, info os.FileInfo, bytes int64, activeReason string), budgets ...*devArtifactScanBudget) {
+	budget := optionalDevArtifactScanBudget(budgets)
+	roots := configuredAgentWorktreeRoots(home, daCfg)
+	activeRefs := activeAgentPathReferences(ctx, roots, home)
+	now := time.Now()
+	for _, root := range roots {
+		if !pathExistsAndIsDir(root) {
+			continue
+		}
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if ctx.Err() != nil {
+				return
+			}
+			if !entry.IsDir() {
+				continue
+			}
+			path := filepath.Join(root, entry.Name())
+			if err := budget.checkPath(ctx, path); err != nil {
+				return
+			}
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			if staleAfter > 0 && info.ModTime().After(now.Add(-staleAfter)) {
+				continue
+			}
+			bytes, err := getDirAllocatedBytesContext(ctx, path)
+			if err != nil {
+				budget.markContextError(ctx, path)
+				return
+			}
+			callback(path, info, bytes, activeRefs[filepath.Clean(path)])
+		}
+	}
+}
+
+func (p *DevArtifactsPlugin) agentTranscriptTarget(home string, path string, bytes int64, staleAfter time.Duration, mutates bool, activeReason string) CleanupTarget {
+	active := activeReason != ""
+	target := CleanupTarget{
+		Type:      "agent-transcript",
+		Name:      devArtifactHomeRelativePath(home, path),
+		Path:      path,
+		Bytes:     bytes,
+		Active:    active,
+		Protected: active || !mutates,
+	}
+	switch {
+	case active:
+		target.Action = "protect"
+		target.Reason = "active process references this transcript: " + activeReason
+	case !mutates:
+		target.Action = "report"
+		target.Reason = "warning level reports agent transcripts without compressing them"
+	default:
+		target.Action = "compress"
+		target.Reason = fmt.Sprintf("agent transcript JSONL is older than %s and can be gzip-compressed without deleting history", formatDevArtifactAge(staleAfter))
+	}
+	annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(target.Action))
+	return target
+}
+
+func (p *DevArtifactsPlugin) agentWorktreeRootTarget(path string, bytes int64, modTime time.Time, staleAfter time.Duration, now time.Time, canDelete bool, protected bool, activeReason string) CleanupTarget {
+	active := activeReason != ""
+	target := CleanupTarget{
+		Type:      "agent-worktree-root",
+		Name:      filepath.Base(path),
+		Path:      path,
+		Bytes:     bytes,
+		Active:    active,
+		Protected: active || protected || !canDelete,
+	}
+	switch {
+	case active:
+		target.Action = "protect"
+		target.Reason = "active process references this agent worktree: " + activeReason
+	case protected:
+		target.Action = "protect"
+		target.Reason = "path is covered by dev_artifacts.protect_paths"
+	case staleAfter > 0 && modTime.After(now.Add(-staleAfter)):
+		target.Action = "protect"
+		target.Protected = true
+		target.Reason = fmt.Sprintf("agent worktree root is newer than %s", formatDevArtifactAge(staleAfter))
+	case !canDelete:
+		target.Action = "report"
+		target.Reason = "agent worktree root deletion requires critical cleanup level"
+	default:
+		target.Action = "delete"
+		target.Reason = fmt.Sprintf("top-level agent scratch worktree is older than %s", formatDevArtifactAge(staleAfter))
+	}
+	annotateCleanupTargetPolicy(&target, CleanupTierDestructive, hostReclaimForAction(target.Action))
+	return target
 }
 
 func (p *DevArtifactsPlugin) planPnpmStore(ctx context.Context, home string, level CleanupLevel, active devArtifactActivity, targets *[]CleanupTarget) {
@@ -633,6 +840,51 @@ func (p *DevArtifactsPlugin) cleanAgentWorktreeArtifacts(ctx context.Context, ho
 		}
 		totalFreed += p.cleanRustTargets(ctx, root, rustAge, daCfg.ProtectPaths, active, tracker, logger, budgets...)
 	}
+	return totalFreed
+}
+
+func (p *DevArtifactsPlugin) compressAgentTranscripts(ctx context.Context, home string, staleAfter time.Duration, daCfg config.DevArtifactsConfig, logger *slog.Logger, budgets ...*devArtifactScanBudget) int64 {
+	var totalFreed int64
+	p.forEachAgentTranscript(ctx, home, staleAfter, daCfg, func(path string, info os.FileInfo, activeReason string) {
+		if activeReason != "" {
+			logger.Debug("preserving active agent transcript", "path", path, "reason", activeReason)
+			return
+		}
+		freed, err := gzipAgentTranscript(path, info)
+		if err != nil {
+			logger.Warn("failed to compress agent transcript", "path", path, "error", err)
+			return
+		}
+		totalFreed += freed
+		if freed > 0 {
+			logger.Info("compressed agent transcript", "path", path, "freed_mb", freed/(1024*1024))
+		}
+	}, budgets...)
+	return totalFreed
+}
+
+func (p *DevArtifactsPlugin) cleanAgentWorktreeRoots(ctx context.Context, home string, level CleanupLevel, daCfg config.DevArtifactsConfig, logger *slog.Logger, budgets ...*devArtifactScanBudget) int64 {
+	if level < LevelCritical {
+		return 0
+	}
+	var totalFreed int64
+	staleAfter := parseNixPolicyDuration(daCfg.AgentWorktreeStaleAfter, 14*24*time.Hour)
+	p.forEachAgentWorktreeRoot(ctx, home, staleAfter, daCfg, func(path string, _ os.FileInfo, bytes int64, activeReason string) {
+		if activeReason != "" {
+			logger.Debug("preserving active agent worktree", "path", path, "reason", activeReason)
+			return
+		}
+		if p.isProtected(path, daCfg.ProtectPaths) {
+			logger.Debug("preserving protected agent worktree", "path", path)
+			return
+		}
+		if err := os.RemoveAll(path); err != nil {
+			logger.Warn("failed to delete stale agent worktree", "path", path, "error", err)
+			return
+		}
+		totalFreed += bytes
+		logger.Info("deleted stale agent worktree", "path", path, "freed_mb", bytes/(1024*1024))
+	}, budgets...)
 	return totalFreed
 }
 
@@ -1837,6 +2089,151 @@ func pathWithin(path string, root string) bool {
 	}
 	rel, err := filepath.Rel(root, path)
 	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+func devArtifactHomeRelativePath(home string, path string) string {
+	if rel, err := filepath.Rel(home, path); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return filepath.Base(path)
+}
+
+func activeAgentPathReferences(ctx context.Context, roots []string, home string) map[string]string {
+	if len(roots) == 0 {
+		return nil
+	}
+	psCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(psCtx, "ps", "-axo", "comm=,args=")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	return activeAgentPathReferencesFromProcessOutput(string(output), roots, home)
+}
+
+func activeAgentPathReferencesFromProcessOutput(output string, roots []string, home string) map[string]string {
+	refs := map[string]string{}
+	cleanRoots := make([]string, 0, len(roots))
+	for _, root := range roots {
+		cleanRoots = append(cleanRoots, filepath.Clean(expandHome(root, home)))
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		command := agentCommandNameFromProcessLine(line)
+		for _, rawPath := range absoluteDevArtifactPathPattern.FindAllString(line, -1) {
+			path := filepath.Clean(expandHome(rawPath, home))
+			for _, root := range cleanRoots {
+				if !pathWithin(path, root) {
+					continue
+				}
+				for _, target := range agentPathReferenceTargets(path, root) {
+					if _, ok := refs[target]; !ok {
+						refs[target] = command
+					}
+				}
+			}
+		}
+	}
+	return refs
+}
+
+func agentPathReferenceTargets(path string, root string) []string {
+	targets := []string{path}
+	if rel, err := filepath.Rel(root, path); err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		parts := strings.Split(rel, string(os.PathSeparator))
+		if len(parts) > 0 && parts[0] != "" {
+			targets = append(targets, filepath.Join(root, parts[0]))
+		}
+	}
+	return targets
+}
+
+func agentCommandNameFromProcessLine(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return "unknown"
+	}
+	command := filepath.Base(fields[0])
+	if len(fields) > 1 {
+		command = filepath.Base(fields[1])
+	}
+	return command
+}
+
+func gzipAgentTranscript(path string, info os.FileInfo) (int64, error) {
+	if info == nil {
+		var err error
+		info, err = os.Stat(path)
+		if err != nil {
+			return 0, err
+		}
+	}
+	if !info.Mode().IsRegular() {
+		return 0, nil
+	}
+	dest := path + ".gz"
+	if pathExists(dest) {
+		return 0, nil
+	}
+
+	input, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer input.Close()
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.gz")
+	if err != nil {
+		return 0, err
+	}
+	tmpPath := tmp.Name()
+	cleanupTmp := true
+	defer func() {
+		if cleanupTmp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	writer, err := gzip.NewWriterLevel(tmp, gzip.BestCompression)
+	if err != nil {
+		_ = tmp.Close()
+		return 0, err
+	}
+	if _, err := io.Copy(writer, input); err != nil {
+		_ = writer.Close()
+		_ = tmp.Close()
+		return 0, err
+	}
+	if err := writer.Close(); err != nil {
+		_ = tmp.Close()
+		return 0, err
+	}
+	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
+		_ = tmp.Close()
+		return 0, err
+	}
+	if err := tmp.Close(); err != nil {
+		return 0, err
+	}
+	if err := os.Chtimes(tmpPath, info.ModTime(), info.ModTime()); err != nil {
+		return 0, err
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		return 0, err
+	}
+	cleanupTmp = false
+	if err := os.Remove(path); err != nil {
+		return 0, err
+	}
+	compressedInfo, err := os.Stat(dest)
+	if err != nil {
+		return 0, err
+	}
+	return safeBytesDiff(info.Size(), compressedInfo.Size()), nil
 }
 
 func devArtifactProcessCWDs(ctx context.Context, candidates []devArtifactProcessCandidate) map[string]string {

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -1,7 +1,9 @@
 package plugins
 
 import (
+	"compress/gzip"
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -1541,6 +1543,126 @@ func TestDevArtifactActivityReasonsSorted(t *testing.T) {
 	}
 }
 
+func TestAgentTranscriptCompressionPreservesHistory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	transcriptRoot := filepath.Join(home, ".codex", "sessions")
+	transcript := filepath.Join(transcriptRoot, "2026", "05", "01", "rollout.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Repeat(`{"event":"large transcript"}`+"\n", 2048)
+	if err := os.WriteFile(transcript, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(transcript, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := agentStateRetentionConfig(home)
+	plugin := newDevArtifactsPluginWithActive(nil)
+	plan := plugin.PlanCleanup(context.Background(), LevelModerate, cfg, devArtifactTestLogger())
+	target := findDevArtifactTarget(t, plan.Targets, "agent-transcript", transcript)
+	if target.Action != "compress" || target.Protected {
+		t.Fatalf("expected old transcript to be compressed, got %#v", target)
+	}
+
+	result := plugin.Cleanup(context.Background(), LevelModerate, cfg, devArtifactTestLogger())
+	if result.ItemsCleaned != 1 || result.BytesFreed <= 0 {
+		t.Fatalf("expected transcript compression to reclaim bytes, got %#v", result)
+	}
+	if pathExists(transcript) {
+		t.Fatal("uncompressed transcript should be replaced")
+	}
+	gzPath := transcript + ".gz"
+	if !pathExists(gzPath) {
+		t.Fatal("compressed transcript should exist")
+	}
+	got := readGzipFile(t, gzPath)
+	if got != content {
+		t.Fatal("compressed transcript did not preserve content")
+	}
+}
+
+func TestAgentWorktreeRootCleanupDeletesOnlyStaleCriticalRoots(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := filepath.Join(home, ".claude", "worktrees")
+	stale := filepath.Join(root, "agent-old")
+	recent := filepath.Join(root, "agent-new")
+	protected := filepath.Join(root, "agent-protected")
+	for _, dir := range []string{stale, recent, protected} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "state.bin"), []byte(strings.Repeat("x", 1024)), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldTime := time.Now().Add(-30 * 24 * time.Hour)
+	for _, dir := range []string{stale, protected} {
+		if err := os.Chtimes(dir, oldTime, oldTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := agentStateRetentionConfig(home)
+	cfg.DevArtifacts.ProtectPaths = []string{protected}
+	plugin := newDevArtifactsPluginWithActive(nil)
+
+	aggressivePlan := plugin.PlanCleanup(context.Background(), LevelAggressive, cfg, devArtifactTestLogger())
+	aggressiveTarget := findDevArtifactTarget(t, aggressivePlan.Targets, "agent-worktree-root", stale)
+	if aggressiveTarget.Action != "report" || !aggressiveTarget.Protected {
+		t.Fatalf("expected aggressive cleanup to report stale root only, got %#v", aggressiveTarget)
+	}
+
+	criticalPlan := plugin.PlanCleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	staleTarget := findDevArtifactTarget(t, criticalPlan.Targets, "agent-worktree-root", stale)
+	if staleTarget.Action != "delete" || staleTarget.Protected {
+		t.Fatalf("expected critical cleanup to delete stale root, got %#v", staleTarget)
+	}
+	protectedTarget := findDevArtifactTarget(t, criticalPlan.Targets, "agent-worktree-root", protected)
+	if protectedTarget.Action != "protect" || !protectedTarget.Protected {
+		t.Fatalf("expected protected stale root to remain protected, got %#v", protectedTarget)
+	}
+	if _, ok := findDevArtifactTargetMaybe(criticalPlan.Targets, "agent-worktree-root", recent); ok {
+		t.Fatalf("recent worktree should not be a cleanup target")
+	}
+
+	result := plugin.Cleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	if result.ItemsCleaned != 1 || result.BytesFreed <= 0 {
+		t.Fatalf("expected one stale worktree deleted, got %#v", result)
+	}
+	if pathExists(stale) {
+		t.Fatal("stale worktree should be deleted")
+	}
+	if !pathExists(recent) {
+		t.Fatal("recent worktree should remain")
+	}
+	if !pathExists(protected) {
+		t.Fatal("protected worktree should remain")
+	}
+}
+
+func TestActiveAgentPathReferencesFromProcessOutputMapsNestedPathToRoot(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".claude", "worktrees")
+	worktree := filepath.Join(root, "agent-live")
+	nested := filepath.Join(worktree, "src", "main.go")
+	output := "codex codex edit " + nested + "\n"
+
+	refs := activeAgentPathReferencesFromProcessOutput(output, []string{root}, home)
+	if refs[filepath.Clean(nested)] != "codex" {
+		t.Fatalf("expected nested path reference, got %#v", refs)
+	}
+	if refs[filepath.Clean(worktree)] != "codex" {
+		t.Fatalf("expected top-level worktree reference, got %#v", refs)
+	}
+}
+
 func TestGetGoCacheDir(t *testing.T) {
 	p := NewDevArtifactsPlugin()
 
@@ -1557,6 +1679,52 @@ func TestGetGoCacheDir(t *testing.T) {
 	_ = dir
 }
 
+func agentStateRetentionConfig(home string) *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.DevArtifacts.ScanPaths = nil
+	cfg.DevArtifacts.TempArtifacts = false
+	cfg.DevArtifacts.NodeModules = false
+	cfg.DevArtifacts.PythonVenvs = false
+	cfg.DevArtifacts.RustTargets = false
+	cfg.DevArtifacts.ZigArtifacts = false
+	cfg.DevArtifacts.AgentWorktreeArtifacts = false
+	cfg.DevArtifacts.AgentWorktreeRootCleanup = true
+	cfg.DevArtifacts.AgentWorktreeRoots = []string{filepath.Join(home, ".claude", "worktrees")}
+	cfg.DevArtifacts.AgentWorktreeStaleAfter = "7d"
+	cfg.DevArtifacts.AgentTranscriptCompression = true
+	cfg.DevArtifacts.AgentTranscriptRoots = []string{filepath.Join(home, ".codex", "sessions")}
+	cfg.DevArtifacts.AgentTranscriptCompressAfter = "7d"
+	cfg.DevArtifacts.PnpmStore = false
+	cfg.DevArtifacts.GoBuildCache = false
+	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.LargeLocalArtifacts = false
+	cfg.DevArtifacts.LMStudioModels = false
+	return cfg
+}
+
+func readGzipFile(t *testing.T, path string) string {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func devArtifactTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
 func findDevArtifactTarget(t *testing.T, targets []CleanupTarget, targetType, path string) CleanupTarget {
 	t.Helper()
 	for _, target := range targets {
@@ -1566,6 +1734,15 @@ func findDevArtifactTarget(t *testing.T, targets []CleanupTarget, targetType, pa
 	}
 	t.Fatalf("target %s at %s not found in %#v", targetType, path, targets)
 	return CleanupTarget{}
+}
+
+func findDevArtifactTargetMaybe(targets []CleanupTarget, targetType, path string) (CleanupTarget, bool) {
+	for _, target := range targets {
+		if target.Type == targetType && target.Path == path {
+			return target, true
+		}
+	}
+	return CleanupTarget{}, false
 }
 
 func newDevArtifactsPluginWithActive(active map[string]string) *DevArtifactsPlugin {

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -161,6 +161,7 @@ func hostReclaimForAction(action string) string {
 	switch {
 	case strings.HasPrefix(action, "delete"),
 		action == "stop_idle_server_then_delete_output_base",
+		action == "compress",
 		action == "clean-cache",
 		action == "clean-stale-files",
 		action == "thin_local_snapshots":


### PR DESCRIPTION
## Summary
- add opt-in gzip compression for stale agent transcript JSONL files, preserving history while reclaiming disk
- add opt-in, critical-only deletion of stale top-level agent scratch worktree roots
- support configurable/globbed transcript and worktree roots for host-specific pressure profiles

## Context
Neo hit disk pressure after recent crash/workstream churn. Manual incident cleanup found two repeat offenders outside the previous safe auto-clean policy:
- `~/.codex/sessions` old JSONL transcripts
- repo-local `.claude/worktrees` scratch roots

This keeps the cleanup package conservative by default: both new behaviors are opt-in.

## Validation
- `git diff --check`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./config ./plugins -run 'Test(DevArtifactsConfigDefaults|LoadConfigWithNewFields|AgentTranscriptCompressionPreservesHistory|AgentWorktreeRootCleanupDeletesOnlyStaleCriticalRoots|ActiveAgentPathReferencesFromProcessOutputMapsNestedPathToRoot)'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
