### PR TITLE
bazel: add explicit cache and RBE proof contract

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,9 +6,36 @@ build --spawn_strategy=sandboxed
 test --test_output=errors
 test --test_summary=detailed
 
-# Shared-cache CI configuration. Pass --remote_cache from a wrapper because
-# Bazel does not expand environment variables in .bazelrc values.
-build:ci-cached --remote_upload_local_results=true
-build:ci-cached --remote_timeout=60
-test:ci-cached --remote_upload_local_results=true
-test:ci-cached --remote_timeout=60
+# Remote cache endpoints are supplied by scripts/bazel-cache-backed.sh with an
+# explicit --remote_cache flag. Keep .bazelrc endpoint-free so stale private
+# hostnames cannot silently shadow the GloriousFlywheel-provided endpoint.
+build:remote --remote_upload_local_results=false
+build:remote --remote_download_outputs=toplevel
+build:remote --remote_timeout=300
+build:remote --remote_local_fallback=true
+
+# Remote executor endpoints are never stored in .bazelrc. Use
+# scripts/bazel-rbe-proof.sh with BAZEL_REMOTE_EXECUTOR, BAZEL_REMOTE_CACHE, and
+# GF_BAZEL_SUBSTRATE_MODE=executor-backed for explicit REAPI proof runs.
+build:executor-backed --config=ci
+test:executor-backed --config=ci
+
+build:ci --config=remote
+test:ci --config=remote
+build:ci --show_progress_rate_limit=10
+build:ci --curses=no
+build:ci --color=yes
+build:ci --keep_going=false
+test:ci --test_output=errors
+test:ci --test_summary=short
+
+build:ci-local --disk_cache=/tmp/tinyland-cleanup-bazel-disk-cache
+build:ci-local --curses=no
+build:ci-local --color=yes
+build:ci-local --keep_going=false
+test:ci-local --test_output=errors
+test:ci-local --test_summary=short
+
+# Backward-compatible alias retained for older docs and proof invocations.
+build:ci-cached --config=ci
+test:ci-cached --config=ci

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+self-hosted-runner:
+  labels:
+    - tinyland-dind
+    - tinyland-docker
+    - tinyland-nix
+    - tinyland-nix-gpu
+    - tinyland-nix-heavy
+    - tinyland-nix-kvm

--- a/.github/workflows/gloriousflywheel-proof.yml
+++ b/.github/workflows/gloriousflywheel-proof.yml
@@ -4,17 +4,28 @@ on:
   workflow_dispatch:
     inputs:
       bazel_remote_cache:
-        description: Bazel remote cache URL
-        required: true
-        default: grpc://bazel-cache.nix-cache.svc.cluster.local:9092
+        description: Optional Bazel remote cache URL; runner-provided BAZEL_REMOTE_CACHE is used when omitted
+        required: false
+      bazel_remote_executor:
+        description: Optional Bazel remote executor URL for explicit RBE proof mode
+        required: false
+      remote_execution_platform:
+        description: Required when bazel_remote_executor is set
+        required: false
+      rbe_proof_target:
+        description: RBE proof target listed in config/bazel-rbe-target-eligibility.json
+        required: false
+        default: //:bazel_cache_policy_check
+      bazel_remote_upload:
+        description: Upload local results to the remote cache from this trusted proof run
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   shared-cache-proof:
-    name: Shared cache proof
+    name: Bazel cache and RBE proof
     runs-on: tinyland-nix
-    env:
-      BAZEL_REMOTE_CACHE: ${{ inputs.bazel_remote_cache }}
-      GF_BAZEL_SUBSTRATE_MODE: shared-cache-backed
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Go validation
@@ -26,5 +37,46 @@ jobs:
           GOFLAGS: -mod=vendor
       - name: Nix package
         run: nix build .#default --no-link --print-build-logs
-      - name: Bazel shared-cache test
+      - name: Apply Bazel proof inputs
+        env:
+          INPUT_BAZEL_REMOTE_CACHE: ${{ inputs.bazel_remote_cache }}
+          INPUT_BAZEL_REMOTE_EXECUTOR: ${{ inputs.bazel_remote_executor }}
+          INPUT_REMOTE_EXECUTION_PLATFORM: ${{ inputs.remote_execution_platform }}
+          INPUT_BAZEL_REMOTE_UPLOAD: ${{ inputs.bazel_remote_upload }}
+        run: |
+          if [ -n "$INPUT_BAZEL_REMOTE_CACHE" ]; then
+            echo "::add-mask::$INPUT_BAZEL_REMOTE_CACHE"
+          fi
+          if [ -n "$INPUT_BAZEL_REMOTE_EXECUTOR" ]; then
+            echo "::add-mask::$INPUT_BAZEL_REMOTE_EXECUTOR"
+          fi
+          {
+            if [ -n "$INPUT_BAZEL_REMOTE_CACHE" ]; then
+              printf 'BAZEL_REMOTE_CACHE=%s\n' "$INPUT_BAZEL_REMOTE_CACHE"
+            fi
+            if [ -n "$INPUT_BAZEL_REMOTE_EXECUTOR" ]; then
+              printf 'BAZEL_REMOTE_EXECUTOR=%s\n' "$INPUT_BAZEL_REMOTE_EXECUTOR"
+              printf 'GF_BAZEL_SUBSTRATE_MODE=executor-backed\n'
+              printf 'GF_RBE_PROOF_MODE=explicit\n'
+            fi
+            if [ -n "$INPUT_REMOTE_EXECUTION_PLATFORM" ]; then
+              printf 'GF_BAZEL_REMOTE_EXECUTION_PLATFORM=%s\n' "$INPUT_REMOTE_EXECUTION_PLATFORM"
+            fi
+            printf 'BAZEL_REMOTE_UPLOAD=%s\n' "$INPUT_BAZEL_REMOTE_UPLOAD"
+          } >> "$GITHUB_ENV"
+      - name: Classify Bazel substrate
+        run: |
+          if [ -n "${BAZEL_REMOTE_EXECUTOR:-}" ]; then
+            printf 'GF_BAZEL_SUBSTRATE_MODE=executor-backed\n' >> "$GITHUB_ENV"
+          elif [ -n "${BAZEL_REMOTE_CACHE:-}" ]; then
+            printf 'GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed\n' >> "$GITHUB_ENV"
+          fi
+      - name: Bazel cache contract
+        run: bash scripts/validation/bazel-cache-contract.sh --strict
+      - name: Bazel cache-backed test
         run: nix shell nixpkgs#bazelisk --command bash scripts/bazel-cache-backed.sh test //...
+      - name: Bazel explicit RBE proof
+        if: ${{ inputs.bazel_remote_executor != '' }}
+        env:
+          RBE_PROOF_TARGET: ${{ inputs.rbe_proof_target }}
+        run: nix shell nixpkgs#bazelisk --command bash scripts/bazel-rbe-proof.sh --target "$RBE_PROOF_TARGET"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,94 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 gazelle(name = "gazelle")
 
+exports_files([
+    ".bazelrc",
+    ".github/actionlint.yaml",
+    ".github/workflows/gloriousflywheel-proof.yml",
+    "config/bazel-rbe-target-eligibility.json",
+    "scripts/bazel-cache-backed.sh",
+    "scripts/bazel-rbe-proof.sh",
+    "scripts/validation/bazel-cache-contract.sh",
+    "scripts/validation/check-bazel-cache-policy.sh",
+    "scripts/validation/test-bazel-cache-backed-wrapper.sh",
+    "scripts/validation/test-bazel-cache-contract.sh",
+    "scripts/validation/test-bazel-rbe-proof-wrapper.sh",
+    "scripts/validation/validate-bazel-rbe-target-eligibility.py",
+])
+
+filegroup(
+    name = "bazel_control_plane_files",
+    srcs = [
+        ".bazelrc",
+        ".github/actionlint.yaml",
+        ".github/workflows/gloriousflywheel-proof.yml",
+        "config/bazel-rbe-target-eligibility.json",
+        "scripts/bazel-cache-backed.sh",
+        "scripts/bazel-rbe-proof.sh",
+        "scripts/validation/bazel-cache-contract.sh",
+        "scripts/validation/check-bazel-cache-policy.sh",
+        "scripts/validation/test-bazel-cache-backed-wrapper.sh",
+        "scripts/validation/test-bazel-cache-contract.sh",
+        "scripts/validation/test-bazel-rbe-proof-wrapper.sh",
+        "scripts/validation/validate-bazel-rbe-target-eligibility.py",
+    ],
+)
+
+sh_test(
+    name = "bazel_cache_policy_check",
+    srcs = ["scripts/validation/check-bazel-cache-policy.sh"],
+    data = [":bazel_control_plane_files"],
+    tags = [
+        "bazel-cache-policy",
+        "fast",
+        "presubmit",
+    ],
+)
+
+sh_test(
+    name = "bazel_cache_contract_check",
+    srcs = ["scripts/validation/test-bazel-cache-contract.sh"],
+    data = [":bazel_control_plane_files"],
+    tags = [
+        "bazel-cache-policy",
+        "fast",
+        "presubmit",
+    ],
+)
+
+sh_test(
+    name = "bazel_cache_backed_wrapper_check",
+    srcs = ["scripts/validation/test-bazel-cache-backed-wrapper.sh"],
+    data = [":bazel_control_plane_files"],
+    tags = [
+        "bazel-cache-policy",
+        "fast",
+        "presubmit",
+    ],
+)
+
+sh_test(
+    name = "bazel_rbe_proof_wrapper_check",
+    srcs = ["scripts/validation/test-bazel-rbe-proof-wrapper.sh"],
+    data = [":bazel_control_plane_files"],
+    tags = [
+        "bazel-cache-policy",
+        "fast",
+        "presubmit",
+    ],
+)
+
+sh_test(
+    name = "bazel_rbe_target_eligibility_check",
+    srcs = ["scripts/validation/validate-bazel-rbe-target-eligibility.py"],
+    data = [":bazel_control_plane_files"],
+    tags = [
+        "bazel-cache-policy",
+        "fast",
+        "presubmit",
+    ],
+)
+
 go_binary(
     name = "tinyland-cleanup",
     embed = [":tinyland-cleanup_lib"],
@@ -159,6 +247,11 @@ go_test(
 test_suite(
     name = "all_tests",
     tests = [
+        ":bazel_cache_backed_wrapper_check",
+        ":bazel_cache_contract_check",
+        ":bazel_cache_policy_check",
+        ":bazel_rbe_proof_wrapper_check",
+        ":bazel_rbe_target_eligibility_check",
         ":config_test",
         ":monitor_test",
         ":plugins_test",

--- a/README.md
+++ b/README.md
@@ -45,8 +45,19 @@ nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-c
 Shared-cache Bazel runners can use:
 
 ```sh
-BAZEL_REMOTE_CACHE=grpc://bazel-cache.nix-cache.svc.cluster.local:9092 \
-  scripts/bazel-cache-backed.sh test //...
+BAZEL_REMOTE_CACHE=grpc://example.internal:9092 \
+  bash scripts/bazel-cache-backed.sh test //...
+```
+
+Explicit remote-execution proof is separate from cache-backed validation:
+
+```sh
+GF_RBE_PROOF_MODE=explicit \
+GF_BAZEL_SUBSTRATE_MODE=executor-backed \
+GF_BAZEL_REMOTE_EXECUTION_PLATFORM=linux-x86_64 \
+BAZEL_REMOTE_CACHE=grpc://example-cache.internal:9092 \
+BAZEL_REMOTE_EXECUTOR=grpc://example-executor.internal:8980 \
+  bash scripts/bazel-rbe-proof.sh --target //:bazel_cache_policy_check
 ```
 
 ## Operator Review

--- a/config/bazel-rbe-target-eligibility.json
+++ b/config/bazel-rbe-target-eligibility.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "owner_issue": "TIN-2170",
+  "updated": "2026-06-23",
+  "platform": "gloriousflywheel-rbe-linux-x86_64",
+  "default_posture": "cache-forward local or CI execution; executor-backed mode is explicit-proof only",
+  "proved_target_classes": [],
+  "candidate_target_classes": [
+    {
+      "name": "bazel-cache-policy-contract",
+      "status": "candidate",
+      "labels": [
+        "//:bazel_cache_policy_check"
+      ],
+      "allowed_modes": [
+        "explicit-proof"
+      ],
+      "requirements": [
+        "shell and Python static policy checks only",
+        "declared repo configuration files only",
+        "no host mutation",
+        "no ambient secrets",
+        "no fleet reachability dependency"
+      ],
+      "proof_required": [
+        "run through scripts/bazel-rbe-proof.sh with BAZEL_REMOTE_EXECUTOR and BAZEL_REMOTE_CACHE",
+        "force execution with --remote_accept_cached=false",
+        "capture a proof artifact showing nonzero remote executor processes"
+      ],
+      "boundary": "This candidate does not prove //:all_tests, //..., Go toolchain execution, Nix evaluation, package builds, or cleanup runtime behavior."
+    }
+  ],
+  "blocked_target_classes": [
+    {
+      "name": "broad-go-and-presubmit-graph",
+      "labels": [
+        "//:all_tests",
+        "//...",
+        "//:tinyland-cleanup"
+      ],
+      "blockers": [
+        "broad presubmit has not been proved against a matching rules_go remote execution platform",
+        "platform-specific Darwin/Linux selects need executor parity proof",
+        "test sandbox behavior must be compared against local and shared-cache runs before marking eligible"
+      ]
+    },
+    {
+      "name": "host-cleanup-runtime",
+      "labels": [
+        "bazel run //:tinyland-cleanup",
+        "tinyland-cleanup --once",
+        "tinyland-cleanup daemon"
+      ],
+      "blockers": [
+        "cleanup runtime can inspect or mutate host cache and service state",
+        "operator dry-run and real cleanup semantics belong to the target host",
+        "remote execution would hide the machine under pressure"
+      ]
+    },
+    {
+      "name": "nix-packaging-and-release",
+      "labels": [
+        "nix build .#default",
+        "nix flake check",
+        ".github/workflows/release.yml"
+      ],
+      "blockers": [
+        "uses Nix store, host platform, and cache trust state",
+        "release artifacts remain under the Nix and GitHub release control planes",
+        "Attic and FlakeHub cache attachment is not Bazel remote execution"
+      ]
+    }
+  ],
+  "invariants": [
+    "Remote cache hits are not RBE proof.",
+    "Executor-backed proof requires both BAZEL_REMOTE_EXECUTOR and BAZEL_REMOTE_CACHE.",
+    "Attic and FlakeHub are Nix cache substrates, not Bazel remote execution substrates.",
+    "No broad presubmit or cleanup runtime target is RBE eligible until a target-class proof artifact exists.",
+    "Runner and IaC selection remains explicit; do not infer remote execution from branch names or cache attachment."
+  ]
+}

--- a/docs/bazel-cache-policy.md
+++ b/docs/bazel-cache-policy.md
@@ -111,3 +111,36 @@ Runtime boundary:
 Do not disable active-output-base protection on developer machines or shared
 runners unless an operator has already drained the relevant jobs and accepted
 the risk.
+
+## Bazel Cache and RBE Proof Contract
+
+The repo keeps Bazel endpoint configuration out of `.bazelrc`. Operators and
+GloriousFlywheel runners attach cache and executor endpoints through
+environment variables consumed by `scripts/bazel-cache-backed.sh`:
+
+```sh
+BAZEL_REMOTE_CACHE=grpc://example.internal:9092 \
+  bash scripts/bazel-cache-backed.sh test //...
+```
+
+By default the wrapper uses local execution with a local disk cache. When
+`BAZEL_REMOTE_CACHE` is set it uses shared remote cache mode and does not upload
+local results unless `BAZEL_REMOTE_UPLOAD=true` is set by a trusted proof run.
+
+Remote execution is explicit proof-only. Use `scripts/bazel-rbe-proof.sh` with
+both a cache endpoint and executor endpoint, and only for a target listed in
+`config/bazel-rbe-target-eligibility.json`:
+
+```sh
+GF_RBE_PROOF_MODE=explicit \
+GF_BAZEL_SUBSTRATE_MODE=executor-backed \
+GF_BAZEL_REMOTE_EXECUTION_PLATFORM=linux-x86_64 \
+BAZEL_REMOTE_CACHE=grpc://example-cache.internal:9092 \
+BAZEL_REMOTE_EXECUTOR=grpc://example-executor.internal:8980 \
+  bash scripts/bazel-rbe-proof.sh --target //:bazel_cache_policy_check
+```
+
+Remote cache hits are not RBE proof. The manifest currently marks only the
+Bazel cache policy contract as an explicit proof candidate; the broad Go test
+graph, cleanup runtime, and Nix packaging surfaces remain local/shared-cache
+validated until a matching executor proof artifact exists.

--- a/scripts/bazel-cache-backed.sh
+++ b/scripts/bazel-cache-backed.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/bazel-cache-backed.sh <build|test|coverage|run|info> [bazel args...]
+
+Run Bazel through the tinyland-cleanup cache/REAPI control-plane contract. The
+wrapper supports local compatibility mode, shared remote cache mode, and
+explicit executor-backed proof mode without hardcoding private endpoints.
+
+Environment:
+  BAZEL_BIN                                 Bazel binary, default: bazelisk
+  BAZEL_REMOTE_CACHE                        Optional remote cache endpoint
+  BAZEL_REMOTE_EXECUTOR                     Optional remote executor endpoint
+  BAZEL_REMOTE_UPLOAD                       true/false, default: false
+  GF_BAZEL_SUBSTRATE_MODE                   Optional explicit substrate mode
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM        Required when BAZEL_REMOTE_EXECUTOR is set
+  TINYLAND_CLEANUP_BAZEL_CONFIG             Override Bazel --config selection
+  TINYLAND_CLEANUP_BAZEL_OUTPUT_USER_ROOT   Optional Bazel startup --output_user_root
+  TINYLAND_CLEANUP_BAZEL_DISK_CACHE         Optional local --disk_cache
+  TINYLAND_CLEANUP_BAZEL_STARTUP_ARGS       Optional whitespace-separated startup args
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+command_name="$1"
+shift
+
+case "$command_name" in
+  build | test | coverage | run | info)
+    ;;
+  -h | --help | help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "error: unsupported Bazel command: $command_name" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ "${command_name}" == "info" && $# -eq 0 ]]; then
+  :
+fi
+
+bazel_bin="${BAZEL_BIN:-bazelisk}"
+if ! command -v "$bazel_bin" >/dev/null 2>&1; then
+  echo "error: Bazel binary not found: $bazel_bin" >&2
+  echo "hint: run through nix shell nixpkgs#bazelisk or set BAZEL_BIN" >&2
+  exit 127
+fi
+
+remote_cache="${BAZEL_REMOTE_CACHE:-}"
+remote_executor="${BAZEL_REMOTE_EXECUTOR:-}"
+declared_mode="${GF_BAZEL_SUBSTRATE_MODE:-}"
+execution_platform="${GF_BAZEL_REMOTE_EXECUTION_PLATFORM:-}"
+
+contract_args=()
+if [[ -n "$remote_cache" || -n "$remote_executor" || "$declared_mode" == "shared-cache-backed" || "$declared_mode" == "executor-backed" ]]; then
+  contract_args+=(--strict)
+fi
+if ((${#contract_args[@]} > 0)); then
+  "$repo_root/scripts/validation/bazel-cache-contract.sh" "${contract_args[@]}"
+else
+  "$repo_root/scripts/validation/bazel-cache-contract.sh"
+fi
+
+if [[ -n "${TINYLAND_CLEANUP_BAZEL_STARTUP_ARGS:-}" ]]; then
+  # shellcheck disable=SC2206
+  startup_args=(${TINYLAND_CLEANUP_BAZEL_STARTUP_ARGS})
+else
+  startup_args=()
+fi
+
+if [[ -n "${TINYLAND_CLEANUP_BAZEL_OUTPUT_USER_ROOT:-}" ]]; then
+  startup_args+=("--output_user_root=${TINYLAND_CLEANUP_BAZEL_OUTPUT_USER_ROOT}")
+fi
+
+bazel_config="${TINYLAND_CLEANUP_BAZEL_CONFIG:-}"
+if [[ -z "$bazel_config" ]]; then
+  if [[ -n "$remote_executor" ]]; then
+    bazel_config="executor-backed"
+  elif [[ -n "$remote_cache" ]]; then
+    bazel_config="ci"
+  else
+    bazel_config="ci-local"
+  fi
+fi
+
+bazel_args=("--config=${bazel_config}")
+
+if [[ -n "${TINYLAND_CLEANUP_BAZEL_DISK_CACHE:-}" ]]; then
+  bazel_args+=("--disk_cache=${TINYLAND_CLEANUP_BAZEL_DISK_CACHE}")
+fi
+
+if [[ -n "${BAZEL_REPOSITORY_CACHE:-}" ]]; then
+  bazel_args+=("--repository_cache=${BAZEL_REPOSITORY_CACHE}")
+fi
+
+if [[ -n "${BAZEL_DISTDIR:-}" ]]; then
+  bazel_args+=("--distdir=${BAZEL_DISTDIR}")
+fi
+
+if [[ -n "$remote_cache" ]]; then
+  upload="${BAZEL_REMOTE_UPLOAD:-false}"
+  case "$upload" in
+    1 | true | TRUE | yes | YES)
+      upload="true"
+      ;;
+    0 | false | FALSE | no | NO | "")
+      upload="false"
+      ;;
+    *)
+      echo "error: BAZEL_REMOTE_UPLOAD must be true or false" >&2
+      exit 2
+      ;;
+  esac
+
+  bazel_args+=(
+    "--remote_cache=${remote_cache}"
+    "--remote_upload_local_results=${upload}"
+    "--remote_download_outputs=toplevel"
+    "--remote_local_fallback=true"
+  )
+fi
+
+if [[ -n "$remote_executor" ]]; then
+  bazel_args+=("--remote_executor=${remote_executor}")
+  bazel_args+=("--remote_default_exec_properties=gf.platform=${execution_platform}")
+fi
+
+if ((${#startup_args[@]} > 0)); then
+  exec "$bazel_bin" "${startup_args[@]}" "$command_name" "${bazel_args[@]}" "$@"
+fi
+
+exec "$bazel_bin" "$command_name" "${bazel_args[@]}" "$@"

--- a/scripts/bazel-rbe-proof.sh
+++ b/scripts/bazel-rbe-proof.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/bazel-rbe-proof.sh [--target LABEL] [--bazel-command test] [-- ARGS...]
+
+Run an explicit remote-execution proof for a target listed in
+config/bazel-rbe-target-eligibility.json. This is intentionally not the default
+CI path: remote cache hits are not RBE proof, and RBE proof mode must be opted
+into with GF_RBE_PROOF_MODE=explicit.
+
+Required environment:
+  GF_RBE_PROOF_MODE=explicit
+  BAZEL_REMOTE_CACHE
+  BAZEL_REMOTE_EXECUTOR
+  GF_BAZEL_SUBSTRATE_MODE=executor-backed
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM
+EOF
+}
+
+target="//:bazel_cache_policy_check"
+bazel_command="test"
+extra_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      target="${2:?missing target after --target}"
+      shift 2
+      ;;
+    --bazel-command)
+      bazel_command="${2:?missing command after --bazel-command}"
+      shift 2
+      ;;
+    --)
+      shift
+      extra_args+=("$@")
+      break
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$bazel_command" in
+  build | test | coverage)
+    ;;
+  *)
+    echo "error: RBE proof supports build, test, or coverage only" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "${GF_RBE_PROOF_MODE:-}" != "explicit" ]]; then
+  echo "error: set GF_RBE_PROOF_MODE=explicit before running an RBE proof" >&2
+  exit 2
+fi
+
+if [[ -z "${BAZEL_REMOTE_CACHE:-}" || -z "${BAZEL_REMOTE_EXECUTOR:-}" ]]; then
+  echo "error: BAZEL_REMOTE_CACHE and BAZEL_REMOTE_EXECUTOR are both required" >&2
+  exit 2
+fi
+
+if [[ "${GF_BAZEL_SUBSTRATE_MODE:-}" != "executor-backed" ]]; then
+  echo "error: set GF_BAZEL_SUBSTRATE_MODE=executor-backed for RBE proof mode" >&2
+  exit 2
+fi
+
+"$repo_root/scripts/validation/validate-bazel-rbe-target-eligibility.py" \
+  --target "$target" \
+  --allow-candidate
+
+"$repo_root/scripts/validation/bazel-cache-contract.sh" --strict
+
+proof_args=(--remote_accept_cached=false)
+if ((${#extra_args[@]} > 0)); then
+  proof_args+=("${extra_args[@]}")
+fi
+proof_args+=("$target")
+
+exec "$repo_root/scripts/bazel-cache-backed.sh" \
+  "$bazel_command" \
+  "${proof_args[@]}"

--- a/scripts/validation/bazel-cache-contract.sh
+++ b/scripts/validation/bazel-cache-contract.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/validation/bazel-cache-contract.sh [--strict] [--strict-nix]
+
+Classify and validate the tinyland-cleanup Bazel cache/REAPI substrate without
+printing private endpoint values.
+
+Modes:
+  compatibility-local-only  No shared Bazel cache or executor is configured.
+  shared-cache-backed       BAZEL_REMOTE_CACHE is configured.
+  executor-backed           BAZEL_REMOTE_EXECUTOR and BAZEL_REMOTE_CACHE are configured.
+
+Environment:
+  BAZEL_REMOTE_CACHE
+  BAZEL_REMOTE_EXECUTOR
+  GF_BAZEL_SUBSTRATE_MODE
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM
+  BAZEL_REPOSITORY_CACHE
+  BAZEL_DISTDIR
+
+Options:
+  --strict      Require a shared cache or executor-backed substrate.
+  --strict-nix  Check optional Attic/FlakeHub cache environment for partial config.
+EOF
+}
+
+strict=false
+strict_nix=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --strict)
+      strict=true
+      ;;
+    --strict-nix)
+      strict_nix=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+errors=()
+
+add_error() {
+  errors+=("$1")
+}
+
+is_set() {
+  [[ -n "${1:-}" ]]
+}
+
+describe_endpoint() {
+  local value="${1:-}"
+
+  if [[ -z "$value" ]]; then
+    printf 'unset'
+    return
+  fi
+
+  if [[ "$value" == *"://"* ]]; then
+    printf '%s://<configured>' "${value%%://*}"
+    return
+  fi
+
+  printf '<configured>'
+}
+
+require_supported_cache_endpoint() {
+  local name="$1"
+  local value="$2"
+
+  [[ -z "$value" ]] && return
+
+  if [[ "$value" =~ attic-cache-dev|fuzzy-dev|attic\.dev-cluster|attic\.tinyland|bazel-cache\.fuzzy-dev ]]; then
+    add_error "$name points at a stale legacy cache endpoint"
+  fi
+
+  if [[ "$value" == *'${'* || "$value" == *'}'* ]]; then
+    add_error "$name contains an unevaluated placeholder"
+  fi
+
+  if [[ ! "$value" =~ ^(grpc|grpcs|http|https):// ]]; then
+    add_error "$name must use grpc://, grpcs://, http://, or https://"
+  fi
+}
+
+require_supported_executor_endpoint() {
+  local name="$1"
+  local value="$2"
+
+  [[ -z "$value" ]] && return
+
+  if [[ "$value" =~ fuzzy-dev|dev-cluster|attic\.tinyland ]]; then
+    add_error "$name points at a stale legacy endpoint"
+  fi
+
+  if [[ "$value" == *'${'* || "$value" == *'}'* ]]; then
+    add_error "$name contains an unevaluated placeholder"
+  fi
+
+  if [[ ! "$value" =~ ^(grpc|grpcs):// ]]; then
+    add_error "$name must use grpc:// or grpcs://"
+  fi
+}
+
+remote_cache="${BAZEL_REMOTE_CACHE:-}"
+remote_executor="${BAZEL_REMOTE_EXECUTOR:-}"
+declared_mode="${GF_BAZEL_SUBSTRATE_MODE:-}"
+execution_platform="${GF_BAZEL_REMOTE_EXECUTION_PLATFORM:-}"
+repository_cache="${BAZEL_REPOSITORY_CACHE:-}"
+distdir="${BAZEL_DISTDIR:-}"
+
+expected_mode="compatibility-local-only"
+if is_set "$remote_executor"; then
+  expected_mode="executor-backed"
+elif is_set "$remote_cache"; then
+  expected_mode="shared-cache-backed"
+fi
+
+effective_mode="${declared_mode:-$expected_mode}"
+
+case "$effective_mode" in
+  compatibility-local-only | shared-cache-backed | executor-backed)
+    ;;
+  *)
+    add_error "GF_BAZEL_SUBSTRATE_MODE must be compatibility-local-only, shared-cache-backed, or executor-backed"
+    ;;
+esac
+
+if [[ -n "$declared_mode" && "$declared_mode" != "$expected_mode" ]]; then
+  add_error "GF_BAZEL_SUBSTRATE_MODE=$declared_mode does not match detected substrate $expected_mode"
+fi
+
+require_supported_cache_endpoint "BAZEL_REMOTE_CACHE" "$remote_cache"
+require_supported_executor_endpoint "BAZEL_REMOTE_EXECUTOR" "$remote_executor"
+
+if is_set "$remote_executor" && ! is_set "$remote_cache"; then
+  add_error "BAZEL_REMOTE_EXECUTOR requires BAZEL_REMOTE_CACHE so proof runs can separate execution from cache reuse"
+fi
+
+if [[ "$effective_mode" == "executor-backed" && -z "$execution_platform" ]]; then
+  add_error "executor-backed mode requires GF_BAZEL_REMOTE_EXECUTION_PLATFORM"
+fi
+
+if $strict && [[ "$expected_mode" == "compatibility-local-only" ]]; then
+  add_error "--strict requires BAZEL_REMOTE_CACHE or BAZEL_REMOTE_EXECUTOR"
+fi
+
+if [[ -n "$repository_cache" && "$repository_cache" == *'${'* ]]; then
+  add_error "BAZEL_REPOSITORY_CACHE contains an unevaluated placeholder"
+fi
+
+if [[ -n "$distdir" && "$distdir" == *'${'* ]]; then
+  add_error "BAZEL_DISTDIR contains an unevaluated placeholder"
+fi
+
+if $strict_nix; then
+  attic_endpoint="${ATTIC_SERVER:-}"
+  attic_key="${ATTIC_PUBLIC_KEY:-}"
+  nix_config="${NIX_CONFIG:-}"
+
+  if [[ -n "$attic_endpoint" || -n "$attic_key" ]]; then
+    if [[ -z "$attic_endpoint" || -z "$attic_key" ]]; then
+      add_error "Attic cache environment is partial; set both ATTIC_SERVER and ATTIC_PUBLIC_KEY or neither"
+    fi
+  fi
+
+  if [[ "$nix_config" == *attic* && "$nix_config" != *extra-substituters* ]]; then
+    add_error "NIX_CONFIG mentions Attic but does not set extra-substituters"
+  fi
+
+  if [[ "$nix_config" == *attic* && "$nix_config" != *trusted-public-keys* && "$nix_config" != *extra-trusted-public-keys* ]]; then
+    add_error "NIX_CONFIG mentions Attic but does not set trusted public keys"
+  fi
+fi
+
+cat <<EOF
+Bazel substrate mode: ${effective_mode}
+Bazel detected substrate: ${expected_mode}
+Bazel remote cache: $(describe_endpoint "$remote_cache")
+Bazel remote executor: $(describe_endpoint "$remote_executor")
+Bazel execution platform: ${execution_platform:-unset}
+Bazel repository cache: $(if [[ -n "$repository_cache" ]]; then printf 'configured'; else printf 'unset'; fi)
+Bazel distdir: $(if [[ -n "$distdir" ]]; then printf 'configured'; else printf 'unset'; fi)
+EOF
+
+if ((${#errors[@]} > 0)); then
+  printf '\nBazel cache/REAPI contract failed:\n' >&2
+  for error in "${errors[@]}"; do
+    printf '  - %s\n' "$error" >&2
+  done
+  exit 1
+fi
+
+printf 'Bazel cache/REAPI contract passed\n'

--- a/scripts/validation/check-bazel-cache-policy.sh
+++ b/scripts/validation/check-bazel-cache-policy.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
+  cd "${TEST_SRCDIR}/${TEST_WORKSPACE}"
+else
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  cd "$repo_root"
+fi
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_contains() {
+  local path="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if ! grep -Eq -- "$pattern" "$path"; then
+    fail "$description missing from $path"
+  fi
+}
+
+reject_contains() {
+  local path="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if grep -Eq -- "$pattern" "$path"; then
+    fail "$description found in $path"
+  fi
+}
+
+reject_contains .bazelrc 'bazel-cache\.fuzzy-dev\.tinyland\.dev' "stale Bazel cache endpoint"
+reject_contains .bazelrc '^[[:space:]]*build:remote[[:space:]]+--remote_cache=' "hard-coded remote cache endpoint"
+reject_contains .bazelrc '^[[:space:]]*(build|test):.*--remote_executor=' "hard-coded remote executor endpoint"
+require_contains .bazelrc 'explicit --remote_cache flag' "operator-provided remote cache comment"
+require_contains .bazelrc 'build:remote --remote_upload_local_results=false' "read-only remote cache default"
+require_contains .bazelrc 'build:executor-backed --config=ci' "endpoint-free executor-backed config"
+
+contract="scripts/validation/bazel-cache-contract.sh"
+require_contains "$contract" 'GF_BAZEL_SUBSTRATE_MODE' "Bazel substrate mode contract"
+require_contains "$contract" 'BAZEL_REMOTE_CACHE' "Bazel remote cache contract"
+require_contains "$contract" 'BAZEL_REMOTE_EXECUTOR' "Bazel remote executor contract"
+require_contains "$contract" 'executor-backed' "executor-backed mode contract"
+reject_contains "$contract" 'bazel-cache\.fuzzy-dev\.tinyland\.dev' "stale Bazel cache endpoint"
+
+eligibility="config/bazel-rbe-target-eligibility.json"
+require_contains "$eligibility" 'TIN-2170' "tracker-linked RBE eligibility manifest"
+require_contains "$eligibility" 'Remote cache hits are not RBE proof' "cache-vs-RBE invariant"
+require_contains "$eligibility" 'executor-backed mode is explicit-proof only' "explicit RBE proof posture"
+
+validator="scripts/validation/validate-bazel-rbe-target-eligibility.py"
+require_contains "$validator" 'remote executor process evidence' "RBE proof evidence validator"
+require_contains "$validator" '--allow-candidate' "candidate proof gate"
+
+cache_wrapper="scripts/bazel-cache-backed.sh"
+require_contains "$cache_wrapper" 'bazel-cache-contract.sh' "wrapper contract preflight"
+require_contains "$cache_wrapper" '--remote_cache=\$\{remote_cache\}' "wrapper remote cache flag"
+require_contains "$cache_wrapper" '--remote_executor=\$\{remote_executor\}' "wrapper remote executor flag"
+require_contains "$cache_wrapper" '--remote_upload_local_results=\$\{upload\}' "wrapper upload mode flag"
+
+proof_wrapper="scripts/bazel-rbe-proof.sh"
+require_contains "$proof_wrapper" 'GF_RBE_PROOF_MODE=explicit' "explicit RBE proof mode gate"
+require_contains "$proof_wrapper" 'validate-bazel-rbe-target-eligibility.py' "RBE eligibility validation"
+require_contains "$proof_wrapper" '--remote_accept_cached=false' "forced execution proof flag"
+
+workflow=".github/workflows/gloriousflywheel-proof.yml"
+require_contains "$workflow" 'scripts/bazel-cache-backed.sh test //\.\.\.' "Bazel cache-backed wrapper invocation"
+require_contains "$workflow" 'scripts/bazel-rbe-proof.sh' "Bazel RBE proof wrapper invocation"
+require_contains "$workflow" 'BAZEL_REMOTE_UPLOAD' "remote upload mode wiring"
+require_contains "$workflow" 'GF_RBE_PROOF_MODE=explicit' "explicit proof mode workflow gate"
+reject_contains "$workflow" 'echo .*\$BAZEL_REMOTE_CACHE' "private remote cache endpoint echo"
+reject_contains "$workflow" '--remote_cache=\$\{BAZEL_REMOTE_CACHE\}' "workflow-local remote cache handroll"
+reject_contains "$workflow" 'bazel-cache\.nix-cache\.svc\.cluster\.local' "private Bazel cache endpoint literal"
+reject_contains "$workflow" 'bazel-cache\.fuzzy-dev\.tinyland\.dev' "stale Bazel cache endpoint"
+
+echo "Bazel cache policy check passed"

--- a/scripts/validation/test-bazel-cache-backed-wrapper.sh
+++ b/scripts/validation/test-bazel-cache-backed-wrapper.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
+  cd "${TEST_SRCDIR}/${TEST_WORKSPACE}"
+else
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_bazel="$tmpdir/fake-bazel"
+capture="$tmpdir/bazel-args.txt"
+
+cat >"$fake_bazel" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >"${BAZEL_ARG_CAPTURE:?}"
+EOF
+chmod +x "$fake_bazel"
+
+env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_BIN="$fake_bazel" \
+  BAZEL_ARG_CAPTURE="$capture" \
+  TINYLAND_CLEANUP_BAZEL_OUTPUT_USER_ROOT="$tmpdir/output" \
+  TINYLAND_CLEANUP_BAZEL_DISK_CACHE="$tmpdir/disk-cache" \
+  bash scripts/bazel-cache-backed.sh test //:dummy
+
+grep -F -- "--output_user_root=$tmpdir/output" "$capture" >/dev/null
+grep -Fx "test" "$capture" >/dev/null
+grep -F -- "--config=ci-local" "$capture" >/dev/null
+grep -F -- "--disk_cache=$tmpdir/disk-cache" "$capture" >/dev/null
+grep -F -- "//:dummy" "$capture" >/dev/null
+
+env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_BIN="$fake_bazel" \
+  BAZEL_ARG_CAPTURE="$capture" \
+  BAZEL_REMOTE_CACHE="grpc://bazel-cache.example.internal:9092" \
+  BAZEL_REMOTE_UPLOAD="true" \
+  GF_BAZEL_SUBSTRATE_MODE="shared-cache-backed" \
+  bash scripts/bazel-cache-backed.sh build //:all_tests
+
+grep -Fx "build" "$capture" >/dev/null
+grep -F -- "--config=ci" "$capture" >/dev/null
+grep -F -- "--remote_cache=grpc://bazel-cache.example.internal:9092" "$capture" >/dev/null
+grep -F -- "--remote_upload_local_results=true" "$capture" >/dev/null
+grep -F -- "--remote_download_outputs=toplevel" "$capture" >/dev/null
+
+env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_BIN="$fake_bazel" \
+  BAZEL_ARG_CAPTURE="$capture" \
+  BAZEL_REMOTE_CACHE="grpc://bazel-cache.example.internal:9092" \
+  BAZEL_REMOTE_EXECUTOR="grpc://rbe.example.internal:8980" \
+  GF_BAZEL_SUBSTRATE_MODE="executor-backed" \
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM="linux-x86_64" \
+  bash scripts/bazel-cache-backed.sh test //:bazel_cache_policy_check
+
+grep -F -- "--config=executor-backed" "$capture" >/dev/null
+grep -F -- "--remote_executor=grpc://rbe.example.internal:8980" "$capture" >/dev/null
+grep -F -- "--remote_default_exec_properties=gf.platform=linux-x86_64" "$capture" >/dev/null
+
+echo "bazel-cache-backed wrapper tests passed"

--- a/scripts/validation/test-bazel-cache-contract.sh
+++ b/scripts/validation/test-bazel-cache-contract.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
+  cd "${TEST_SRCDIR}/${TEST_WORKSPACE}"
+else
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+run_contract() {
+  env -i \
+    PATH="$PATH" \
+    HOME="${HOME:-$tmpdir/home}" \
+    "$@" \
+    bash scripts/validation/bazel-cache-contract.sh
+}
+
+run_contract >"$tmpdir/local.out"
+grep -F "Bazel substrate mode: compatibility-local-only" "$tmpdir/local.out" >/dev/null
+grep -F "Bazel cache/REAPI contract passed" "$tmpdir/local.out" >/dev/null
+
+env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_REMOTE_CACHE="grpc://bazel-cache.example.internal:9092" \
+  GF_BAZEL_SUBSTRATE_MODE="shared-cache-backed" \
+  bash scripts/validation/bazel-cache-contract.sh --strict >"$tmpdir/cache.out"
+grep -F "Bazel substrate mode: shared-cache-backed" "$tmpdir/cache.out" >/dev/null
+grep -F "Bazel remote cache: grpc://<configured>" "$tmpdir/cache.out" >/dev/null
+
+if env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_REMOTE_EXECUTOR="grpc://rbe.example.internal:8980" \
+  GF_BAZEL_SUBSTRATE_MODE="executor-backed" \
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM="linux-x86_64" \
+  bash scripts/validation/bazel-cache-contract.sh --strict >"$tmpdir/executor-missing-cache.out" 2>&1; then
+  echo "expected executor without cache to fail" >&2
+  exit 1
+fi
+grep -F "BAZEL_REMOTE_EXECUTOR requires BAZEL_REMOTE_CACHE" "$tmpdir/executor-missing-cache.out" >/dev/null
+
+if env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_REMOTE_CACHE="grpc://bazel-cache.fuzzy-dev.invalid:9092" \
+  GF_BAZEL_SUBSTRATE_MODE="shared-cache-backed" \
+  bash scripts/validation/bazel-cache-contract.sh --strict >"$tmpdir/stale.out" 2>&1; then
+  echo "expected stale cache endpoint to fail" >&2
+  exit 1
+fi
+grep -F "stale legacy cache endpoint" "$tmpdir/stale.out" >/dev/null
+
+echo "bazel-cache-contract tests passed"

--- a/scripts/validation/test-bazel-rbe-proof-wrapper.sh
+++ b/scripts/validation/test-bazel-rbe-proof-wrapper.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
+  cd "${TEST_SRCDIR}/${TEST_WORKSPACE}"
+else
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_bazel="$tmpdir/fake-bazel"
+capture="$tmpdir/bazel-args.txt"
+
+cat >"$fake_bazel" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >"${BAZEL_ARG_CAPTURE:?}"
+EOF
+chmod +x "$fake_bazel"
+
+if env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_BIN="$fake_bazel" \
+  BAZEL_ARG_CAPTURE="$capture" \
+  BAZEL_REMOTE_CACHE="grpc://bazel-cache.example.internal:9092" \
+  BAZEL_REMOTE_EXECUTOR="grpc://rbe.example.internal:8980" \
+  GF_BAZEL_SUBSTRATE_MODE="executor-backed" \
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM="linux-x86_64" \
+  bash scripts/bazel-rbe-proof.sh --target //:bazel_cache_policy_check >"$tmpdir/missing-mode.out" 2>&1; then
+  echo "expected proof wrapper to require explicit proof mode" >&2
+  exit 1
+fi
+grep -F "GF_RBE_PROOF_MODE=explicit" "$tmpdir/missing-mode.out" >/dev/null
+
+env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_BIN="$fake_bazel" \
+  BAZEL_ARG_CAPTURE="$capture" \
+  GF_RBE_PROOF_MODE="explicit" \
+  BAZEL_REMOTE_CACHE="grpc://bazel-cache.example.internal:9092" \
+  BAZEL_REMOTE_EXECUTOR="grpc://rbe.example.internal:8980" \
+  GF_BAZEL_SUBSTRATE_MODE="executor-backed" \
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM="linux-x86_64" \
+  bash scripts/bazel-rbe-proof.sh \
+    --target //:bazel_cache_policy_check \
+    --bazel-command test \
+    -- --test_output=errors
+
+grep -Fx "test" "$capture" >/dev/null
+grep -F -- "--remote_accept_cached=false" "$capture" >/dev/null
+grep -F -- "--remote_executor=grpc://rbe.example.internal:8980" "$capture" >/dev/null
+grep -F -- "--test_output=errors" "$capture" >/dev/null
+grep -F -- "//:bazel_cache_policy_check" "$capture" >/dev/null
+
+env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_BIN="$fake_bazel" \
+  BAZEL_ARG_CAPTURE="$capture" \
+  GF_RBE_PROOF_MODE="explicit" \
+  BAZEL_REMOTE_CACHE="grpc://bazel-cache.example.internal:9092" \
+  BAZEL_REMOTE_EXECUTOR="grpc://rbe.example.internal:8980" \
+  GF_BAZEL_SUBSTRATE_MODE="executor-backed" \
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM="linux-x86_64" \
+  bash scripts/bazel-rbe-proof.sh --target //:bazel_cache_policy_check
+
+grep -F -- "--remote_accept_cached=false" "$capture" >/dev/null
+grep -F -- "//:bazel_cache_policy_check" "$capture" >/dev/null
+
+if env -i \
+  PATH="$PATH" \
+  HOME="${HOME:-$tmpdir/home}" \
+  BAZEL_BIN="$fake_bazel" \
+  BAZEL_ARG_CAPTURE="$capture" \
+  GF_RBE_PROOF_MODE="explicit" \
+  BAZEL_REMOTE_CACHE="grpc://bazel-cache.example.internal:9092" \
+  BAZEL_REMOTE_EXECUTOR="grpc://rbe.example.internal:8980" \
+  GF_BAZEL_SUBSTRATE_MODE="executor-backed" \
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM="linux-x86_64" \
+  bash scripts/bazel-rbe-proof.sh --target //:all_tests >"$tmpdir/unlisted.out" 2>&1; then
+  echo "expected unlisted target to fail eligibility validation" >&2
+  exit 1
+fi
+grep -F "explicitly blocked from RBE proof" "$tmpdir/unlisted.out" >/dev/null
+
+echo "bazel-rbe-proof wrapper tests passed"

--- a/scripts/validation/validate-bazel-rbe-target-eligibility.py
+++ b/scripts/validation/validate-bazel-rbe-target-eligibility.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Validate the tinyland-cleanup Bazel RBE target eligibility manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = REPO_ROOT / "config" / "bazel-rbe-target-eligibility.json"
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        raise SystemExit(f"error: manifest not found: {path}") from None
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"error: invalid JSON in {path}: {exc}") from None
+
+    if not isinstance(data, dict):
+        raise SystemExit("error: manifest must be a JSON object")
+    return data
+
+
+def require(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def ensure_string_list(value: Any, field: str, errors: list[str], *, nonempty: bool = True) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        errors.append(f"{field} must be a list of nonempty strings")
+        return []
+    if nonempty and not value:
+        errors.append(f"{field} must not be empty")
+    return value
+
+
+def validate_entry_list(
+    data: dict[str, Any],
+    field: str,
+    errors: list[str],
+    *,
+    require_proof: bool,
+) -> list[dict[str, Any]]:
+    entries = data.get(field)
+    if not isinstance(entries, list):
+        errors.append(f"{field} must be a list")
+        return []
+
+    typed_entries: list[dict[str, Any]] = []
+    for index, entry in enumerate(entries):
+        prefix = f"{field}[{index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+
+        typed_entries.append(entry)
+        require(isinstance(entry.get("name"), str) and bool(entry.get("name")), f"{prefix}.name is required", errors)
+        labels = ensure_string_list(entry.get("labels"), f"{prefix}.labels", errors)
+
+        if field != "blocked_target_classes":
+            for label in labels:
+                if label.startswith("//") and ":" not in label:
+                    errors.append(f"{prefix}.labels entry {label!r} must use an explicit Bazel target label")
+
+            status = entry.get("status")
+            require(status in {"candidate", "proved"}, f"{prefix}.status must be candidate or proved", errors)
+            ensure_string_list(entry.get("allowed_modes"), f"{prefix}.allowed_modes", errors)
+            ensure_string_list(entry.get("requirements"), f"{prefix}.requirements", errors)
+            proof_required = ensure_string_list(entry.get("proof_required"), f"{prefix}.proof_required", errors)
+            require(
+                any("remote" in item.lower() and "process" in item.lower() for item in proof_required),
+                f"{prefix}.proof_required must require remote executor process evidence",
+                errors,
+            )
+            if require_proof:
+                require(status == "proved", f"{prefix} must be proved before entering proved_target_classes", errors)
+        else:
+            ensure_string_list(entry.get("blockers"), f"{prefix}.blockers", errors)
+
+    return typed_entries
+
+
+def validate_manifest(data: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    errors: list[str] = []
+
+    require(data.get("schema_version") == 1, "schema_version must be 1", errors)
+    owner_issue = data.get("owner_issue")
+    require(isinstance(owner_issue, str) and bool(owner_issue), "owner_issue is required", errors)
+    require(isinstance(data.get("updated"), str) and bool(data.get("updated")), "updated is required", errors)
+    require(isinstance(data.get("platform"), str) and bool(data.get("platform")), "platform is required", errors)
+    default_posture = data.get("default_posture")
+    require(
+        isinstance(default_posture, str) and "cache-forward" in default_posture,
+        "default_posture must describe cache-forward posture",
+        errors,
+    )
+
+    proved = validate_entry_list(data, "proved_target_classes", errors, require_proof=True)
+    candidates = validate_entry_list(data, "candidate_target_classes", errors, require_proof=False)
+    blocked = validate_entry_list(data, "blocked_target_classes", errors, require_proof=False)
+
+    invariants = ensure_string_list(data.get("invariants"), "invariants", errors)
+    invariant_text = "\n".join(invariants).lower()
+    for required in ("remote cache hits", "rbe proof", "attic", "flakehub", "broad presubmit", "runner"):
+        require(required in invariant_text, f"invariants must mention {required!r}", errors)
+
+    require(bool(candidates), "candidate_target_classes must contain at least one explicit proof candidate", errors)
+    require(bool(blocked), "blocked_target_classes must document known unsafe target classes", errors)
+
+    seen_labels: dict[str, str] = {}
+    for section, entries in (
+        ("proved_target_classes", proved),
+        ("candidate_target_classes", candidates),
+        ("blocked_target_classes", blocked),
+    ):
+        for entry in entries:
+            for label in entry.get("labels", []):
+                previous = seen_labels.setdefault(label, section)
+                if previous != section:
+                    errors.append(f"label {label!r} appears in both {previous} and {section}")
+
+    if errors:
+        print("Bazel RBE target eligibility manifest failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        raise SystemExit(1)
+
+    return proved, candidates, blocked
+
+
+def find_target(target: str, entries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for entry in entries:
+        if target in entry.get("labels", []):
+            return entry
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--target", help="Require that a target is eligible for explicit proof")
+    parser.add_argument("--allow-candidate", action="store_true", help="Allow candidate targets for proof runs")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args()
+
+    data = load_manifest(args.manifest)
+    proved, candidates, blocked = validate_manifest(data)
+
+    result: dict[str, Any] = {
+        "manifest": str(args.manifest),
+        "proved_target_classes": len(proved),
+        "candidate_target_classes": len(candidates),
+        "blocked_target_classes": len(blocked),
+    }
+
+    if args.target:
+        target = args.target
+        if find_target(target, blocked):
+            print(f"error: target {target} is explicitly blocked from RBE proof", file=sys.stderr)
+            return 1
+        if find_target(target, proved):
+            result["target_status"] = "proved"
+        elif find_target(target, candidates):
+            if not args.allow_candidate:
+                print(f"error: target {target} is a candidate; pass --allow-candidate for proof runs", file=sys.stderr)
+                return 1
+            result["target_status"] = "candidate"
+        else:
+            print(f"error: target {target} is not listed for RBE proof", file=sys.stderr)
+            return 1
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print("Bazel RBE target eligibility manifest passed")
+        if args.target:
+            print(f"Target {args.target}: {result['target_status']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an endpoint-free Bazel cache/REAPI contract and cache-backed wrapper
- add explicit RBE proof wrapper gated by `GF_RBE_PROOF_MODE=explicit` and `config/bazel-rbe-target-eligibility.json`
- wire wrapper and manifest validation into Bazel tests and the GloriousFlywheel proof workflow
- add actionlint runner-label config and docs for cache-backed vs executor-backed proof boundaries

## Validation
- `bash scripts/validation/test-bazel-cache-contract.sh`
- `bash scripts/validation/test-bazel-cache-backed-wrapper.sh`
- `bash scripts/validation/test-bazel-rbe-proof-wrapper.sh`
- `bash scripts/validation/check-bazel-cache-policy.sh`
- `scripts/validation/validate-bazel-rbe-target-eligibility.py`
- `nix shell nixpkgs#actionlint --command actionlint .github/workflows/gloriousflywheel-proof.yml`
- `nix shell nixpkgs#buildifier --command buildifier -mode=check BUILD.bazel`
- `nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
- `nix build .#default --no-link --print-build-logs --builders '\ --max-jobs 1 --cores 1`