### PR TITLE
docs: point site_url at the live GitHub Pages URL

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: tinyland-cleanup
 site_description: Conservative disk-pressure cleanup daemon for developer machines and CI hosts
-site_url: https://transscendsurvival.org/tinyland-cleanup/
+site_url: https://jesssullivan.github.io/tinyland-cleanup/
 repo_url: https://github.com/Jesssullivan/tinyland-cleanup
 repo_name: Jesssullivan/tinyland-cleanup
 docs_dir: .


### PR DESCRIPTION
The docs site serves at https://jesssullivan.github.io/tinyland-cleanup/. The prior `site_url` (`transscendsurvival.org/tinyland-cleanup/`) is a separate Cloudflare Pages site that doesn't serve this project, so canonical links and the sitemap were wrong. One-line fix.