### PR TITLE
dev-artifacts: shard workspace scans

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -311,6 +311,8 @@ type DevArtifactsConfig struct {
 	ScanMaxDuration string `yaml:"scan_max_duration"`
 	// ScanMaxEntries bounds recursive filesystem entries visited per dev-artifact scan
 	ScanMaxEntries int `yaml:"scan_max_entries"`
+	// WorkspaceScanMaxRoots bounds top-level workspace roots visited per artifact family per cycle.
+	WorkspaceScanMaxRoots int `yaml:"workspace_scan_max_roots"`
 	// TempArtifacts enables review-only reporting for large top-level temp artifacts
 	TempArtifacts bool `yaml:"temp_artifacts"`
 	// TempScanPaths are top-level temporary directories scanned for large generated artifacts
@@ -555,6 +557,7 @@ func DefaultConfig() *Config {
 			ScanPaths:                defaultScanPaths,
 			ScanMaxDuration:          "30s",
 			ScanMaxEntries:           250000,
+			WorkspaceScanMaxRoots:    8,
 			TempArtifacts:            true,
 			TempScanPaths:            defaultTempScanPaths,
 			TempScanMaxRoots:         128,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -326,6 +326,9 @@ func TestPackagedLinuxConfigParsesCurrentNixPolicy(t *testing.T) {
 	if cfg.DevArtifacts.ScanMaxEntries != 250000 {
 		t.Errorf("expected dev_artifacts.scan_max_entries=250000, got %d", cfg.DevArtifacts.ScanMaxEntries)
 	}
+	if cfg.DevArtifacts.WorkspaceScanMaxRoots != 8 {
+		t.Errorf("expected dev_artifacts.workspace_scan_max_roots=8, got %d", cfg.DevArtifacts.WorkspaceScanMaxRoots)
+	}
 	if cfg.DevArtifacts.TempScanMaxRoots != 128 {
 		t.Errorf("expected dev_artifacts.temp_scan_max_roots=128, got %d", cfg.DevArtifacts.TempScanMaxRoots)
 	}
@@ -426,6 +429,9 @@ func TestDevArtifactsConfigDefaults(t *testing.T) {
 	}
 	if cfg.DevArtifacts.ScanMaxEntries != 250000 {
 		t.Errorf("DevArtifacts.ScanMaxEntries should default to 250000, got %d", cfg.DevArtifacts.ScanMaxEntries)
+	}
+	if cfg.DevArtifacts.WorkspaceScanMaxRoots != 8 {
+		t.Errorf("DevArtifacts.WorkspaceScanMaxRoots should default to 8, got %d", cfg.DevArtifacts.WorkspaceScanMaxRoots)
 	}
 	if cfg.DevArtifacts.TempScanMaxRoots != 128 {
 		t.Errorf("DevArtifacts.TempScanMaxRoots should default to 128, got %d", cfg.DevArtifacts.TempScanMaxRoots)
@@ -705,6 +711,7 @@ dev_artifacts:
     - ~/src
   scan_max_duration: 5s
   scan_max_entries: 42
+  workspace_scan_max_roots: 2
   temp_artifacts: false
   temp_scan_paths:
     - /tmp/tinyland-cleanup
@@ -861,6 +868,9 @@ darwin_dev_caches:
 	}
 	if cfg.DevArtifacts.ScanMaxEntries != 42 {
 		t.Errorf("DevArtifacts.ScanMaxEntries should be 42 per config, got %d", cfg.DevArtifacts.ScanMaxEntries)
+	}
+	if cfg.DevArtifacts.WorkspaceScanMaxRoots != 2 {
+		t.Errorf("DevArtifacts.WorkspaceScanMaxRoots should be 2 per config, got %d", cfg.DevArtifacts.WorkspaceScanMaxRoots)
 	}
 	if cfg.DevArtifacts.TempScanMaxRoots != 3 {
 		t.Errorf("DevArtifacts.TempScanMaxRoots should be 3 per config, got %d", cfg.DevArtifacts.TempScanMaxRoots)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -213,6 +213,10 @@ dev_artifacts:
     - ~/projects
   scan_max_duration: 30s
   scan_max_entries: 250000
+  # Broad workspace roots such as ~/git are scanned one top-level repo at a
+  # time. A daemon-state cursor rotates the next cycle so one giant repo cannot
+  # starve later node_modules/.venv/target cleanup forever.
+  workspace_scan_max_roots: 8
   # Review-only: surface large top-level temp proof/output trees without
   # deleting them automatically. Darwin compiled defaults use /private/tmp.
   temp_artifacts: true

--- a/config/testdata/home-manager-honey.yaml
+++ b/config/testdata/home-manager-honey.yaml
@@ -32,6 +32,7 @@ dev_artifacts:
     - ~/src
   scan_max_duration: 30s
   scan_max_entries: 250000
+  workspace_scan_max_roots: 8
   temp_artifacts: true
   temp_scan_paths:
     - /tmp

--- a/docs/operator-workflow.md
+++ b/docs/operator-workflow.md
@@ -233,7 +233,12 @@ preserving scan budget for surfaces that can still reclaim space. Zig
 modified within the recent-output grace window, even at critical pressure.
 Dev-artifact filesystem walking is bounded by
 `dev_artifacts.scan_max_duration`, `dev_artifacts.scan_max_entries`, and
-`dev_artifacts.temp_scan_max_roots`; when a budget is hit, dry-run metadata sets
+`dev_artifacts.workspace_scan_max_roots`; broad workspace scan paths such as
+`~/git` are sharded by top-level repo and rotated with a cursor stored beside
+the daemon state file, so one giant worktree cannot starve later
+`node_modules`, `.venv`, `target`, or Zig artifact cleanup indefinitely.
+Temporary-root discovery is separately bounded by
+`dev_artifacts.temp_scan_max_roots`. When a budget is hit, dry-run metadata sets
 `scan_budget_exhausted: true`, reports `scan_truncated_paths`, and treats the
 omitted evidence as non-actionable. Symlink-heavy temporary roots, including Nix
 shell symlink forests, are measured as symlink entries rather than as the

--- a/plugins/devartifacts.go
+++ b/plugins/devartifacts.go
@@ -8,6 +8,7 @@ package plugins
 import (
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -50,23 +51,178 @@ type devArtifactProcessCandidate struct {
 }
 
 type devArtifactScanBudget struct {
-	maxDuration  time.Duration
-	maxEntries   int
-	tempMaxRoots int
+	maxDuration             time.Duration
+	maxEntries              int
+	workspaceMaxRoots       int
+	workspaceCursorFile     string
+	workspaceCursorState    devArtifactWorkspaceCursorState
+	persistWorkspaceCursors bool
+	tempMaxRoots            int
 
-	entries       int
-	tempRoots     int
-	tempRootSeen  map[string]struct{}
-	truncatedPath map[string]string
+	entries               int
+	workspaceRootsVisited int
+	workspaceRootsSkipped int
+	tempRoots             int
+	tempRootSeen          map[string]struct{}
+	truncatedPath         map[string]string
+}
+
+type devArtifactWorkspaceCursorState struct {
+	Version int               `json:"version"`
+	Cursors map[string]string `json:"cursors"`
 }
 
 func newDevArtifactScanBudget(cfg config.DevArtifactsConfig) *devArtifactScanBudget {
 	return &devArtifactScanBudget{
-		maxDuration:   parseNixPolicyDuration(cfg.ScanMaxDuration, 30*time.Second),
-		maxEntries:    cfg.ScanMaxEntries,
-		tempMaxRoots:  cfg.TempScanMaxRoots,
+		maxDuration:       parseNixPolicyDuration(cfg.ScanMaxDuration, 30*time.Second),
+		maxEntries:        cfg.ScanMaxEntries,
+		workspaceMaxRoots: cfg.WorkspaceScanMaxRoots,
+		tempMaxRoots:      cfg.TempScanMaxRoots,
+		tempRootSeen:      map[string]struct{}{},
+		truncatedPath:     map[string]string{},
+	}
+}
+
+func newDevArtifactScanBudgetForConfig(cfg *config.Config, persistWorkspaceCursors bool) *devArtifactScanBudget {
+	budget := newDevArtifactScanBudget(cfg.DevArtifacts)
+	budget.workspaceCursorFile = devArtifactWorkspaceCursorFile(cfg.Policy.StateFile)
+	budget.persistWorkspaceCursors = persistWorkspaceCursors
+	budget.loadWorkspaceCursors()
+	return budget
+}
+
+func devArtifactWorkspaceCursorFile(stateFile string) string {
+	if stateFile == "" {
+		return ""
+	}
+	home, _ := os.UserHomeDir()
+	expanded := expandHome(stateFile, home)
+	ext := filepath.Ext(expanded)
+	if ext == "" {
+		return expanded + ".dev-artifacts.json"
+	}
+	return strings.TrimSuffix(expanded, ext) + ".dev-artifacts" + ext
+}
+
+func (b *devArtifactScanBudget) loadWorkspaceCursors() {
+	if b == nil || b.workspaceCursorFile == "" {
+		return
+	}
+	data, err := os.ReadFile(b.workspaceCursorFile)
+	if err != nil {
+		return
+	}
+	var state devArtifactWorkspaceCursorState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return
+	}
+	if state.Cursors == nil {
+		state.Cursors = map[string]string{}
+	}
+	b.workspaceCursorState = state
+}
+
+func (b *devArtifactScanBudget) saveWorkspaceCursors() {
+	if b == nil || !b.persistWorkspaceCursors || b.workspaceCursorFile == "" || len(b.workspaceCursorState.Cursors) == 0 {
+		return
+	}
+	state := b.workspaceCursorState
+	state.Version = 1
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(b.workspaceCursorFile), 0755); err != nil {
+		return
+	}
+	tmp := b.workspaceCursorFile + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, b.workspaceCursorFile)
+}
+
+func (b *devArtifactScanBudget) selectWorkspaceRoots(key string, roots []string) []string {
+	if b == nil || len(roots) == 0 {
+		return roots
+	}
+	selected := roots
+	if b.workspaceMaxRoots > 0 && len(roots) > b.workspaceMaxRoots {
+		selected = rotateWorkspaceRootsAfterCursor(roots, b.workspaceCursorState.Cursors[key], b.workspaceMaxRoots)
+		b.workspaceRootsSkipped += len(roots) - len(selected)
+	}
+	b.workspaceRootsVisited += len(selected)
+	return selected
+}
+
+func rotateWorkspaceRootsAfterCursor(roots []string, cursor string, maxRoots int) []string {
+	if maxRoots <= 0 || len(roots) <= maxRoots {
+		return roots
+	}
+	start := 0
+	if cursor != "" {
+		start = len(roots)
+		for idx, root := range roots {
+			if root > cursor {
+				start = idx
+				break
+			}
+		}
+		if start >= len(roots) {
+			start = 0
+		}
+	}
+	selected := make([]string, 0, maxRoots)
+	for offset := 0; offset < len(roots) && len(selected) < maxRoots; offset++ {
+		selected = append(selected, roots[(start+offset)%len(roots)])
+	}
+	return selected
+}
+
+func (b *devArtifactScanBudget) recordWorkspaceCursor(key string, root string) {
+	if b == nil || !b.persistWorkspaceCursors || b.workspaceCursorFile == "" || key == "" || root == "" {
+		return
+	}
+	if b.workspaceCursorState.Cursors == nil {
+		b.workspaceCursorState.Cursors = map[string]string{}
+	}
+	b.workspaceCursorState.Cursors[key] = filepath.Clean(root)
+	b.saveWorkspaceCursors()
+}
+
+func (b *devArtifactScanBudget) workspaceRootBudget(selectedRoots int) *devArtifactScanBudget {
+	if b == nil {
+		return nil
+	}
+	maxDuration := b.maxDuration
+	if selectedRoots > 1 && maxDuration > 0 {
+		maxDuration = maxDuration / time.Duration(selectedRoots)
+		if maxDuration < time.Second {
+			maxDuration = time.Second
+		}
+	}
+	maxEntries := b.maxEntries
+	if selectedRoots > 1 && maxEntries > 0 {
+		maxEntries = (maxEntries + selectedRoots - 1) / selectedRoots
+		if maxEntries < 1 {
+			maxEntries = 1
+		}
+	}
+	return &devArtifactScanBudget{
+		maxDuration:   maxDuration,
+		maxEntries:    maxEntries,
 		tempRootSeen:  map[string]struct{}{},
 		truncatedPath: map[string]string{},
+	}
+}
+
+func (b *devArtifactScanBudget) mergeWorkspaceRootBudget(rootBudget *devArtifactScanBudget) {
+	if b == nil || rootBudget == nil || rootBudget == b {
+		return
+	}
+	b.entries += rootBudget.entries
+	for path, reason := range rootBudget.truncatedPath {
+		b.markTruncated(path, reason)
 	}
 }
 
@@ -162,6 +318,9 @@ func (b *devArtifactScanBudget) annotatePlan(plan *CleanupPlan) {
 	}
 	plan.Metadata["scan_max_duration"] = b.maxDuration.String()
 	plan.Metadata["scan_max_entries"] = strconv.Itoa(b.maxEntries)
+	plan.Metadata["workspace_scan_max_roots"] = strconv.Itoa(b.workspaceMaxRoots)
+	plan.Metadata["workspace_roots_visited"] = strconv.Itoa(b.workspaceRootsVisited)
+	plan.Metadata["workspace_roots_skipped"] = strconv.Itoa(b.workspaceRootsSkipped)
 	plan.Metadata["temp_scan_max_roots"] = strconv.Itoa(b.tempMaxRoots)
 	plan.Metadata["scan_entries_visited"] = strconv.Itoa(b.entries)
 	plan.Metadata["temp_roots_visited"] = strconv.Itoa(b.tempRoots)
@@ -214,7 +373,7 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 	home, _ := os.UserHomeDir()
 	daCfg := cfg.DevArtifacts
 	nodeAge, venvAge, rustAge, zigAge, mutates := devArtifactThresholds(level)
-	scanBudget := newDevArtifactScanBudget(daCfg)
+	scanBudget := newDevArtifactScanBudgetForConfig(cfg, false)
 	scanCtx, cancelScan := scanBudget.context(ctx)
 	defer cancelScan()
 	plan := CleanupPlan{
@@ -291,16 +450,16 @@ func (p *DevArtifactsPlugin) PlanCleanup(ctx context.Context, level CleanupLevel
 			continue
 		}
 		if daCfg.NodeModules && !active.GlobalFamilyActive("node_modules") {
-			p.planNodeModules(scanCtx, expanded, nodeAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
+			p.planNodeModules(ctx, expanded, nodeAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
 		}
 		if daCfg.PythonVenvs && !active.GlobalFamilyActive("python-venv") {
-			p.planPythonVenvs(scanCtx, expanded, venvAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
+			p.planPythonVenvs(ctx, expanded, venvAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
 		}
 		if daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
-			p.planRustTargets(scanCtx, expanded, rustAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
+			p.planRustTargets(ctx, expanded, rustAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
 		}
 		if daCfg.ZigArtifacts && !active.GlobalFamilyActive("zig-artifact") {
-			p.planZigArtifacts(scanCtx, expanded, zigAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
+			p.planZigArtifacts(ctx, expanded, zigAge, mutates, daCfg.ProtectPaths, active, tracker, &targets, scanBudget)
 		}
 		if daCfg.LargeLocalArtifacts {
 			p.planLargeLocalArtifacts(scanCtx, expanded, largeLocalArtifactMinBytes(daCfg), daCfg.ProtectPaths, mountedImages, &targets, scanBudget)
@@ -356,7 +515,7 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 
 	home, _ := os.UserHomeDir()
 	daCfg := cfg.DevArtifacts
-	scanBudget := newDevArtifactScanBudget(daCfg)
+	scanBudget := newDevArtifactScanBudgetForConfig(cfg, true)
 	scanCtx, cancelScan := scanBudget.context(ctx)
 	defer cancelScan()
 
@@ -441,7 +600,7 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 		}
 
 		if daCfg.NodeModules && !active.GlobalFamilyActive("node_modules") {
-			freed := p.cleanNodeModules(scanCtx, expanded, nodeAge, daCfg.ProtectPaths, active, tracker, logger, scanBudget)
+			freed := p.cleanNodeModules(ctx, expanded, nodeAge, daCfg.ProtectPaths, active, tracker, logger, scanBudget)
 			result.BytesFreed += freed
 			if freed > 0 {
 				result.ItemsCleaned++
@@ -453,7 +612,7 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 		}
 
 		if daCfg.PythonVenvs && !active.GlobalFamilyActive("python-venv") {
-			freed := p.cleanPythonVenvs(scanCtx, expanded, venvAge, daCfg.ProtectPaths, active, tracker, logger, scanBudget)
+			freed := p.cleanPythonVenvs(ctx, expanded, venvAge, daCfg.ProtectPaths, active, tracker, logger, scanBudget)
 			result.BytesFreed += freed
 			if freed > 0 {
 				result.ItemsCleaned++
@@ -465,7 +624,7 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 		}
 
 		if daCfg.RustTargets && !active.GlobalFamilyActive("rust-target") {
-			freed := p.cleanRustTargets(scanCtx, expanded, rustAge, daCfg.ProtectPaths, active, tracker, logger, scanBudget)
+			freed := p.cleanRustTargets(ctx, expanded, rustAge, daCfg.ProtectPaths, active, tracker, logger, scanBudget)
 			result.BytesFreed += freed
 			if freed > 0 {
 				result.ItemsCleaned++
@@ -477,7 +636,7 @@ func (p *DevArtifactsPlugin) Cleanup(ctx context.Context, level CleanupLevel, cf
 		}
 
 		if daCfg.ZigArtifacts && !active.GlobalFamilyActive("zig-artifact") {
-			freed := p.cleanZigArtifacts(scanCtx, expanded, zigAge, daCfg.ProtectPaths, active, tracker, logger, scanBudget)
+			freed := p.cleanZigArtifacts(ctx, expanded, zigAge, daCfg.ProtectPaths, active, tracker, logger, scanBudget)
 			result.BytesFreed += freed
 			if freed > 0 {
 				result.ItemsCleaned++
@@ -3146,9 +3305,82 @@ func (p *DevArtifactsPlugin) cleanLMStudioModels(ctx context.Context, level Clea
 // Limits directory depth to 4 levels to avoid excessive scanning.
 func (p *DevArtifactsPlugin) findArtifactDirs(ctx context.Context, scanPath string, targetName string, markerFile string, callback func(dir string, size int64), budgets ...*devArtifactScanBudget) {
 	budget := optionalDevArtifactScanBudget(budgets)
+	roots := p.devArtifactWorkspaceRoots(scanPath, targetName, markerFile)
+	key := devArtifactWorkspaceCursorKey(scanPath, targetName, markerFile)
+	selectedRoots := roots
+	if budget != nil {
+		selectedRoots = budget.selectWorkspaceRoots(key, roots)
+	}
+	for _, root := range selectedRoots {
+		rootBudget := budget
+		if budget != nil {
+			rootBudget = budget.workspaceRootBudget(len(selectedRoots))
+		}
+		rootCtx, cancel := rootBudget.context(ctx)
+		p.findArtifactDirsInRoot(rootCtx, scanPath, root, targetName, markerFile, callback, rootBudget)
+		cancel()
+		if budget != nil {
+			budget.mergeWorkspaceRootBudget(rootBudget)
+			budget.recordWorkspaceCursor(key, root)
+		}
+	}
+}
+
+func (p *DevArtifactsPlugin) devArtifactWorkspaceRoots(scanPath string, targetName string, markerFile string) []string {
+	cleanScanPath := filepath.Clean(scanPath)
+	if devArtifactScanPathHasProjectMarker(cleanScanPath, targetName, markerFile) {
+		return []string{cleanScanPath}
+	}
+	entries, err := os.ReadDir(cleanScanPath)
+	if err != nil {
+		return []string{cleanScanPath}
+	}
+	roots := make([]string, 0, len(entries)+1)
+	if markerFile == "" && pathExistsAndIsDir(filepath.Join(cleanScanPath, targetName)) {
+		roots = append(roots, cleanScanPath)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == targetName {
+			continue
+		}
+		if strings.HasPrefix(name, ".") && name != ".venv" {
+			continue
+		}
+		roots = append(roots, filepath.Join(cleanScanPath, name))
+	}
+	if len(roots) == 0 {
+		return []string{cleanScanPath}
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+func devArtifactScanPathHasProjectMarker(scanPath string, targetName string, markerFile string) bool {
+	if markerFile != "" {
+		return pathExists(filepath.Join(scanPath, markerFile))
+	}
+	if targetName == ".venv" {
+		for _, marker := range []string{"pyproject.toml", "setup.py", "requirements.txt"} {
+			if pathExists(filepath.Join(scanPath, marker)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func devArtifactWorkspaceCursorKey(scanPath string, targetName string, markerFile string) string {
+	return filepath.Clean(scanPath) + "|" + targetName + "|" + markerFile
+}
+
+func (p *DevArtifactsPlugin) findArtifactDirsInRoot(ctx context.Context, scanPath string, root string, targetName string, markerFile string, callback func(dir string, size int64), budget *devArtifactScanBudget) {
 	scanDepth := strings.Count(scanPath, string(os.PathSeparator))
 
-	filepath.Walk(scanPath, func(path string, info os.FileInfo, err error) error {
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err := budget.checkPath(ctx, path); err != nil {
 			return err
 		}

--- a/plugins/devartifacts_test.go
+++ b/plugins/devartifacts_test.go
@@ -1474,6 +1474,112 @@ func TestCleanupDoesNotDeleteAfterDevArtifactScanBudgetExhaustion(t *testing.T) 
 	}
 }
 
+func TestPlanCleanupShardsWorkspaceRoots(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	tmpDir := t.TempDir()
+	firstProject := filepath.Join(tmpDir, "aaa-first")
+	secondProject := filepath.Join(tmpDir, "zzz-second")
+	for _, project := range []string{firstProject, secondProject} {
+		if err := os.MkdirAll(filepath.Join(project, "node_modules", "pkg"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		packageJSON := filepath.Join(project, "package.json")
+		if err := os.WriteFile(packageJSON, []byte(`{"name":"test"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(project, "node_modules", "pkg", "index.js"), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		oldTime := time.Now().Add(-60 * 24 * time.Hour)
+		if err := os.Chtimes(packageJSON, oldTime, oldTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := budgetedDevArtifactConfig(tmpDir)
+	cfg.Policy.StateFile = filepath.Join(t.TempDir(), "state.json")
+	cfg.DevArtifacts.ScanMaxEntries = 100
+	cfg.DevArtifacts.WorkspaceScanMaxRoots = 1
+
+	plan := p.PlanCleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	if len(plan.Targets) != 1 {
+		t.Fatalf("expected one sharded workspace target, got %#v", plan.Targets)
+	}
+	if plan.Metadata["workspace_roots_visited"] != "1" {
+		t.Fatalf("expected one workspace root visited, metadata=%#v", plan.Metadata)
+	}
+	if plan.Metadata["workspace_roots_skipped"] != "1" {
+		t.Fatalf("expected one workspace root skipped, metadata=%#v", plan.Metadata)
+	}
+	if plan.Metadata["scan_budget_exhausted"] == "true" {
+		t.Fatalf("shard limit alone should not mark scan evidence incomplete, metadata=%#v", plan.Metadata)
+	}
+}
+
+func TestCleanupRotatesWorkspaceShardCursorAfterBudgetExhaustion(t *testing.T) {
+	p := newDevArtifactsPluginWithActive(nil)
+	tmpDir := t.TempDir()
+	heavyProject := filepath.Join(tmpDir, "aaa-heavy")
+	staleProject := filepath.Join(tmpDir, "zzz-stale")
+	heavyNodeModules := filepath.Join(heavyProject, "node_modules")
+	staleNodeModules := filepath.Join(staleProject, "node_modules")
+	if err := os.MkdirAll(filepath.Join(heavyNodeModules, "pkg"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(staleNodeModules, "pkg"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(heavyProject, "package.json"), []byte(`{"name":"heavy"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stalePackageJSON := filepath.Join(staleProject, "package.json")
+	if err := os.WriteFile(stalePackageJSON, []byte(`{"name":"stale"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"a00", "a01", "a02", "a03", "a04", "a05"} {
+		if err := os.MkdirAll(filepath.Join(heavyProject, name, "nested"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(heavyNodeModules, "pkg", "index.js"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleNodeModules, "pkg", "index.js"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	if err := os.Chtimes(stalePackageJSON, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := budgetedDevArtifactConfig(tmpDir)
+	cfg.Policy.StateFile = filepath.Join(t.TempDir(), "state.json")
+	cfg.DevArtifacts.ScanMaxEntries = 4
+	cfg.DevArtifacts.WorkspaceScanMaxRoots = 1
+
+	first := p.Cleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	if first.BytesFreed != 0 || first.ItemsCleaned != 0 {
+		t.Fatalf("first budget-exhausted shard should not delete anything, got %#v", first)
+	}
+	if !pathExists(heavyNodeModules) {
+		t.Fatal("heavy node_modules should be preserved when its shard exhausts before complete evidence")
+	}
+	if !pathExists(staleNodeModules) {
+		t.Fatal("stale node_modules should not be reached in the first shard-limited pass")
+	}
+
+	second := p.Cleanup(context.Background(), LevelCritical, cfg, devArtifactTestLogger())
+	if second.BytesFreed <= 0 || second.ItemsCleaned != 1 {
+		t.Fatalf("second pass should advance cursor and clean stale node_modules, got %#v", second)
+	}
+	if !pathExists(heavyNodeModules) {
+		t.Fatal("heavy node_modules should remain protected by incomplete evidence")
+	}
+	if pathExists(staleNodeModules) {
+		t.Fatal("stale node_modules should be deleted after cursor advances to its shard")
+	}
+}
+
 func budgetedDevArtifactConfig(scanPath string) *config.Config {
 	cfg := config.DefaultConfig()
 	cfg.DevArtifacts.ScanPaths = []string{scanPath}


### PR DESCRIPTION
## Summary
- shard broad dev-artifact workspace scans by top-level repo so one giant worktree cannot starve later artifact cleanup
- persist a per-artifact-family cursor beside the daemon state file and rotate bounded workspace roots across cleanup cycles
- expose `dev_artifacts.workspace_scan_max_roots` with defaults, fixture coverage, operator docs, and regression tests

Fixes #112.

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...`
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...`
