### PR TITLE
nix: remediation for TCC-wedged bundles is rm-only

### DIFF
--- a/docs/nix-cleanup-policy.md
+++ b/docs/nix-cleanup-policy.md
@@ -137,11 +137,16 @@ reclaim counts parsed from the GC output, and emits a WARN with `store_path`,
 `app_path`, and a `remediation` field instead of failing the cleanup result.
 The WARN log is the operator contract; GC remains blocked until remediation.
 
-Remediation, from a TCC-privileged terminal (one granted App Management):
+Remediation, from a TCC-privileged terminal:
 
 ```sh
-sudo chmod -R u+w /nix/store/<hash>-<name> && sudo rm -rf /nix/store/<hash>-<name>
+sudo rm -rf /nix/store/<hash>-<name>
 ```
+
+Do not prepend `chmod -R u+w`: macl denies chmod on every stamped entry even
+under sudo (verified live 2026-07-07), and chaining with `&&` aborts before
+the `rm` ever runs. Plain `rm -rf` succeeds because unlink only needs write on
+the parent directory, which macl does not protect.
 
 This recurs per GUI-app update: each upgrade leaves the old macl-stamped store
 path behind for a future GC to trip over.

--- a/plugins/nix.go
+++ b/plugins/nix.go
@@ -358,7 +358,7 @@ func (p *NixPlugin) collectGarbage(ctx context.Context, level CleanupLevel, args
 			logger.Warn("Nix GC wedged by TCC-protected app bundle (com.apple.macl); GC stays blocked until the store path is removed from a TCC-privileged terminal",
 				"store_path", storePath,
 				"app_path", appPath,
-				"remediation", "sudo chmod -R u+w "+storePath+" && sudo rm -rf "+storePath)
+				"remediation", "sudo rm -rf "+storePath)
 			return result
 		}
 		result.Error = err


### PR DESCRIPTION
## Summary
- change the wedge WARN `remediation` field and the doc one-liner from `sudo chmod -R u+w <p> && sudo rm -rf <p>` to `sudo rm -rf <p>`
- field evidence (2026-07-07, macbook-neo): `chmod -R` fails on every macl-stamped entry even under sudo, and the `&&` chain aborts before `rm` runs; plain `rm -rf` succeeds because unlink only needs parent-directory write, which macl does not protect — proven on both real wedges (vscode-1.106.2, cmux-lab-0.75.0)
- doc explains why chmod must not be prepended

Follow-up to #114. Linear: TIN-2595

## Validation
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go test ./plugins/ -run TestNix` — ok (full suite in CI)
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go vet ./...` — clean
- `env GOCACHE=/tmp/tinyland-cleanup-gocache GOFLAGS=-mod=vendor go build ./...` — clean
- no test asserts the remediation string; behavior unchanged otherwise