### PR TITLE
docs: correct site_url to the live Pages custom domain

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: tinyland-cleanup
 site_description: Conservative disk-pressure cleanup daemon for developer machines and CI hosts
-site_url: https://jesssullivan.github.io/tinyland-cleanup/
+site_url: https://transscendsurvival.org/tinyland-cleanup/
 repo_url: https://github.com/Jesssullivan/tinyland-cleanup
 repo_name: Jesssullivan/tinyland-cleanup
 docs_dir: .


### PR DESCRIPTION
One-line fix: `mkdocs.yml` `site_url` should be `https://transscendsurvival.org/tinyland-cleanup/` (the account's Pages custom domain, Cloudflare-fronted) so canonical links and the sitemap are correct. Pure doc change; CI rebuilds the site to validate.