### PR TITLE
cleanup: prune Bazel logs and TCFS target caches

### DIFF
--- a/plugins/bazel.go
+++ b/plugins/bazel.go
@@ -89,9 +89,10 @@ func (p *BazelPlugin) buildCleanupPlan(ctx context.Context, level CleanupLevel, 
 		WouldRun: true,
 		Steps: []string{
 			"Discover Bazel output bases, repository caches, disk caches, and Bazelisk downloads",
+			"Discover Bazel server logs that may contain captured client environments",
 			"Measure logical and physical bytes without following repo-local bazel-* symlinks",
 			"Protect active output bases, protected workspace output bases, and newest output bases",
-			"Delete only stale inactive output bases and budget-excess cache tiers in real cleanup mode at moderate or higher levels",
+			"Delete only stale inactive output bases, stale inactive server logs, and budget-excess cache tiers in real cleanup mode at moderate or higher levels",
 			"Remove repo-local bazel-* symlinks only after their target output base was deleted",
 		},
 		Metadata: map[string]string{
@@ -308,7 +309,10 @@ func discoverBazelRootCandidates(root string) []bazelCandidate {
 
 	var candidates []bazelCandidate
 	if isBazelOutputBase(root) {
-		return []bazelCandidate{newBazelCandidate("output_base", filepath.Base(root), root, info.ModTime())}
+		return append(
+			[]bazelCandidate{newBazelCandidate("output_base", filepath.Base(root), root, info.ModTime())},
+			discoverBazelServerLogCandidates(root)...,
+		)
 	}
 	if isBazelPartialOutputBase(root) {
 		return []bazelCandidate{newBazelCandidate("partial_output_base", filepath.Base(root), root, info.ModTime())}
@@ -336,6 +340,7 @@ func discoverBazelRootCandidates(root string) []bazelCandidate {
 		case isBazelOutputBase(path):
 			if info, err := entry.Info(); err == nil {
 				candidates = append(candidates, newBazelCandidate("output_base", entry.Name(), path, info.ModTime()))
+				candidates = append(candidates, discoverBazelServerLogCandidates(path)...)
 			}
 		case isBazelPartialOutputBase(path):
 			if info, err := entry.Info(); err == nil {
@@ -392,11 +397,37 @@ func discoverBazelOutputBases(outputUserRoot string) []bazelCandidate {
 		switch {
 		case isBazelOutputBase(path):
 			candidates = append(candidates, newBazelCandidate("output_base", entry.Name(), path, info.ModTime()))
+			candidates = append(candidates, discoverBazelServerLogCandidates(path)...)
 		case isBazelPartialOutputBase(path):
 			candidates = append(candidates, newBazelCandidate("partial_output_base", entry.Name(), path, info.ModTime()))
 		}
 	}
 	return candidates
+}
+
+func discoverBazelServerLogCandidates(outputBase string) []bazelCandidate {
+	entries, err := os.ReadDir(outputBase)
+	if err != nil {
+		return nil
+	}
+
+	var candidates []bazelCandidate
+	for _, entry := range entries {
+		if entry.IsDir() || !bazelServerLogNameAllowed(entry.Name()) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		path := filepath.Join(outputBase, entry.Name())
+		candidates = append(candidates, newBazelCandidate("server_log", entry.Name(), path, info.ModTime()))
+	}
+	return candidates
+}
+
+func bazelServerLogNameAllowed(name string) bool {
+	return name == "command.log" || name == "jvm.out" || strings.HasPrefix(name, "java.log")
 }
 
 func discoverBazeliskCandidates(root string) []bazelCandidate {
@@ -733,6 +764,15 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 	case level == LevelWarning:
 		action = "review"
 		reason = "warning level reports Bazel cache footprint only"
+	case candidate.Type == "server_log":
+		if candidate.ModTime.After(now.Add(-staleAfter)) {
+			action = "keep"
+			protected = true
+			reason = "newer than configured Bazel server-log stale threshold"
+		} else {
+			action = "delete_server_log"
+			reason = "stale inactive Bazel server log; server logs can contain captured client environments"
+		}
 	case !outputBaseLike:
 		if !budgetExceeded {
 			action = "review_cache_budget"
@@ -777,6 +817,8 @@ func bazelTargetForCandidate(candidate bazelCandidate, staleAfter time.Duration,
 func bazelCandidateTier(candidateType string) string {
 	switch candidateType {
 	case "bazelisk":
+		return CleanupTierSafe
+	case "server_log":
 		return CleanupTierSafe
 	case "repository_cache", "disk_cache", "remote_cache", "output_base", "partial_output_base":
 		return CleanupTierWarm
@@ -851,6 +893,8 @@ func bazelTargetEligibleForDeletion(target CleanupTarget) bool {
 		return target.Type == "partial_output_base"
 	case "stop_idle_server_then_delete_output_base":
 		return target.Type == "output_base"
+	case "delete_server_log":
+		return target.Type == "server_log"
 	case "delete_cache_tier":
 		return target.Type == "repository_cache" || target.Type == "disk_cache" || target.Type == "remote_cache" || target.Type == "bazelisk"
 	default:
@@ -867,6 +911,8 @@ func deleteBazelTarget(ctx context.Context, target CleanupTarget, logger *slog.L
 		return deleteBazelOutputBase(target.Path, logger)
 	case "partial_output_base":
 		return deleteBazelPartialOutputBase(target.Path, logger)
+	case "server_log":
+		return deleteBazelServerLog(target.Path, logger)
 	case "repository_cache", "disk_cache", "remote_cache", "bazelisk":
 		return deleteBazelCacheTier(target.Type, target.Path, logger)
 	default:
@@ -1121,6 +1167,20 @@ func deleteBazelPartialOutputBase(path string, logger *slog.Logger) error {
 		return err
 	}
 	return os.RemoveAll(path)
+}
+
+func deleteBazelServerLog(path string, logger *slog.Logger) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || !bazelServerLogNameAllowed(filepath.Base(path)) {
+		return fmt.Errorf("refusing to delete unsafe Bazel server log path: %s", path)
+	}
+	if err := normalizeBazelDeletionPermissions(path, logger); err != nil {
+		return err
+	}
+	return os.Remove(path)
 }
 
 func cleanupRepoLocalBazelSymlinksForDeletedOutputBase(workspaceRoots []string, home string, outputBase string, logger *slog.Logger) int {

--- a/plugins/bazel_test.go
+++ b/plugins/bazel_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -903,6 +904,125 @@ func TestApplyBazelCleanupTargetsDeletesEligibleCacheTier(t *testing.T) {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("expected %s to be deleted, stat err=%v", path, err)
 		}
+	}
+}
+
+func TestDiscoverBazelRootCandidatesReportsServerLogs(t *testing.T) {
+	root := t.TempDir()
+	outputBase := filepath.Join(root, "_bazel_jess", "loggy")
+	makeBazelOutputBase(t, outputBase)
+	logPath := filepath.Join(outputBase, "java.log.neo.jess.log.java.20260702")
+	if err := os.WriteFile(logPath, []byte("client env"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outputBase, "not-a-bazel-log.txt"), []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	resolvedLogPath, err := filepath.EvalSymlinks(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	candidates := discoverBazelRootCandidates(outputBase)
+	var found bool
+	for _, candidate := range candidates {
+		if candidate.Type == "server_log" && candidate.Path == resolvedLogPath && candidate.Name == filepath.Base(logPath) {
+			found = true
+		}
+		if candidate.Type == "server_log" && strings.Contains(candidate.Path, "not-a-bazel-log") {
+			t.Fatalf("unexpected non-Bazel log candidate: %+v", candidate)
+		}
+	}
+	if !found {
+		t.Fatalf("did not discover Bazel server log candidate in %+v", candidates)
+	}
+}
+
+func TestBazelPlanTargetsDeletesOnlyStaleInactiveServerLogs(t *testing.T) {
+	now := time.Now()
+	cfg := config.DefaultConfig().Bazel
+	cfg.StaleAfter = "24h"
+
+	targets, _ := bazelPlanTargets([]bazelCandidate{
+		{
+			Type:     "server_log",
+			Name:     "java.log.old",
+			Path:     "/tmp/output-base/java.log.old",
+			ModTime:  now.Add(-48 * time.Hour),
+			Physical: 11,
+		},
+		{
+			Type:     "server_log",
+			Name:     "java.log.new",
+			Path:     "/tmp/output-base/java.log.new",
+			ModTime:  now.Add(-1 * time.Hour),
+			Physical: 13,
+		},
+		{
+			Type:     "server_log",
+			Name:     "java.log.active",
+			Path:     "/tmp/output-base/java.log.active",
+			ModTime:  now.Add(-48 * time.Hour),
+			Physical: 17,
+			Active:   true,
+			Reason:   "active Bazel process or output-base lock detected",
+		},
+	}, cfg, LevelModerate, now, false)
+
+	actions := map[string]CleanupTarget{}
+	for _, target := range targets {
+		actions[target.Name] = target
+	}
+	if got := actions["java.log.old"].Action; got != "delete_server_log" {
+		t.Fatalf("old server log action = %q, want delete_server_log", got)
+	}
+	if got := actions["java.log.new"].Action; got != "keep" {
+		t.Fatalf("new server log action = %q, want keep", got)
+	}
+	if got := actions["java.log.active"].Action; got != "keep" {
+		t.Fatalf("active server log action = %q, want keep", got)
+	}
+}
+
+func TestApplyBazelCleanupTargetsDeletesEligibleServerLog(t *testing.T) {
+	root := t.TempDir()
+	outputBase := filepath.Join(root, "_bazel_jess", "loggy")
+	makeBazelOutputBase(t, outputBase)
+	logPath := filepath.Join(outputBase, "command.log")
+	if err := os.WriteFile(logPath, []byte("client env"), 0400); err != nil {
+		t.Fatal(err)
+	}
+	unsafePath := filepath.Join(outputBase, "not-a-bazel-log.txt")
+	if err := os.WriteFile(unsafePath, []byte("keep"), 0400); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := applyBazelCleanupTargets(context.Background(), "bazel", LevelModerate, []CleanupTarget{
+		{
+			Type:   "server_log",
+			Name:   "command.log",
+			Path:   logPath,
+			Bytes:  10,
+			Action: "delete_server_log",
+		},
+		{
+			Type:   "server_log",
+			Name:   "not-a-bazel-log.txt",
+			Path:   unsafePath,
+			Bytes:  20,
+			Action: "delete_server_log",
+		},
+	}, nil, root, logger)
+
+	if result.ItemsCleaned != 1 {
+		t.Fatalf("items cleaned = %d, want 1", result.ItemsCleaned)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("expected server log to be deleted, stat err=%v", err)
+	}
+	if _, err := os.Stat(unsafePath); err != nil {
+		t.Fatalf("unsafe path should remain, err=%v", err)
 	}
 }
 

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -32,6 +32,7 @@ var tempArtifactPathPattern = regexp.MustCompile(`(?:/private)?/tmp/[^\s"'<>]+|/
 var absoluteDevArtifactPathPattern = regexp.MustCompile(`(?:~|/)[^\s"'<>]+`)
 var nixTempRootNamePattern = regexp.MustCompile(`^(?:nix-shell\.[A-Za-z0-9]+|nix-develop-\d+-\d+|nix-\d+-\d+|nix-build-[A-Za-z0-9._+@=-]+-\d+)$`)
 var temporaryProofLaneNamePattern = regexp.MustCompile(`^t[0-9]+[A-Za-z]*-[A-Za-z0-9._-]+$`)
+var tcfsRustTargetCacheNamePattern = regexp.MustCompile(`^tcfs-[A-Za-z0-9._]+-target$`)
 
 var errDevArtifactScanBudgetExceeded = errors.New("dev artifact scan budget exceeded")
 
@@ -308,6 +309,9 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 	if daCfg.AgentWorktreeArtifacts && daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
 		p.planAgentWorktreeArtifacts(scanCtx, home, rustAge, mutates, daCfg, active, tracker, &targets, scanBudget)
 	}
+	if daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
+		p.planTCFSRustTargetCaches(scanCtx, home, rustAge, mutates, daCfg, active, &targets, scanBudget)
+	}
 
 	if daCfg.GoBuildCache {
 		p.planGoBuildCache(ctx, level, active, &targets)
@@ -491,6 +495,13 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 			result.ItemsCleaned++
 		}
 	}
+	if daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
+		freed := p.cleanTCFSRustTargetCaches(scanCtx, home, rustAge, daCfg, active, logger, scanBudget)
+		result.BytesFreed += freed
+		if freed > 0 {
+			result.ItemsCleaned++
+		}
+	}
 	if scanBudget.exhausted() {
 		logger.Warn("stopping dev artifact cleanup because scan budget was exhausted", "truncated_paths", strings.Join(scanBudget.truncatedDetails(), "; "))
 		return result
@@ -598,6 +609,12 @@ func (p *DevArtifactsPlugin) planAgentWorktreeArtifacts(ctx context.Context, hom
 		}
 		p.planRustTargets(ctx, root, rustAge, mutates, daCfg.ProtectPaths, active, tracker, targets, budgets...)
 	}
+}
+
+func (p *DevArtifactsPlugin) planTCFSRustTargetCaches(ctx context.Context, home string, maxAge time.Duration, mutates bool, daCfg config.DevArtifactsConfig, active devArtifactActivity, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
+	p.forEachTCFSRustTargetCache(ctx, home, daCfg, active, func(path string, info os.FileInfo, bytes int64, protected bool, activeReason string) {
+		*targets = append(*targets, p.tcfsRustTargetCacheTarget(path, bytes, info.ModTime(), maxAge, mutates, protected, activeReason))
+	}, budgets...)
 }
 
 func (p *DevArtifactsPlugin) planAgentTranscripts(ctx context.Context, home string, staleAfter time.Duration, mutates bool, daCfg config.DevArtifactsConfig, targets *[]CleanupTarget, budgets ...*devArtifactScanBudget) {
@@ -766,6 +783,38 @@ func (p *DevArtifactsPlugin) agentTranscriptTarget(home string, path string, byt
 		target.Reason = fmt.Sprintf("agent transcript JSONL is older than %s and can be gzip-compressed without deleting history", formatDevArtifactAge(staleAfter))
 	}
 	annotateCleanupTargetPolicy(&target, CleanupTierSafe, hostReclaimForAction(target.Action))
+	return target
+}
+
+func (p *DevArtifactsPlugin) tcfsRustTargetCacheTarget(path string, bytes int64, modTime time.Time, maxAge time.Duration, mutates bool, protected bool, activeReason string) CleanupTarget {
+	active := activeReason != ""
+	stale := maxAge == 0 || !modTime.After(time.Now().Add(-maxAge))
+	target := CleanupTarget{
+		Type:      "tcfs-rust-target",
+		Name:      filepath.Base(path),
+		Path:      path,
+		Bytes:     bytes,
+		Active:    active,
+		Protected: active || protected || !stale,
+	}
+	switch {
+	case active:
+		target.Action = "protect"
+		target.Reason = "active development process detected: " + activeReason
+	case protected:
+		target.Action = "protect"
+		target.Reason = "path is covered by dev_artifacts.protect_paths"
+	case !mutates:
+		target.Action = "report"
+		target.Reason = "warning level reports TCFS Rust target caches without deleting them"
+	case stale:
+		target.Action = "delete"
+		target.Reason = fmt.Sprintf("TCFS Rust target cache is stale for %s", formatDevArtifactAge(maxAge))
+	default:
+		target.Action = "protect"
+		target.Reason = fmt.Sprintf("TCFS Rust target cache is newer than %s", formatDevArtifactAge(maxAge))
+	}
+	annotateCleanupTargetPolicy(&target, CleanupTierWarm, hostReclaimForAction(target.Action))
 	return target
 }
 
@@ -2782,6 +2831,66 @@ func (p *DevArtifactsPlugin) cleanPythonVenvs(ctx context.Context, scanPath stri
 	}
 
 	return totalFreed
+}
+
+func (p *DevArtifactsPlugin) cleanTCFSRustTargetCaches(ctx context.Context, home string, maxAge time.Duration, daCfg config.DevArtifactsConfig, active devArtifactActivity, logger *slog.Logger, budgets ...*devArtifactScanBudget) int64 {
+	var totalFreed int64
+	p.forEachTCFSRustTargetCache(ctx, home, daCfg, active, func(path string, info os.FileInfo, bytes int64, protected bool, activeReason string) {
+		if protected || activeReason != "" {
+			return
+		}
+		if maxAge > 0 && info.ModTime().After(time.Now().Add(-maxAge)) {
+			return
+		}
+		logger.Debug("removing stale TCFS Rust target cache", "path", path, "size_mb", bytes/(1024*1024))
+		if err := os.RemoveAll(path); err != nil {
+			logger.Debug("failed to remove TCFS Rust target cache", "path", path, "error", err)
+			return
+		}
+		totalFreed += bytes
+	}, budgets...)
+	if totalFreed > 0 {
+		logger.Info("cleaned stale TCFS Rust target caches", "freed_mb", totalFreed/(1024*1024))
+	}
+	return totalFreed
+}
+
+func (p *DevArtifactsPlugin) forEachTCFSRustTargetCache(ctx context.Context, home string, daCfg config.DevArtifactsConfig, active devArtifactActivity, callback func(path string, info os.FileInfo, bytes int64, protected bool, activeReason string), budgets ...*devArtifactScanBudget) {
+	cacheRoot := filepath.Join(home, ".cache")
+	entries, err := os.ReadDir(cacheRoot)
+	if err != nil {
+		return
+	}
+	budget := optionalDevArtifactScanBudget(budgets)
+	for _, entry := range entries {
+		if !entry.IsDir() || !tcfsRustTargetCacheNamePattern.MatchString(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(cacheRoot, entry.Name())
+		if budget != nil {
+			if err := budget.checkPath(ctx, path); err != nil {
+				return
+			}
+		} else if err := ctx.Err(); err != nil {
+			return
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		bytes, err := getDirSizeContext(ctx, path)
+		if err != nil {
+			if budget != nil {
+				budget.markContextError(ctx, path)
+			}
+			return
+		}
+		if bytes <= 0 {
+			continue
+		}
+		activeReason, _ := active.TargetReason("rust-target", path)
+		callback(path, info, bytes, p.isProtected(path, daCfg.ProtectPaths), activeReason)
+	}
 }
 
 // cleanRustTargets removes stale Rust target/ directories.

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -1052,6 +1052,75 @@ func TestPlanCleanupReportsPnpmStorePruneTarget(t *testing.T) {
 	}
 }
 
+func TestPlanCleanupReportsStaleTCFSRustTargetCache(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	staleTarget := filepath.Join(home, ".cache", "tcfs-513-target", "debug")
+	recentTarget := filepath.Join(home, ".cache", "tcfs-999-target", "debug")
+	ignoredTarget := filepath.Join(home, ".cache", "tcfs-999-not-target", "debug")
+	for _, dir := range []string{staleTarget, recentTarget, ignoredTarget} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "artifact"), []byte("artifact"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldTime := time.Now().Add(-15 * 24 * time.Hour)
+	if err := os.Chtimes(filepath.Dir(staleTarget), oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tcfsRustTargetCacheConfig()
+	plan := p.PlanCleanup(context.Background(), LevelAggressive, cfg, slog.Default())
+
+	stale := findDevArtifactTarget(t, plan.Targets, "tcfs-rust-target", filepath.Dir(staleTarget))
+	if stale.Action != "delete" || stale.Protected {
+		t.Fatalf("expected stale TCFS Rust target cache to be deletable, got %#v", stale)
+	}
+	recent := findDevArtifactTarget(t, plan.Targets, "tcfs-rust-target", filepath.Dir(recentTarget))
+	if recent.Action != "protect" || !recent.Protected {
+		t.Fatalf("expected recent TCFS Rust target cache to be protected, got %#v", recent)
+	}
+	if _, ok := findDevArtifactTargetMaybe(plan.Targets, "tcfs-rust-target", filepath.Dir(ignoredTarget)); ok {
+		t.Fatalf("unexpected non-TCFS target cache in plan: %s", filepath.Dir(ignoredTarget))
+	}
+}
+
+func TestCleanupDeletesStaleTCFSRustTargetCache(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	staleTarget := filepath.Join(home, ".cache", "tcfs-513-target")
+	recentTarget := filepath.Join(home, ".cache", "tcfs-999-target")
+	for _, dir := range []string{filepath.Join(staleTarget, "debug"), filepath.Join(recentTarget, "debug")} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "artifact"), []byte("artifact"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldTime := time.Now().Add(-15 * 24 * time.Hour)
+	if err := os.Chtimes(staleTarget, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tcfsRustTargetCacheConfig()
+	result := p.Cleanup(context.Background(), LevelAggressive, cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if result.ItemsCleaned != 1 {
+		t.Fatalf("items cleaned = %d, want 1", result.ItemsCleaned)
+	}
+	if _, err := os.Stat(staleTarget); !os.IsNotExist(err) {
+		t.Fatalf("expected stale TCFS Rust target cache to be deleted, stat err=%v", err)
+	}
+	if _, err := os.Stat(recentTarget); err != nil {
+		t.Fatalf("expected recent TCFS Rust target cache to remain, stat err=%v", err)
+	}
+}
+
 func TestPlanCleanupReportsGeneratedArtifactsInsideStaleTemporaryRoots(t *testing.T) {
 	p := newDevArtifactsPluginWithActive(nil)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -1271,6 +1340,23 @@ func pnpmStoreConfig() *config.Config {
 	cfg.DevArtifacts.RustTargets = false
 	cfg.DevArtifacts.ZigArtifacts = false
 	cfg.DevArtifacts.PnpmStore = true
+	cfg.DevArtifacts.GoBuildCache = false
+	cfg.DevArtifacts.HaskellCache = false
+	cfg.DevArtifacts.LargeLocalArtifacts = false
+	cfg.DevArtifacts.LMStudioModels = false
+	return cfg
+}
+
+func tcfsRustTargetCacheConfig() *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.DevArtifacts.ScanPaths = nil
+	cfg.DevArtifacts.TempArtifacts = false
+	cfg.DevArtifacts.AgentWorktreeArtifacts = false
+	cfg.DevArtifacts.NodeModules = false
+	cfg.DevArtifacts.PythonVenvs = false
+	cfg.DevArtifacts.RustTargets = true
+	cfg.DevArtifacts.ZigArtifacts = false
+	cfg.DevArtifacts.PnpmStore = false
 	cfg.DevArtifacts.GoBuildCache = false
 	cfg.DevArtifacts.HaskellCache = false
 	cfg.DevArtifacts.LargeLocalArtifacts = false


### PR DESCRIPTION
Linear: TIN-982

## Summary
- model Bazel server logs as safe cleanup targets, deleting stale inactive logs that can capture client environments
- add narrow dev-artifacts cleanup for `~/.cache/tcfs-*-target` Rust target caches under the existing Rust target policy
- keep active/recent/protected targets guarded by existing process and path checks

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins -run 'Test.*(Bazel|TCFS)'`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
