### PR TITLE
dev-artifacts: protect dirty agent worktrees

### DIFF
--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -609,7 +609,13 @@ func (p *DevArtifactsPlugin) planAgentTranscripts(ctx context.Context, home stri
 func (p *DevArtifactsPlugin) planAgentWorktreeRoots(ctx context.Context, home string, level CleanupLevel, daCfg config.DevArtifactsConfig, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
 	staleAfter := parseNixPolicyDuration(daCfg.AgentWorktreeStaleAfter, 14*24*time.Hour)
 	p.forEachAgentWorktreeRoot(ctx, home, staleAfter, daCfg, func(path string, info os.FileInfo, bytes int64, activeReason string) {
-		*targets = append(*targets, p.agentWorktreeRootTarget(path, bytes, info.ModTime(), staleAfter, time.Now(), level >= LevelCritical, p.isProtected(path, daCfg.ProtectPaths), activeReason))
+		protectReason := ""
+		if p.isProtected(path, daCfg.ProtectPaths) {
+			protectReason = "path is covered by dev_artifacts.protect_paths"
+		} else if reason := gitWorktreeProtectReason(ctx, path); reason != "" {
+			protectReason = reason
+		}
+		*targets = append(*targets, p.agentWorktreeRootTarget(path, bytes, info.ModTime(), staleAfter, time.Now(), level >= LevelCritical, protectReason, activeReason))
 	}, budgets...)
 }
 
@@ -763,8 +769,9 @@ func (p *DevArtifactsPlugin) agentTranscriptTarget(home string, path string, byt
 	return target
 }
 
-func (p *DevArtifactsPlugin) agentWorktreeRootTarget(path string, bytes int64, modTime time.Time, staleAfter time.Duration, now time.Time, canDelete bool, protected bool, activeReason string) CleanupTarget {
+func (p *DevArtifactsPlugin) agentWorktreeRootTarget(path string, bytes int64, modTime time.Time, staleAfter time.Duration, now time.Time, canDelete bool, protectReason string, activeReason string) CleanupTarget {
 	active := activeReason != ""
+	protected := protectReason != ""
 	target := CleanupTarget{
 		Type:      "agent-worktree-root",
 		Name:      filepath.Base(path),
@@ -779,7 +786,7 @@ func (p *DevArtifactsPlugin) agentWorktreeRootTarget(path string, bytes int64, m
 		target.Reason = "active process references this agent worktree: " + activeReason
 	case protected:
 		target.Action = "protect"
-		target.Reason = "path is covered by dev_artifacts.protect_paths"
+		target.Reason = protectReason
 	case staleAfter > 0 && modTime.After(now.Add(-staleAfter)):
 		target.Action = "protect"
 		target.Protected = true
@@ -876,6 +883,10 @@ func (p *DevArtifactsPlugin) cleanAgentWorktreeRoots(ctx context.Context, home s
 		}
 		if p.isProtected(path, daCfg.ProtectPaths) {
 			logger.Debug("preserving protected agent worktree", "path", path)
+			return
+		}
+		if reason := gitWorktreeProtectReason(ctx, path); reason != "" {
+			logger.Debug("preserving git agent worktree", "path", path, "reason", reason)
 			return
 		}
 		if err := os.RemoveAll(path); err != nil {
@@ -2397,6 +2408,60 @@ func newDevArtifactGitTracker() *devArtifactGitTracker {
 
 func devArtifactContainsTrackedFiles(path string) bool {
 	return newDevArtifactGitTracker().ContainsTrackedFiles(path)
+}
+
+func gitWorktreeProtectReason(ctx context.Context, path string) string {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		if pathExists(filepath.Join(path, ".git")) {
+			return "git worktree cannot be verified because git is unavailable"
+		}
+		return ""
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(checkCtx, gitPath, "-C", path, "rev-parse", "--is-inside-work-tree")
+	output, err := cmd.Output()
+	if err != nil || strings.TrimSpace(string(output)) != "true" {
+		return ""
+	}
+
+	statusCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	statusCmd := exec.CommandContext(statusCtx, gitPath, "-C", path, "status", "--porcelain", "--untracked-files=all")
+	statusOutput, err := statusCmd.Output()
+	if err != nil {
+		return "git worktree status could not be verified"
+	}
+	if strings.TrimSpace(string(statusOutput)) != "" {
+		return "git worktree has uncommitted changes"
+	}
+
+	upstreamCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	upstreamCmd := exec.CommandContext(upstreamCtx, gitPath, "-C", path, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	upstreamOutput, err := upstreamCmd.Output()
+	if err != nil || strings.TrimSpace(string(upstreamOutput)) == "" {
+		return "git worktree has no upstream branch"
+	}
+
+	aheadCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	aheadCmd := exec.CommandContext(aheadCtx, gitPath, "-C", path, "rev-list", "--count", "@{u}..HEAD")
+	aheadOutput, err := aheadCmd.Output()
+	if err != nil {
+		return "git worktree upstream comparison could not be verified"
+	}
+	ahead, err := strconv.Atoi(strings.TrimSpace(string(aheadOutput)))
+	if err != nil {
+		return "git worktree upstream comparison could not be parsed"
+	}
+	if ahead > 0 {
+		return "git worktree has unpushed commits"
+	}
+
+	return ""
 }
 
 func (t *devArtifactGitTracker) ContainsTrackedFiles(path string) bool {

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -1647,6 +1647,97 @@ func TestAgentWorktreeRootCleanupDeletesOnlyStaleCriticalRoots(t *testing.T) {
 	}
 }
 
+func TestAgentWorktreeRootCleanupProtectsDirtyGitWorktree(t *testing.T) {
+	git := requireGit(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := filepath.Join(home, ".claude", "worktrees")
+	dirty := filepath.Join(root, "agent-dirty")
+	if err := os.MkdirAll(dirty, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, git, dirty, "init")
+	runGit(t, git, dirty, "config", "user.email", "test@example.invalid")
+	runGit(t, git, dirty, "config", "user.name", "Tinyland Test")
+	runGit(t, git, dirty, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dirty, ".gitignore"), []byte("state.bin\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, git, dirty, "add", ".gitignore")
+	runGit(t, git, dirty, "commit", "-m", "seed")
+	if err := os.WriteFile(filepath.Join(dirty, ".gitignore"), []byte("state.bin\nscratch.log\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(dirty, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := agentStateRetentionConfig(home)
+	plugin := newDevArtifactsPluginWithActive(nil)
+	criticalPlan := plugin.PlanCleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	dirtyTarget := findDevArtifactTarget(t, criticalPlan.Targets, "agent-worktree-root", dirty)
+	if dirtyTarget.Action != "protect" || !dirtyTarget.Protected {
+		t.Fatalf("expected dirty git worktree to be protected, got %#v", dirtyTarget)
+	}
+	if !strings.Contains(dirtyTarget.Reason, "uncommitted changes") {
+		t.Fatalf("expected dirty-git reason, got %q", dirtyTarget.Reason)
+	}
+
+	result := plugin.Cleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	if result.ItemsCleaned != 0 || result.BytesFreed != 0 {
+		t.Fatalf("expected dirty git worktree cleanup to reclaim nothing, got %#v", result)
+	}
+	if !pathExists(dirty) {
+		t.Fatal("dirty git worktree should remain")
+	}
+}
+
+func TestAgentWorktreeRootCleanupProtectsLocalOnlyGitWorktree(t *testing.T) {
+	git := requireGit(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := filepath.Join(home, ".claude", "worktrees")
+	localOnly := filepath.Join(root, "agent-local-only")
+	if err := os.MkdirAll(localOnly, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, git, localOnly, "init")
+	runGit(t, git, localOnly, "config", "user.email", "test@example.invalid")
+	runGit(t, git, localOnly, "config", "user.name", "Tinyland Test")
+	runGit(t, git, localOnly, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(localOnly, "state.bin"), []byte(strings.Repeat("x", 1024)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, git, localOnly, "add", "state.bin")
+	runGit(t, git, localOnly, "commit", "-m", "local-only")
+	oldTime := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(localOnly, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := agentStateRetentionConfig(home)
+	plugin := newDevArtifactsPluginWithActive(nil)
+	criticalPlan := plugin.PlanCleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	localTarget := findDevArtifactTarget(t, criticalPlan.Targets, "agent-worktree-root", localOnly)
+	if localTarget.Action != "protect" || !localTarget.Protected {
+		t.Fatalf("expected local-only git worktree to be protected, got %#v", localTarget)
+	}
+	if !strings.Contains(localTarget.Reason, "no upstream") {
+		t.Fatalf("expected no-upstream reason, got %q", localTarget.Reason)
+	}
+
+	result := plugin.Cleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	if result.ItemsCleaned != 0 || result.BytesFreed != 0 {
+		t.Fatalf("expected local-only git worktree cleanup to reclaim nothing, got %#v", result)
+	}
+	if !pathExists(localOnly) {
+		t.Fatal("local-only git worktree should remain")
+	}
+}
+
 func TestActiveAgentPathReferencesFromProcessOutputMapsNestedPathToRoot(t *testing.T) {
 	home := t.TempDir()
 	root := filepath.Join(home, ".claude", "worktrees")


### PR DESCRIPTION
## Summary
- protect stale agent worktree roots when Git cannot prove they are disposable
- preserve dirty Git worktrees, no-upstream local branches, and unpushed commits during critical cleanup
- add regressions for dirty and local-only agent worktrees

## Root Cause
`agent_worktree_root_cleanup` only checked staleness, cleanup level, explicit protected paths, and active process references before deletion. A critical dry-run on Neo showed stale MassageIthaca Claude worktree roots with local modifications would be deleted. That is not safe for workstation cleanup.

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'TestAgentWorktreeRootCleanup|TestActiveAgentPathReferences|TestAgentTranscriptCompression'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `nix build .#default --no-link --print-build-logs`
