### PR TITLE
darwin: treat live cache ENOTEMPTY as partial cleanup

### DIFF
--- a/plugins/darwin.go
+++ b/plugins/darwin.go
@@ -4,6 +4,7 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Jesssullivan/tinyland-cleanup/config"
@@ -1391,6 +1393,24 @@ func (p *CachePlugin) cleanupDarwinDeveloperCacheTargets(ctx context.Context, le
 		}
 		result.EstimatedBytesFreed += sizeBefore
 		if err := removeDarwinDeveloperCacheTarget(target.Path); err != nil {
+			if isDarwinDeveloperCacheNonFatalRemoveError(err) {
+				sizeAfter := int64(0)
+				if pathExistsAndIsDir(target.Path) {
+					sizeAfter = getDirAllocatedBytes(target.Path)
+				}
+				freed := safeBytesDiff(sizeBefore, sizeAfter)
+				result.BytesFreed += freed
+				if freed > 0 {
+					result.ItemsCleaned++
+				}
+				logger.Warn("Darwin developer cache target remained active during deletion; treating partial cleanup as non-fatal",
+					"path", target.Path,
+					"type", target.Type,
+					"freed_mb", freed/(1024*1024),
+					"remaining_mb", sizeAfter/(1024*1024),
+					"error", err)
+				continue
+			}
 			result.Error = err
 			logger.Warn("failed to delete Darwin developer cache target", "path", target.Path, "type", target.Type, "error", err)
 			continue
@@ -1408,6 +1428,16 @@ func (p *CachePlugin) cleanupDarwinDeveloperCacheTargets(ctx context.Context, le
 			"freed_mb", freed/(1024*1024))
 	}
 	return result
+}
+
+func isDarwinDeveloperCacheNonFatalRemoveError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ENOTEMPTY) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "directory not empty")
 }
 
 func removeDarwinDeveloperCacheTarget(path string) error {

--- a/plugins/darwin_dev_cache_test.go
+++ b/plugins/darwin_dev_cache_test.go
@@ -4,10 +4,12 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -249,6 +251,22 @@ func TestRemoveAllDarwinCacheTargetWithRetryHandlesTransientNonEmptyDirectory(t 
 	}
 	if pathExists(dir) {
 		t.Fatalf("expected cache directory to be removed")
+	}
+}
+
+func TestDarwinDeveloperCacheNonFatalRemoveErrorIncludesDirectoryNotEmpty(t *testing.T) {
+	if !isDarwinDeveloperCacheNonFatalRemoveError(&os.PathError{
+		Op:   "unlinkat",
+		Path: filepath.Join(t.TempDir(), "uv"),
+		Err:  syscall.ENOTEMPTY,
+	}) {
+		t.Fatal("expected ENOTEMPTY to be treated as non-fatal for live-mutating cache cleanup")
+	}
+	if !isDarwinDeveloperCacheNonFatalRemoveError(errors.New("unlinkat /Users/jess/.cache/uv: directory not empty")) {
+		t.Fatal("expected directory-not-empty text to be treated as non-fatal for live-mutating cache cleanup")
+	}
+	if isDarwinDeveloperCacheNonFatalRemoveError(os.ErrPermission) {
+		t.Fatal("permission errors must remain fatal")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat Darwin developer-cache `ENOTEMPTY`/`directory not empty` removal failures as non-fatal partial cleanup.
- Preserve hard failures such as permission errors.
- Add focused coverage for the live-mutating cache case observed on Neo with `~/.cache/uv`.

## Validation
- `gofmt -w plugins/darwin.go plugins/darwin_dev_cache_test.go`
- `env GOCACHE="$HOME/.cache/tinyland-cleanup-gocache" GOFLAGS=-mod=vendor go test ./plugins -run 'Test(DarwinDeveloperCacheNonFatalRemoveErrorIncludesDirectoryNotEmpty|RemoveAllDarwinCacheTargetWithRetryHandlesTransientNonEmptyDirectory|CacheCleanupDarwinDevCaches)'`\n