### PR TITLE
feat: adopt GloriousFlywheel front-door kit

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@ common --enable_bzlmod
 
 build --announce_rc
 build --spawn_strategy=sandboxed
+build --experimental_convenience_symlinks=ignore
 
 test --test_output=errors
 test --test_summary=detailed

--- a/.bazelrc
+++ b/.bazelrc
@@ -39,3 +39,5 @@ test:ci-local --test_summary=short
 # Backward-compatible alias retained for older docs and proof invocations.
 build:ci-cached --config=ci
 test:ci-cached --config=ci
+
+try-import %workspace%/.bazelrc.flywheel

--- a/.bazelrc.flywheel
+++ b/.bazelrc.flywheel
@@ -1,0 +1,24 @@
+# GloriousFlywheel consumer Bazel cache/RBE contract.
+#
+# This file is endpoint-free on purpose. Set BAZEL_REMOTE_CACHE,
+# BAZEL_REMOTE_EXECUTOR, GF_BAZEL_SUBSTRATE_MODE, and runtime auth through the
+# fleet-managed profile, CI runtime, or .env.flywheel.local fallback. The
+# gloriousflywheel-bazel wrapper passes concrete endpoint flags after validating
+# the profile shape.
+
+build:ci-cached --remote_upload_local_results=true
+build:ci-cached --remote_timeout=60
+build:ci-cached --experimental_remote_cache_compression
+
+test:ci-cached --remote_upload_local_results=true
+test:ci-cached --remote_timeout=60
+test:ci-cached --experimental_remote_cache_compression
+
+# Opt-in executor-backed contract. The executor endpoint is intentionally not
+# set here; gloriousflywheel-bazel passes --remote_executor from
+# BAZEL_REMOTE_EXECUTOR only after it validates executor-backed mode.
+build:executor-backed --config=ci-cached
+build:executor-backed --remote_local_fallback=false
+build:executor-backed --spawn_strategy=remote
+build:executor-backed --remote_download_minimal
+test:executor-backed --config=executor-backed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test
-        run: nix develop --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+        env:
+          BAZEL_OUTPUT_USER_ROOT: /tmp/tinyland-cleanup-bazel
+        run: nix develop --command just flywheel-test //...
 
   nix:
     name: Nix package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   go:
     name: Go
-    runs-on: ubuntu-latest
+    runs-on: tinyland-nix
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Version consistency
@@ -23,40 +23,26 @@ jobs:
             echo "::error::version mismatch — keep VERSION, MODULE.bazel, and main.go in sync"
             exit 1
           fi
-      - uses: actions/setup-go@v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
       - name: Build
-        run: go build ./...
-        env:
-          GOFLAGS: -mod=vendor
+        run: nix develop --command go build ./...
       - name: Test
-        run: go test ./...
-        env:
-          GOFLAGS: -mod=vendor
+        run: nix develop --command go test ./...
       - name: Vet
-        run: go vet ./...
-        env:
-          GOFLAGS: -mod=vendor
+        run: nix develop --command go vet ./...
 
   bazel:
     name: Bazel
-    runs-on: ubuntu-latest
+    runs-on: tinyland-nix
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
       - name: Test
-        run: nix shell nixpkgs#bazelisk --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+        run: nix develop --command bazelisk --output_user_root=/tmp/tinyland-cleanup-bazel test //...
 
   nix:
     name: Nix package
-    runs-on: ubuntu-latest
+    runs-on: tinyland-nix
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
       - name: Flake metadata
         run: nix flake check --no-build
       - name: Build package

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,6 +15,7 @@ gazelle(name = "gazelle")
 exports_files([
     ".bazelrc",
     ".github/actionlint.yaml",
+    ".github/workflows/ci.yml",
     ".github/workflows/gloriousflywheel-proof.yml",
     ".bazelrc.flywheel",
     "config/bazel-rbe-target-eligibility.json",
@@ -37,6 +38,7 @@ filegroup(
     srcs = [
         ".bazelrc",
         ".github/actionlint.yaml",
+        ".github/workflows/ci.yml",
         ".github/workflows/gloriousflywheel-proof.yml",
         ".bazelrc.flywheel",
         "config/bazel-rbe-target-eligibility.json",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,15 +16,20 @@ exports_files([
     ".bazelrc",
     ".github/actionlint.yaml",
     ".github/workflows/gloriousflywheel-proof.yml",
+    ".bazelrc.flywheel",
     "config/bazel-rbe-target-eligibility.json",
+    "Justfile",
+    "justfile.flywheel",
     "scripts/bazel-cache-backed.sh",
     "scripts/bazel-rbe-proof.sh",
     "scripts/validation/bazel-cache-contract.sh",
     "scripts/validation/check-bazel-cache-policy.sh",
+    "scripts/validation/check-flywheel-frontdoor-kit.sh",
     "scripts/validation/test-bazel-cache-backed-wrapper.sh",
     "scripts/validation/test-bazel-cache-contract.sh",
     "scripts/validation/test-bazel-rbe-proof-wrapper.sh",
     "scripts/validation/validate-bazel-rbe-target-eligibility.py",
+    "scripts/gloriousflywheel-bazel.sh",
 ])
 
 filegroup(
@@ -33,15 +38,31 @@ filegroup(
         ".bazelrc",
         ".github/actionlint.yaml",
         ".github/workflows/gloriousflywheel-proof.yml",
+        ".bazelrc.flywheel",
         "config/bazel-rbe-target-eligibility.json",
+        "Justfile",
+        "justfile.flywheel",
         "scripts/bazel-cache-backed.sh",
         "scripts/bazel-rbe-proof.sh",
+        "scripts/gloriousflywheel-bazel.sh",
         "scripts/validation/bazel-cache-contract.sh",
         "scripts/validation/check-bazel-cache-policy.sh",
+        "scripts/validation/check-flywheel-frontdoor-kit.sh",
         "scripts/validation/test-bazel-cache-backed-wrapper.sh",
         "scripts/validation/test-bazel-cache-contract.sh",
         "scripts/validation/test-bazel-rbe-proof-wrapper.sh",
         "scripts/validation/validate-bazel-rbe-target-eligibility.py",
+    ],
+)
+
+sh_test(
+    name = "flywheel_frontdoor_kit_check",
+    srcs = ["scripts/validation/check-flywheel-frontdoor-kit.sh"],
+    data = [":bazel_control_plane_files"],
+    tags = [
+        "bazel-cache-policy",
+        "fast",
+        "presubmit",
     ],
 )
 

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,1 @@
+import? "justfile.flywheel"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,9 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
+    # Shared tinyland-nix ARC runners currently execute jobs as root; rules_python
+    # otherwise rejects the hermetic interpreter before CI reaches the docs graph.
+    ignore_root_user_error = True,
     is_default = True,
     python_version = "3.12",
 )

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,6 +45,10 @@ BAZEL_REMOTE_CACHE=grpc://example.internal:9092 \
   bash scripts/bazel-cache-backed.sh test //...
 ```
 
+Pull-request CI dogfoods the shared `tinyland-nix` runner lane and enters the
+same Nix devshell before Go, Bazel, and Nix package checks. Do not move normal
+CI back to `ubuntu-latest` as a cache or runner fallback.
+
 Remote-execution proof is separate from cache-backed validation:
 
 ```sh

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,8 +22,7 @@ nix build .#default --no-link --print-build-logs
 ## Bazel graph
 
 ```sh
-nix shell nixpkgs#bazelisk --command bazelisk \
-  --output_user_root=/tmp/tinyland-cleanup-bazel test //...
+nix develop --command just flywheel-test //...
 ```
 
 ## Shared-cache and remote-execution proof
@@ -46,8 +45,13 @@ BAZEL_REMOTE_CACHE=grpc://example.internal:9092 \
 ```
 
 Pull-request CI dogfoods the shared `tinyland-nix` runner lane and enters the
-same Nix devshell before Go, Bazel, and Nix package checks. Do not move normal
-CI back to `ubuntu-latest` as a cache or runner fallback.
+same Nix devshell before Go, Bazel, and Nix package checks. Bazel CI uses the
+front-door kit (`just flywheel-test`), not a raw `bazelisk` command. Do not move
+normal CI back to `ubuntu-latest` as a cache or runner fallback.
+
+The shared runner currently executes jobs as root, so `MODULE.bazel` explicitly
+opts the docs Python toolchain into rules_python's root-user escape hatch. Remove
+that setting when the runner lane executes Bazel as a non-root user.
 
 Remote-execution proof is separate from cache-backed validation:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,6 +28,16 @@ nix shell nixpkgs#bazelisk --command bazelisk \
 
 ## Shared-cache and remote-execution proof
 
+The repo imports the GloriousFlywheel front-door kit through `Justfile` and
+`.bazelrc`. The advertised consumer commands are:
+
+```sh
+just flywheel-doctor
+just flywheel-enroll shared-cache-backed --cache-endpoint "$BAZEL_REMOTE_CACHE"
+just flywheel-verify
+just flywheel-test //...
+```
+
 Cache-backed validation on GloriousFlywheel runners:
 
 ```sh

--- a/justfile.flywheel
+++ b/justfile.flywheel
@@ -4,9 +4,10 @@
 #
 #   import? "justfile.flywheel"
 #
-# The commands assume `gloriousflywheel-profile-tools` is on PATH through the
-# fleet-managed NixOS/Home Manager profile, `nix develop`, or an equivalent
-# operator-managed tool profile.
+# The profile commands assume `gloriousflywheel-profile-tools` is on PATH
+# through the fleet-managed NixOS/Home Manager profile, `nix develop`, or an
+# equivalent operator-managed tool profile. Bazel commands use the local copied
+# wrapper so CI can dogfood the front door without relying on a global PATH shim.
 
 set dotenv-load := true
 
@@ -28,20 +29,20 @@ flywheel-consumer-env profile *args:
 
 # Run the GloriousFlywheel Bazel wrapper directly.
 flywheel-bazel command *args:
-    @gloriousflywheel-bazel "{{command}}" {{args}}
+    @./scripts/gloriousflywheel-bazel.sh "{{command}}" {{args}}
 
 # Cache-backed Bazel build through the wrapper.
 flywheel-build *targets:
-    @gloriousflywheel-bazel build {{targets}}
+    @./scripts/gloriousflywheel-bazel.sh build {{targets}}
 
 # Cache-backed Bazel test through the wrapper.
 flywheel-test *targets:
-    @gloriousflywheel-bazel test {{targets}}
+    @./scripts/gloriousflywheel-bazel.sh test {{targets}}
 
 # Cache-backed Bazel fetch through the wrapper.
 flywheel-fetch *targets:
-    @gloriousflywheel-bazel fetch {{targets}}
+    @./scripts/gloriousflywheel-bazel.sh fetch {{targets}}
 
 # Print Bazel info through the wrapper after profile validation.
 flywheel-info *args:
-    @gloriousflywheel-bazel info {{args}}
+    @./scripts/gloriousflywheel-bazel.sh info {{args}}

--- a/justfile.flywheel
+++ b/justfile.flywheel
@@ -1,0 +1,47 @@
+# GloriousFlywheel consumer front-door recipes.
+#
+# Include this file from a consumer repo Justfile:
+#
+#   import? "justfile.flywheel"
+#
+# The commands assume `gloriousflywheel-profile-tools` is on PATH through the
+# fleet-managed NixOS/Home Manager profile, `nix develop`, or an equivalent
+# operator-managed tool profile.
+
+set dotenv-load := true
+
+# Explain the current GloriousFlywheel enrollment/profile state.
+flywheel-doctor *args:
+    @flywheel-doctor {{args}}
+
+# Fail unless the current shell is attached or explicitly in local-proof mode.
+flywheel-verify *args:
+    @flywheel-verify {{args}}
+
+# Materialize a fallback .env.flywheel.local profile for a consumer repo.
+flywheel-enroll profile *args:
+    @flywheel-enroll "{{profile}}" {{args}}
+
+# Materialize a sourceable non-secret GloriousFlywheel Bazel profile.
+flywheel-consumer-env profile *args:
+    @flywheel-consumer-env "{{profile}}" {{args}}
+
+# Run the GloriousFlywheel Bazel wrapper directly.
+flywheel-bazel command *args:
+    @gloriousflywheel-bazel "{{command}}" {{args}}
+
+# Cache-backed Bazel build through the wrapper.
+flywheel-build *targets:
+    @gloriousflywheel-bazel build {{targets}}
+
+# Cache-backed Bazel test through the wrapper.
+flywheel-test *targets:
+    @gloriousflywheel-bazel test {{targets}}
+
+# Cache-backed Bazel fetch through the wrapper.
+flywheel-fetch *targets:
+    @gloriousflywheel-bazel fetch {{targets}}
+
+# Print Bazel info through the wrapper after profile validation.
+flywheel-info *args:
+    @gloriousflywheel-bazel info {{args}}

--- a/scripts/gloriousflywheel-bazel.sh
+++ b/scripts/gloriousflywheel-bazel.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# Consumer-side Bazel wrapper for the GloriousFlywheel cache/RBE contract.
+#
+# Copy this file into a consumer repo, for example:
+#   scripts/gloriousflywheel-bazel.sh
+#
+# Endpoint values come from the environment and are passed as explicit Bazel
+# flags. Do not put deployment-specific remote_cache or remote_executor values
+# in .bazelrc files; Bazel rc files are not the cache authority.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+candidate_envs=("${script_dir}/../.env.flywheel.local" "${PWD}/.env.flywheel.local")
+loaded_env=""
+for flywheel_env in "${candidate_envs[@]}"; do
+  if [[ -n ${loaded_env} && ${flywheel_env} == "${loaded_env}" ]]; then
+    continue
+  fi
+  if [[ -f ${flywheel_env} ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${flywheel_env}"
+    set +a
+    loaded_env="${flywheel_env}"
+  fi
+done
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/gloriousflywheel-bazel.sh <command> [args...]
+
+Commands:
+  build     Run a cache-backed Bazel build
+  test      Run cache-backed Bazel tests
+  run       Run a cache-backed Bazel target
+  coverage  Run cache-backed Bazel coverage
+  fetch     Populate external repositories through the same input contract
+  info      Validate cache attachment, then run bazel info
+
+Required environment:
+  BAZEL_REMOTE_CACHE        grpc://, grpcs://, http://, or https:// endpoint
+  GF_BAZEL_SUBSTRATE_MODE   shared-cache-backed, or executor-backed when
+                            BAZEL_REMOTE_EXECUTOR is set
+
+Optional environment:
+  BAZEL_BIN                 Bazel executable, defaults to bazelisk
+  BAZEL_REMOTE_EXECUTOR     Required in executor-backed mode
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM
+                            Executor platform property; defaults to
+                            gloriousflywheel-rbe-linux-x86_64
+  GF_BAZEL_REMOTE_UPLOAD    true only for trusted cache-writing jobs
+  GF_BAZEL_LOCAL_PROOF      port-forward only for explicit localhost proofs
+  BAZEL_CREDENTIAL_HELPER   Optional Bazel credential helper path or
+                            scope=/path entry. Repeat with newline-separated
+                            values when needed.
+  BAZEL_REMOTE_HEADER       Optional remote header as name=value. Repeat with
+                            newline-separated values when needed.
+  BAZEL_REMOTE_CACHE_HEADER Optional cache-only header as name=value. Repeat
+                            with newline-separated values when needed.
+  BAZEL_REMOTE_EXEC_HEADER  Optional executor-only header as name=value. Repeat
+                            with newline-separated values when needed.
+  BAZEL_REMOTE_INSTANCE_NAME
+                            Optional REAPI instance_name (default or
+                            spoke-<slug>) for cell-backed CAS/AC/RBE.
+  BAZEL_REMOTE_MAX_CONNECTIONS
+                            Optional cap for remote gRPC connections; useful
+                            for kubectl port-forward proof lanes.
+  GF_BAZEL_JOBS             Optional Bazel jobs override for executor-backed
+                            lanes; defaults to the rc profile.
+  BAZEL_OUTPUT_USER_ROOT    Optional isolated Bazel output user root
+  BAZEL_OUTPUT_BASE         Optional isolated Bazel output base
+  BAZEL_REPOSITORY_CACHE    Optional Bazel repository cache directory
+  BAZEL_DISTDIR             Optional colon-separated Bazel distdir paths
+  GF_BAZEL_REPOSITORY_DISABLE_DOWNLOAD
+                            true only for hermetic external-fetch proof lanes
+  GF_BAZEL_INJECT_REPOSITORIES
+                            Optional colon-separated repo=/absolute/path entries
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+
+command="$1"
+shift
+
+case "${command}" in
+build | test | run | coverage | fetch | info) ;;
+-h | --help)
+  usage
+  exit 0
+  ;;
+*)
+  echo "ERROR: unsupported Bazel command for GloriousFlywheel wrapper: ${command}" >&2
+  usage
+  exit 2
+  ;;
+esac
+
+bazel_bin="${BAZEL_BIN:-bazelisk}"
+remote_cache="${BAZEL_REMOTE_CACHE:-}"
+remote_executor="${BAZEL_REMOTE_EXECUTOR:-}"
+mode="${GF_BAZEL_SUBSTRATE_MODE:-}"
+upload="${GF_BAZEL_REMOTE_UPLOAD:-false}"
+local_proof="${GF_BAZEL_LOCAL_PROOF:-}"
+remote_execution_platform="${GF_BAZEL_REMOTE_EXECUTION_PLATFORM:-gloriousflywheel-rbe-linux-x86_64}"
+remote_instance_name="${BAZEL_REMOTE_INSTANCE_NAME:-}"
+repository_disable_download="${GF_BAZEL_REPOSITORY_DISABLE_DOWNLOAD:-false}"
+jobs="${GF_BAZEL_JOBS:-}"
+remote_max_connections="${BAZEL_REMOTE_MAX_CONNECTIONS:-}"
+startup_args=()
+external_fetch_args=()
+inject_repository_args=()
+executor_args=()
+auth_args=()
+cache_auth_args=()
+exec_auth_args=()
+routing_args=()
+
+validate_runtime_value() {
+  local flag_name="$1"
+  local value="$2"
+
+  if [[ ${value} == *'${'* ]] || [[ ${value} == *'}'* ]]; then
+    echo "ERROR: ${flag_name} contains a literal shell placeholder, not a real value." >&2
+    exit 1
+  fi
+}
+
+validate_endpoint() {
+  local flag_name="$1"
+  local value="$2"
+
+  if [[ -z ${value} ]]; then
+    echo "ERROR: ${flag_name} is required for GloriousFlywheel-backed Bazel work." >&2
+    exit 1
+  fi
+  if [[ ${value} =~ (attic-cache-dev|fuzzy-dev|attic\.dev-cluster|attic\.tinyland) ]]; then
+    echo "ERROR: ${flag_name} points at a stale GloriousFlywheel endpoint." >&2
+    exit 1
+  fi
+  if [[ ${value} == *'${'* ]] || [[ ${value} == *'}'* ]]; then
+    echo "ERROR: ${flag_name} is a literal shell placeholder, not a real endpoint." >&2
+    exit 1
+  fi
+  if [[ ! ${value} =~ ^(grpc|grpcs|http|https):// ]]; then
+    echo "ERROR: ${flag_name} must start with grpc://, grpcs://, http://, or https://." >&2
+    exit 1
+  fi
+  if [[ ${value} =~ ^(grpc|grpcs|http|https)://(localhost|127\.0\.0\.1|\[::1\])(:|/|$) ]] && [[ ${local_proof} != "port-forward" ]]; then
+    echo "ERROR: ${flag_name} uses localhost; set GF_BAZEL_LOCAL_PROOF=port-forward only for an explicit local proof." >&2
+    exit 1
+  fi
+}
+
+case "${local_proof}" in
+"" | port-forward) ;;
+*)
+  echo "ERROR: GF_BAZEL_LOCAL_PROOF must be empty or port-forward." >&2
+  exit 1
+  ;;
+esac
+
+if [[ -n ${BAZEL_OUTPUT_USER_ROOT:-} ]]; then
+  startup_args+=(--output_user_root="${BAZEL_OUTPUT_USER_ROOT}")
+fi
+
+if [[ -n ${BAZEL_OUTPUT_BASE:-} ]]; then
+  startup_args+=(--output_base="${BAZEL_OUTPUT_BASE}")
+fi
+
+if [[ -n ${BAZEL_REPOSITORY_CACHE:-} ]]; then
+  external_fetch_args+=(--repository_cache="${BAZEL_REPOSITORY_CACHE}")
+fi
+
+while IFS= read -r credential_helper; do
+  if [[ -n ${credential_helper} ]]; then
+    validate_runtime_value "BAZEL_CREDENTIAL_HELPER" "${credential_helper}"
+    auth_args+=(--credential_helper="${credential_helper}")
+  fi
+done <<<"${BAZEL_CREDENTIAL_HELPER:-}"
+
+while IFS= read -r remote_header; do
+  if [[ -n ${remote_header} ]]; then
+    validate_runtime_value "BAZEL_REMOTE_HEADER" "${remote_header}"
+    auth_args+=(--remote_header="${remote_header}")
+  fi
+done <<<"${BAZEL_REMOTE_HEADER:-}"
+
+while IFS= read -r remote_cache_header; do
+  if [[ -n ${remote_cache_header} ]]; then
+    validate_runtime_value "BAZEL_REMOTE_CACHE_HEADER" "${remote_cache_header}"
+    cache_auth_args+=(--remote_cache_header="${remote_cache_header}")
+  fi
+done <<<"${BAZEL_REMOTE_CACHE_HEADER:-}"
+
+while IFS= read -r remote_exec_header; do
+  if [[ -n ${remote_exec_header} ]]; then
+    validate_runtime_value "BAZEL_REMOTE_EXEC_HEADER" "${remote_exec_header}"
+    exec_auth_args+=(--remote_exec_header="${remote_exec_header}")
+  fi
+done <<<"${BAZEL_REMOTE_EXEC_HEADER:-}"
+
+if [[ -n ${remote_instance_name} ]]; then
+  validate_runtime_value "BAZEL_REMOTE_INSTANCE_NAME" "${remote_instance_name}"
+  routing_args+=(--remote_instance_name="${remote_instance_name}")
+fi
+
+if [[ -n ${BAZEL_DISTDIR:-} ]]; then
+  IFS=: read -r -a bazel_distdirs <<<"${BAZEL_DISTDIR}"
+  for bazel_distdir in "${bazel_distdirs[@]}"; do
+    if [[ -n ${bazel_distdir} ]]; then
+      external_fetch_args+=(--distdir="${bazel_distdir}")
+    fi
+  done
+fi
+
+if [[ -n ${GF_BAZEL_INJECT_REPOSITORIES:-} ]]; then
+  IFS=: read -r -a injected_repositories <<<"${GF_BAZEL_INJECT_REPOSITORIES}"
+  for inject_repository in "${injected_repositories[@]}"; do
+    if [[ -z ${inject_repository} ]]; then
+      continue
+    fi
+    if [[ ! ${inject_repository} =~ ^[A-Za-z][A-Za-z0-9_.-]*= ]]; then
+      echo "ERROR: GF_BAZEL_INJECT_REPOSITORIES entries must be repo=/absolute/path." >&2
+      exit 1
+    fi
+    inject_path="${inject_repository#*=}"
+    if [[ -z ${inject_path} || ${inject_path} != /* ]]; then
+      echo "ERROR: injected Bazel repositories must use absolute local paths." >&2
+      exit 1
+    fi
+    if [[ ! -d ${inject_path} ]]; then
+      echo "ERROR: injected Bazel repository path does not exist: ${inject_path}" >&2
+      exit 1
+    fi
+    inject_repository_args+=(--inject_repository="${inject_repository}")
+  done
+fi
+
+case "${repository_disable_download}" in
+true | 1 | yes)
+  external_fetch_args+=(--repository_disable_download)
+  ;;
+false | 0 | no | "") ;;
+*)
+  echo "ERROR: GF_BAZEL_REPOSITORY_DISABLE_DOWNLOAD must be true or false." >&2
+  exit 1
+  ;;
+esac
+
+validate_endpoint "BAZEL_REMOTE_CACHE" "${remote_cache}"
+
+case "${mode}" in
+shared-cache-backed)
+  if [[ -n ${remote_executor} ]]; then
+    echo "ERROR: BAZEL_REMOTE_EXECUTOR is set but GF_BAZEL_SUBSTRATE_MODE is shared-cache-backed." >&2
+    exit 1
+  fi
+  if [[ ${#exec_auth_args[@]} -gt 0 ]]; then
+    echo "ERROR: BAZEL_REMOTE_EXEC_HEADER requires executor-backed mode." >&2
+    exit 1
+  fi
+  bazel_config="ci-cached"
+  ;;
+executor-backed)
+  validate_endpoint "BAZEL_REMOTE_EXECUTOR" "${remote_executor}"
+  bazel_config="executor-backed"
+  executor_args+=(
+    --remote_executor="${remote_executor}"
+    --remote_local_fallback=false
+    --spawn_strategy=remote
+    --remote_default_exec_properties="gf.platform=${remote_execution_platform}"
+  )
+  if [[ ${#exec_auth_args[@]} -gt 0 ]]; then
+    executor_args+=("${exec_auth_args[@]}")
+  fi
+  if [[ -n ${jobs} ]]; then
+    executor_args+=(--jobs="${jobs}")
+  fi
+  if [[ -n ${remote_max_connections} ]]; then
+    executor_args+=(--remote_max_connections="${remote_max_connections}")
+  fi
+  ;;
+*)
+  echo "ERROR: GF_BAZEL_SUBSTRATE_MODE must be shared-cache-backed or executor-backed." >&2
+  exit 1
+  ;;
+esac
+
+case "${upload}" in
+true | 1 | yes)
+  upload_arg=(--remote_upload_local_results=true)
+  ;;
+false | 0 | no | "")
+  upload_arg=(--remote_upload_local_results=false)
+  ;;
+*)
+  echo "ERROR: GF_BAZEL_REMOTE_UPLOAD must be true or false." >&2
+  exit 1
+  ;;
+esac
+
+if ! command -v "${bazel_bin}" >/dev/null 2>&1; then
+  echo "ERROR: ${bazel_bin} is not on PATH; enter direnv or nix develop first." >&2
+  exit 127
+fi
+
+case "${command}" in
+info)
+  bazel_args=(
+    info
+    --remote_cache="${remote_cache}"
+    "${upload_arg[@]}"
+  )
+  if [[ ${#auth_args[@]} -gt 0 ]]; then
+    bazel_args+=("${auth_args[@]}")
+  fi
+  if [[ ${#cache_auth_args[@]} -gt 0 ]]; then
+    bazel_args+=("${cache_auth_args[@]}")
+  fi
+  if [[ ${#routing_args[@]} -gt 0 ]]; then
+    bazel_args+=("${routing_args[@]}")
+  fi
+  ;;
+*)
+  bazel_args=(
+    "${command}"
+    --config="${bazel_config}"
+    --remote_cache="${remote_cache}"
+    "${upload_arg[@]}"
+  )
+  if [[ ${#auth_args[@]} -gt 0 ]]; then
+    bazel_args+=("${auth_args[@]}")
+  fi
+  if [[ ${#cache_auth_args[@]} -gt 0 ]]; then
+    bazel_args+=("${cache_auth_args[@]}")
+  fi
+  if [[ ${#routing_args[@]} -gt 0 ]]; then
+    bazel_args+=("${routing_args[@]}")
+  fi
+  if [[ ${#executor_args[@]} -gt 0 ]]; then
+    bazel_args+=("${executor_args[@]}")
+  fi
+  if [[ ${#external_fetch_args[@]} -gt 0 ]]; then
+    bazel_args+=("${external_fetch_args[@]}")
+  fi
+  if [[ ${#inject_repository_args[@]} -gt 0 ]]; then
+    bazel_args+=("${inject_repository_args[@]}")
+  fi
+  ;;
+esac
+
+exec_args=("${bazel_bin}")
+if [[ ${#startup_args[@]} -gt 0 ]]; then
+  exec_args+=("${startup_args[@]}")
+fi
+exec_args+=("${bazel_args[@]}" "$@")
+exec "${exec_args[@]}"

--- a/scripts/validation/check-bazel-cache-policy.sh
+++ b/scripts/validation/check-bazel-cache-policy.sh
@@ -42,6 +42,7 @@ require_contains .bazelrc 'build:executor-backed --config=ci' "endpoint-free exe
 
 contract="scripts/validation/bazel-cache-contract.sh"
 require_contains "$contract" 'GF_BAZEL_SUBSTRATE_MODE' "Bazel substrate mode contract"
+require_contains .bazelrc 'experimental_convenience_symlinks=ignore' "Bazel convenience symlink suppression"
 require_contains "$contract" 'BAZEL_REMOTE_CACHE' "Bazel remote cache contract"
 require_contains "$contract" 'BAZEL_REMOTE_EXECUTOR' "Bazel remote executor contract"
 require_contains "$contract" 'executor-backed' "executor-backed mode contract"

--- a/scripts/validation/check-flywheel-frontdoor-kit.sh
+++ b/scripts/validation/check-flywheel-frontdoor-kit.sh
@@ -37,6 +37,8 @@ for path in Justfile justfile.flywheel .bazelrc.flywheel scripts/gloriousflywhee
   [[ -f "$path" ]] || fail "$path is missing"
 done
 
+[[ -f .github/workflows/ci.yml ]] || fail ".github/workflows/ci.yml is missing"
+
 require_contains Justfile '^import\? "justfile\.flywheel"$' "front-door Just import"
 
 require_contains justfile.flywheel '^flywheel-doctor\b' "flywheel-doctor recipe"
@@ -59,5 +61,9 @@ require_contains scripts/gloriousflywheel-bazel.sh 'BAZEL_REMOTE_CACHE' "wrapper
 require_contains scripts/gloriousflywheel-bazel.sh 'BAZEL_REMOTE_EXECUTOR' "wrapper executor endpoint contract"
 require_contains scripts/gloriousflywheel-bazel.sh 'remote_local_fallback=false' "wrapper executor fallback refusal"
 reject_contains scripts/gloriousflywheel-bazel.sh 'ubuntu-latest' "hosted-runner fallback"
+
+require_contains .github/workflows/ci.yml 'runs-on: tinyland-nix' "shared tinyland-nix CI runner"
+reject_contains .github/workflows/ci.yml 'ubuntu-latest' "hosted-runner fallback"
+reject_contains .github/workflows/ci.yml 'DeterminateSystems/nix-installer-action' "hosted-runner Nix installer fallback"
 
 echo "Flywheel front-door kit check passed"

--- a/scripts/validation/check-flywheel-frontdoor-kit.sh
+++ b/scripts/validation/check-flywheel-frontdoor-kit.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
+  cd "${TEST_SRCDIR}/${TEST_WORKSPACE}"
+else
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  cd "$repo_root"
+fi
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_contains() {
+  local path="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if ! grep -Eq -- "$pattern" "$path"; then
+    fail "$description missing from $path"
+  fi
+}
+
+reject_contains() {
+  local path="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if grep -Eq -- "$pattern" "$path"; then
+    fail "$description found in $path"
+  fi
+}
+
+for path in Justfile justfile.flywheel .bazelrc.flywheel scripts/gloriousflywheel-bazel.sh; do
+  [[ -f "$path" ]] || fail "$path is missing"
+done
+
+require_contains Justfile '^import\? "justfile\.flywheel"$' "front-door Just import"
+
+require_contains justfile.flywheel '^flywheel-doctor\b' "flywheel-doctor recipe"
+require_contains justfile.flywheel '^flywheel-enroll\b' "flywheel-enroll recipe"
+require_contains justfile.flywheel '^flywheel-verify\b' "flywheel-verify recipe"
+require_contains justfile.flywheel '^flywheel-bazel\b' "flywheel-bazel recipe"
+require_contains justfile.flywheel 'gloriousflywheel-bazel' "GloriousFlywheel Bazel wrapper invocation"
+
+require_contains .bazelrc 'try-import %workspace%/\.bazelrc\.flywheel' "front-door Bazel rc import"
+require_contains .bazelrc.flywheel '^build:ci-cached\b' "shared-cache Bazel config"
+require_contains .bazelrc.flywheel '^build:executor-backed --config=ci-cached$' "executor-backed Bazel config"
+require_contains .bazelrc.flywheel '^build:executor-backed --remote_local_fallback=false$' "executor fallback refusal"
+reject_contains .bazelrc.flywheel 'remote_cache=' "hard-coded remote cache endpoint"
+reject_contains .bazelrc.flywheel 'remote_executor=' "hard-coded remote executor endpoint"
+reject_contains .bazelrc.flywheel 'ubuntu-latest' "hosted-runner fallback"
+reject_contains .bazelrc.flywheel 'localhost|127\.0\.0\.1' "local proof endpoint"
+
+require_contains scripts/gloriousflywheel-bazel.sh 'GF_BAZEL_SUBSTRATE_MODE' "wrapper substrate-mode contract"
+require_contains scripts/gloriousflywheel-bazel.sh 'BAZEL_REMOTE_CACHE' "wrapper cache endpoint contract"
+require_contains scripts/gloriousflywheel-bazel.sh 'BAZEL_REMOTE_EXECUTOR' "wrapper executor endpoint contract"
+require_contains scripts/gloriousflywheel-bazel.sh 'remote_local_fallback=false' "wrapper executor fallback refusal"
+reject_contains scripts/gloriousflywheel-bazel.sh 'ubuntu-latest' "hosted-runner fallback"
+
+echo "Flywheel front-door kit check passed"

--- a/scripts/validation/check-flywheel-frontdoor-kit.sh
+++ b/scripts/validation/check-flywheel-frontdoor-kit.sh
@@ -45,7 +45,7 @@ require_contains justfile.flywheel '^flywheel-doctor\b' "flywheel-doctor recipe"
 require_contains justfile.flywheel '^flywheel-enroll\b' "flywheel-enroll recipe"
 require_contains justfile.flywheel '^flywheel-verify\b' "flywheel-verify recipe"
 require_contains justfile.flywheel '^flywheel-bazel\b' "flywheel-bazel recipe"
-require_contains justfile.flywheel 'gloriousflywheel-bazel' "GloriousFlywheel Bazel wrapper invocation"
+require_contains justfile.flywheel './scripts/gloriousflywheel-bazel.sh' "local GloriousFlywheel Bazel wrapper invocation"
 
 require_contains .bazelrc 'try-import %workspace%/\.bazelrc\.flywheel' "front-door Bazel rc import"
 require_contains .bazelrc.flywheel '^build:ci-cached\b' "shared-cache Bazel config"


### PR DESCRIPTION
## Summary

- Import the GloriousFlywheel front-door kit into tinyland-cleanup through `Justfile`, `justfile.flywheel`, `.bazelrc.flywheel`, and the generated `gloriousflywheel-bazel` wrapper.
- Wire `.bazelrc` to import the endpoint-free Flywheel fragment.
- Add `//:flywheel_frontdoor_kit_check` so the repo fails if the advertised front-door commands or endpoint-free contract drift.
- Update development docs to show the advertised `just flywheel-*` commands.

## TIN-2186 classification

This is the first measured consumer adoption tranche for TIN-2186.

Current classification for this branch: `shared-cache-backed` front-door adoption plumbing.

Boundary: this does not claim executor-backed RBE proof for tinyland-cleanup. Existing explicit RBE proof wrappers remain intact; executor-backed proof still requires real GloriousFlywheel endpoints and proof artifacts.

## Validation

- `flywheel-frontdoor-kit verify --target .`
- `bash scripts/validation/check-flywheel-frontdoor-kit.sh`
- `bash scripts/validation/check-bazel-cache-policy.sh`
- `bash scripts/validation/test-bazel-cache-backed-wrapper.sh`
- `bash scripts/validation/test-bazel-rbe-proof-wrapper.sh`
- `bash scripts/validation/test-bazel-cache-contract.sh`
- `nix shell /private/tmp/gf-tin2189-frontdoor-kit#gloriousflywheel-profile-tools nixpkgs#just --command sh -lc "command -v flywheel-doctor; command -v flywheel-enroll; command -v flywheel-verify; command -v gloriousflywheel-bazel; just --list"`
- `nix shell nixpkgs#bazelisk --command bazelisk test //:flywheel_frontdoor_kit_check //:bazel_cache_policy_check //:bazel_cache_contract_check //:bazel_cache_backed_wrapper_check //:bazel_rbe_proof_wrapper_check`
- `git diff --check`
- `shellcheck -e SC2016,SC2119,SC2120 scripts/validation/check-flywheel-frontdoor-kit.sh scripts/gloriousflywheel-bazel.sh scripts/bazel-cache-backed.sh scripts/bazel-rbe-proof.sh scripts/validation/*.sh`

Note: the local profile-tools check used the just-merged GloriousFlywheel worktree path because this PR was opened immediately after GloriousFlywheel PR #944 landed. The consumer contract itself is endpoint-free and does not commit local paths.