### PR TITLE
nix: treat Darwin TCC-wedged app-bundle GC as partial cleanup

### DIFF
--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -114,6 +114,38 @@ Runtime behavior:
   output is truncated;
 - `nix-store --optimize` runs only when `allow_store_optimize: true`.
 
+Darwin TCC-protected app bundle wedge:
+
+On macOS, launching a nix-packaged GUI app stamps its `Applications/*.app`
+bundle with the `com.apple.macl` extended attribute. App Management TCC then
+denies `chmod` on that bundle even for root and the nix-daemon. When such a
+store path later becomes dead, `nix-collect-garbage` cannot make it writable
+and aborts the entire pass:
+
+```
+deleting '/nix/store/<hash>-vscode-1.106.2'
+error: chmod "/nix/store/<hash>-vscode-1.106.2/Applications/Visual Studio Code.app": Operation not permitted
+0 store paths deleted, 0.0 KiB freed
+```
+
+After the failed pass the path is DB-orphaned, so every later GC re-hits it
+first and aborts again — the GC lane stays wedged until an operator removes
+the path.
+
+Daemon behavior: the plugin classifies this signature, keeps any partial
+reclaim counts parsed from the GC output, and emits a WARN with `store_path`,
+`app_path`, and a `remediation` field instead of failing the cleanup result.
+The WARN log is the operator contract; GC remains blocked until remediation.
+
+Remediation, from a TCC-privileged terminal (one granted App Management):
+
+```sh
+sudo chmod -R u+w /nix/store/<hash>-<name> && sudo rm -rf /nix/store/<hash>-<name>
+```
+
+This recurs per GUI-app update: each upgrade leaves the old macl-stamped store
+path behind for a future GC to trip over.
+
 Recommended Darwin developer-machine defaults are the repo defaults above.
 They preserve Home Manager rollback safety, avoid fighting active
 `home-manager switch` or `darwin-rebuild` work, and keep store optimization

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -346,6 +346,21 @@ func (p *NixPlugin) collectGarbage(ctx context.Context, level CleanupLevel, args
 			logger.Warn("skipping Nix garbage collection because store contention was reported", "reason", reason)
 			return result
 		}
+		// com.apple.macl / App Management TCC semantics are Darwin-only; a chmod
+		// EPERM on other platforms is a real failure that must stay an error.
+		if storePath, appPath, ok := nixGCWedgedAppBundle(string(output)); ok && goos() == "darwin" {
+			result.CommandBytesFreed = p.parseFreedSpace(string(output))
+			result.BytesFreed = result.CommandBytesFreed
+			result.ItemsCleaned = p.parseDeletedPaths(string(output))
+			if beforeOK {
+				result.HostBytesFreed = p.measuredHostDelta(before, measurePath, logger)
+			}
+			logger.Warn("Nix GC wedged by TCC-protected app bundle (com.apple.macl); GC stays blocked until the store path is removed from a TCC-privileged terminal",
+				"store_path", storePath,
+				"app_path", appPath,
+				"remediation", "sudo chmod -R u+w "+storePath+" && sudo rm -rf "+storePath)
+			return result
+		}
 		result.Error = err
 		return result
 	}
@@ -1373,6 +1388,29 @@ func nixContentionReason(output string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+// nixGCWedgedAppBundleRe matches the chmod failure nix-collect-garbage emits
+// when a dead store path's Applications/*.app bundle cannot be made writable.
+// The quoted path may contain spaces ("Visual Studio Code.app").
+var nixGCWedgedAppBundleRe = regexp.MustCompile(`chmod "(/nix/store/[^/"]+/(?:[^"]*/)?Applications/[^"]*\.app)": Operation not permitted`)
+
+// nixGCWedgedAppBundle reports whether nix-collect-garbage aborted on a
+// TCC-protected macOS app bundle inside the store. Launching a nix-packaged
+// GUI app stamps its .app bundle with the com.apple.macl xattr; App Management
+// TCC then denies chmod on the bundle even for root, so GC aborts the whole
+// pass, the path stays DB-orphaned, and every later GC re-hits it first.
+func nixGCWedgedAppBundle(output string) (storePath, appPath string, ok bool) {
+	matches := nixGCWedgedAppBundleRe.FindStringSubmatch(output)
+	if len(matches) < 2 {
+		return "", "", false
+	}
+	appPath = matches[1]
+	entry, _, found := strings.Cut(strings.TrimPrefix(appPath, "/nix/store/"), "/")
+	if !found || entry == "" {
+		return "", "", false
+	}
+	return "/nix/store/" + entry, appPath, true
 }
 
 func (p *NixPlugin) parseDryRunFreedSpace(output string) int64 {

--- a/plugins/nix_test.go
+++ b/plugins/nix_test.go
@@ -335,6 +335,151 @@ func TestNixContentionReason(t *testing.T) {
 	}
 }
 
+func TestNixGCWedgedAppBundle(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		storePath string
+		appPath   string
+		ok        bool
+	}{
+		{
+			name: "vscode bundle with spaces",
+			output: `deleting '/nix/store/spzws0l6ll4kfjzvzsvv6f7g0zdc1v6a-vscode-1.106.2'
+error: chmod "/nix/store/spzws0l6ll4kfjzvzsvv6f7g0zdc1v6a-vscode-1.106.2/Applications/Visual Studio Code.app": Operation not permitted
+0 store paths deleted, 0.0 KiB freed`,
+			storePath: "/nix/store/spzws0l6ll4kfjzvzsvv6f7g0zdc1v6a-vscode-1.106.2",
+			appPath:   "/nix/store/spzws0l6ll4kfjzvzsvv6f7g0zdc1v6a-vscode-1.106.2/Applications/Visual Studio Code.app",
+			ok:        true,
+		},
+		{
+			name:      "cmux bundle",
+			output:    `error: chmod "/nix/store/hav811c46mqmvmcgfmbfaq7cpi77fbwq-cmux-lab-0.75.0/Applications/cmux.app": Operation not permitted`,
+			storePath: "/nix/store/hav811c46mqmvmcgfmbfaq7cpi77fbwq-cmux-lab-0.75.0",
+			appPath:   "/nix/store/hav811c46mqmvmcgfmbfaq7cpi77fbwq-cmux-lab-0.75.0/Applications/cmux.app",
+			ok:        true,
+		},
+		{
+			name:   "chmod EPERM on non-app store path",
+			output: `error: chmod "/nix/store/abc123-some-tool-1.0/bin/tool": Operation not permitted`,
+			ok:     false,
+		},
+		{
+			name:   "sqlite contention",
+			output: "error: SQLite database '/nix/var/nix/db/db.sqlite' is busy",
+			ok:     false,
+		},
+		{
+			name:   "directory not empty",
+			output: "error: cannot delete '/nix/store/abc123-foo': Directory not empty",
+			ok:     false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			ok:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storePath, appPath, ok := nixGCWedgedAppBundle(tt.output)
+			if ok != tt.ok || storePath != tt.storePath || appPath != tt.appPath {
+				t.Fatalf("nixGCWedgedAppBundle(%q) = %q, %q, %t; want %q, %q, %t",
+					tt.output, storePath, appPath, ok, tt.storePath, tt.appPath, tt.ok)
+			}
+		})
+	}
+}
+
+func TestNixCollectGarbageTreatsTCCWedgedAppBundleAsPartial(t *testing.T) {
+	oldGOOS := goosValue
+	goosValue = "darwin"
+	t.Cleanup(func() { goosValue = oldGOOS })
+
+	binDir := t.TempDir()
+	fakeGC := filepath.Join(binDir, "nix-collect-garbage")
+	script := `#!/bin/sh
+printf '%s\n' "deleting '/nix/store/1234567890abcdefghijklmnopqrstuv-old-cache'"
+printf '%s\n' 'error: chmod "/nix/store/spzws0l6ll4kfjzvzsvv6f7g0zdc1v6a-vscode-1.106.2/Applications/Visual Studio Code.app": Operation not permitted' >&2
+printf '%s\n' "3 store paths deleted, 16.0 MiB freed"
+exit 1
+`
+	if err := os.WriteFile(fakeGC, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cfg := config.DefaultConfig().Nix
+	cfg.HostMeasurePath = t.TempDir()
+	p := NewNixPlugin()
+	p.freeDiskSpace = func(string) (uint64, error) { return 1000, nil }
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := p.collectGarbage(context.Background(), LevelWarning, nil, cfg, logger)
+	if result.Error != nil {
+		t.Fatalf("TCC-wedged app bundle should be a partial cleanup, not an error: %v", result.Error)
+	}
+	if result.CommandBytesFreed != 16*1024*1024 || result.BytesFreed != result.CommandBytesFreed {
+		t.Fatalf("partial reclaim from GC output should be kept: %+v", result)
+	}
+	if result.ItemsCleaned != 3 {
+		t.Fatalf("partial deleted-path count from GC output should be kept: %+v", result)
+	}
+}
+
+func TestNixCollectGarbageStillFailsOnUnclassifiedError(t *testing.T) {
+	binDir := t.TempDir()
+	fakeGC := filepath.Join(binDir, "nix-collect-garbage")
+	script := `#!/bin/sh
+printf '%s\n' "error: chmod \"/nix/store/abc123-some-tool-1.0/bin/tool\": Operation not permitted" >&2
+exit 1
+`
+	if err := os.WriteFile(fakeGC, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cfg := config.DefaultConfig().Nix
+	cfg.HostMeasurePath = t.TempDir()
+	p := NewNixPlugin()
+	p.freeDiskSpace = func(string) (uint64, error) { return 1000, nil }
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := p.collectGarbage(context.Background(), LevelWarning, nil, cfg, logger)
+	if result.Error == nil {
+		t.Fatalf("non-app-bundle chmod failure should remain a hard error: %+v", result)
+	}
+}
+
+func TestNixCollectGarbageWedgedAppBundleRemainsErrorOffDarwin(t *testing.T) {
+	oldGOOS := goosValue
+	goosValue = "linux"
+	t.Cleanup(func() { goosValue = oldGOOS })
+
+	binDir := t.TempDir()
+	fakeGC := filepath.Join(binDir, "nix-collect-garbage")
+	script := `#!/bin/sh
+printf '%s\n' 'error: chmod "/nix/store/spzws0l6ll4kfjzvzsvv6f7g0zdc1v6a-vscode-1.106.2/Applications/Visual Studio Code.app": Operation not permitted' >&2
+exit 1
+`
+	if err := os.WriteFile(fakeGC, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cfg := config.DefaultConfig().Nix
+	cfg.HostMeasurePath = t.TempDir()
+	p := NewNixPlugin()
+	p.freeDiskSpace = func(string) (uint64, error) { return 1000, nil }
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result := p.collectGarbage(context.Background(), LevelWarning, nil, cfg, logger)
+	if result.Error == nil {
+		t.Fatalf("app-bundle chmod failure off darwin should remain a hard error: %+v", result)
+	}
+}
+
 func TestParseNixGenerations(t *testing.T) {
 	output := `
    1   2026-04-01 10:00:00


### PR DESCRIPTION
## Summary
- classify the `chmod "…/Applications/*.app": Operation not permitted` signature from `nix-collect-garbage` as partial cleanup on Darwin instead of a hard plugin error (precedent: 676b0bf ENOTEMPTY-as-partial for live dev caches)
- keep partial reclaim counts (`command_bytes_freed`/`bytes_freed`/`items_cleaned`, plus measured host delta) parsed from the failed GC output — previously the hard-error path dropped them entirely
- emit a structured WARN with `store_path`, `app_path`, and a copy-pasteable `remediation` sudo one-liner; the WARN is the operator contract (CleanupResult has no warnings field; no schema change)
- gate strictly: non-`.app` chmod failures and all non-Darwin platforms still hard-error (`goos()` test seam, new off-darwin regression test)
- document the mechanism and remediation in `docs/nix-cleanup-policy.md`

Why: launching a nix-packaged GUI app stamps its bundle with `com.apple.macl`; App Management TCC then denies chmod even for the root nix-daemon. When that path goes dead, GC aborts the entire pass, the path is left DB-orphaned, and every subsequent pass re-hits it first — the daemon nix GC lane stays silently wedged until an operator removes the path from a TCC-privileged terminal. Observed twice on macbook-neo in one session (vscode-1.106.2, cmux-lab-0.75.0) during the 2026-07-07 disk-reclaim incident.

Linear: TIN-2595

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./...` — all packages ok
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...` — clean
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...` — clean
- `gofmt -w` on touched files; `gofmt -l` clean
- new tests: `TestNixGCWedgedAppBundle` (6-case table incl. spaces-in-bundle-name and non-.app EPERM), `TestNixCollectGarbageTreatsTCCWedgedAppBundleAsPartial` (fake GC on PATH, partial counts preserved), `TestNixCollectGarbageStillFailsOnUnclassifiedError`, `TestNixCollectGarbageWedgedAppBundleRemainsErrorOffDarwin`
- adversarially reviewed + traced against both verbatim production failures (vscode, cmux) before commit

## Safety (SECURITY.md checklist)
- platform/plugin: Darwin, nix plugin only
- invariant preserved: no new privileged operations; the daemon still never escalates; deliberately NO auto-unwedge (a daemon sudo child inherits the daemon TCC context and would hit the same EPERM)
- fail-closed dry-run preflight behavior unchanged