### PR TITLE
ci: deploy docs through Flywheel front door

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,6 +1,12 @@
 name: Docs Deploy
 
 on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'MODULE.bazel'
+      - '.github/workflows/docs-deploy.yml'
   push:
     branches: [main]
     paths:
@@ -23,21 +29,26 @@ concurrency:
 jobs:
   build:
     name: Build site
-    runs-on: ubuntu-latest
+    runs-on: tinyland-nix
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
       - name: Build //docs:site
+        env:
+          BAZEL_OUTPUT_USER_ROOT: /tmp/tinyland-cleanup-bazel
+          GF_BAZEL_REMOTE_UPLOAD: "false"
         run: |
-          nix shell nixpkgs#bazelisk --command bazelisk \
-            --output_user_root=/tmp/tinyland-cleanup-bazel build //docs:site
+          nix develop --command just flywheel-build //docs:site
       - name: Stage site output
+        env:
+          BAZEL_OUTPUT_USER_ROOT: /tmp/tinyland-cleanup-bazel
+          GF_BAZEL_REMOTE_UPLOAD: "false"
         run: |
+          bazel_bin="$(nix develop --command just flywheel-info bazel-bin | tail -n 1)"
           mkdir -p _site
-          # bazel-bin is the convenience symlink to the built TreeArtifact;
-          # -L dereferences Bazel's read-only symlinks into real files for Pages.
-          cp -RL bazel-bin/docs/_site/. _site/
+          # -L dereferences Bazel's read-only TreeArtifact symlinks into real
+          # files for Pages. Do not rely on workspace convenience symlinks; the
+          # repo suppresses them so //... cannot recurse into bazel-* outputs.
+          cp -RL "${bazel_bin}/docs/_site/." _site/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: _site
@@ -45,7 +56,8 @@ jobs:
   deploy:
     name: Deploy to Pages
     needs: build
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    runs-on: tinyland-nix
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/scripts/validation/check-flywheel-frontdoor-kit.sh
+++ b/scripts/validation/check-flywheel-frontdoor-kit.sh
@@ -66,4 +66,15 @@ require_contains .github/workflows/ci.yml 'runs-on: tinyland-nix' "shared tinyla
 reject_contains .github/workflows/ci.yml 'ubuntu-latest' "hosted-runner fallback"
 reject_contains .github/workflows/ci.yml 'DeterminateSystems/nix-installer-action' "hosted-runner Nix installer fallback"
 
+if [[ -f .github/workflows/docs-deploy.yml ]]; then
+  require_contains .github/workflows/docs-deploy.yml 'pull_request:' "docs deploy pull-request build trigger"
+  require_contains .github/workflows/docs-deploy.yml 'runs-on: tinyland-nix' "docs deploy shared runner"
+  require_contains .github/workflows/docs-deploy.yml "if: github.event_name != 'pull_request'" "docs deploy PR deploy gate"
+  require_contains .github/workflows/docs-deploy.yml 'just flywheel-build //docs:site' "docs deploy front-door build"
+  require_contains .github/workflows/docs-deploy.yml 'just flywheel-info bazel-bin' "docs deploy Bazel output discovery"
+  reject_contains .github/workflows/docs-deploy.yml 'ubuntu-latest' "hosted runner fallback in docs deploy"
+  reject_contains .github/workflows/docs-deploy.yml 'DeterminateSystems/nix-installer-action' "hosted-runner Nix installer fallback in docs deploy"
+  reject_contains .github/workflows/docs-deploy.yml 'cp -RL bazel-bin/' "docs deploy convenience-symlink staging"
+fi
+
 echo "Flywheel front-door kit check passed"


### PR DESCRIPTION
Fixes the post-#103 Docs Deploy regression caused by correctly suppressing Bazel convenience symlinks.\n\nChanges:\n- run Docs Deploy build and deploy jobs on the shared tinyland-nix lane instead of ubuntu-latest\n- build docs with nix develop --command just flywheel-build //docs:site\n- stage the Pages artifact from just flywheel-info bazel-bin instead of relying on bazel-bin workspace symlinks\n- extend the front-door kit validator so hosted/raw/symlink docs deploy drift is caught\n\nValidation:\n- bash scripts/validation/check-flywheel-frontdoor-kit.sh\n- bash scripts/validation/check-bazel-cache-policy.sh\n- git diff --check