### PR TITLE
ci(bazel): fail loud on remote-cache outage — drop silent local fallback

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,9 @@ test --test_summary=detailed
 build:remote --remote_upload_local_results=false
 build:remote --remote_download_outputs=toplevel
 build:remote --remote_timeout=300
-build:remote --remote_local_fallback=true
+# Fail loud: do not silently fall back to local when the remote cache is
+# unavailable — a red build is the honest signal, not a quietly-degraded one.
+build:remote --remote_local_fallback=false
 
 # Remote executor endpoints are never stored in .bazelrc. Use
 # scripts/bazel-rbe-proof.sh with BAZEL_REMOTE_EXECUTOR, BAZEL_REMOTE_CACHE, and


### PR DESCRIPTION
## What
`build:remote` is a remote-**cache** lane (no executor). It carried `--remote_local_fallback=true`, so when the remote cache was unavailable Bazel **silently rebuilt locally** and the job still went green — a cache outage masked as success.

Flip to `--remote_local_fallback=false`: a cache/executor outage now surfaces as an honest **red build**.

## Note
Deliberate policy change (fail-loud over silent degradation), surfaced while verifying a code-honesty audit across the GloriousFlywheel adoption repos.